### PR TITLE
Add vhost-device I2C support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+kcov_output/
+target/
+.vscode/
+*.swp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add the list of code owners here (using their GitHub username)
-* gatekeeper-PullAssigner
+* gatekeeper-PullAssigner @vireshk

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,5 @@
-[package]
-name = "crate-template"
-version = "0.1.0"
-authors = ["TODO"]
-description = "This is a template for creating rust-vmm repositories."
-repository = "https://github.com/rust-vmm/crate-template"
-readme = "README.md"
-keywords = ["virt"]
-license = "Apache-2.0 OR BSD-3-Clause"
-edition = "2018"
+[workspace]
 
-[dependencies]
+members = [
+    "src/i2c",
+]

--- a/README.md
+++ b/README.md
@@ -1,41 +1,11 @@
-# Crate Name
+# vhost-device
 
 ## Design
 
-TODO: This section should have a high-level design of the crate.
+This repository hosts various 'vhost-user' device backends in their own crates.
+See their individual README.md files for specific information about those
+crates.
 
-Some questions that might help in writing this section:
-- What is the purpose of this crate?
-- What are the main components of the crate? How do they interact which each
-  other?
+Here is the list of device backends that we support:
 
-## Usage
-
-TODO: This section describes how the crate is used.
-
-Some questions that might help in writing this section:
-- What traits do users need to implement?
-- Does the crate have any default/optional features? What is each feature
-  doing?
-- Is this crate used by other rust-vmm components? If yes, how?
-
-## Examples
-
-TODO: Usage examples.
-
-```rust
-use my_crate;
-
-...
-```
-
-## License
-
-**!!!NOTICE**: The BSD-3-Clause license is not included in this template.
-The license needs to be manually added because the text of the license file
-also includes the copyright. The copyright can be different for different
-crates. If the crate contains code from CrosVM, the crate must add the
-CrosVM copyright which can be found
-[here](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/master/LICENSE).
-For crates developed from scratch, the copyright is different and depends on
-the contributors.
+- [I2C](https://github.com/rust-vmm/vhost-device/blob/master/src/i2c/README.md)

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 90,
+  "coverage_score": 36.7,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/i2c/Cargo.toml
+++ b/src/i2c/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vhost-device-i2c"
+version = "0.1.0"
+authors = ["Viresh Kumar <viresh.kumar@linaro.org>"]
+description = "vhost i2c backend device"
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["i2c", "vhost", "virt", "backend"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/src/i2c/Cargo.toml
+++ b/src/i2c/Cargo.toml
@@ -12,3 +12,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "=3.0.0-beta.2",  features = ["yaml"] }
+epoll = "4.3"
+libc = ">=0.2.95"
+log = ">=0.4.6"
+vhost = { git = "https://github.com/rust-vmm/vhost", features = ["vhost-user-slave"] }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend" }
+virtio-bindings = ">=0.1"
+vm-memory = ">=0.3.0"
+vmm-sys-util = ">=0.8.0"

--- a/src/i2c/README.md
+++ b/src/i2c/README.md
@@ -1,0 +1,41 @@
+# Crate Name
+
+## Design
+
+TODO: This section should have a high-level design of the crate.
+
+Some questions that might help in writing this section:
+- What is the purpose of this crate?
+- What are the main components of the crate? How do they interact which each
+  other?
+
+## Usage
+
+TODO: This section describes how the crate is used.
+
+Some questions that might help in writing this section:
+- What traits do users need to implement?
+- Does the crate have any default/optional features? What is each feature
+  doing?
+- Is this crate used by other rust-vmm components? If yes, how?
+
+## Examples
+
+TODO: Usage examples.
+
+```rust
+use my_crate;
+
+...
+```
+
+## License
+
+**!!!NOTICE**: The BSD-3-Clause license is not included in this template.
+The license needs to be manually added because the text of the license file
+also includes the copyright. The copyright can be different for different
+crates. If the crate contains code from CrosVM, the crate must add the
+CrosVM copyright which can be found
+[here](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/master/LICENSE).
+For crates developed from scratch, the copyright is different and depends on
+the contributors.

--- a/src/i2c/src/cli.yaml
+++ b/src/i2c/src/cli.yaml
@@ -1,0 +1,37 @@
+name: vhost-device-i2c
+version: "0.1.0"
+author: "Viresh Kumar <viresh.kumar@linaro.org>"
+about: Virtio I2C backend daemon.
+
+settings:
+    - ArgRequiredElseHelp
+
+args:
+  # Connection to sockets
+  - socket_path:
+      short: s
+      long: socket-path
+      value_name: FILE
+      takes_value: true
+      about: Location of vhost-user Unix domain socket. This is suffixed by 0,1,2..socket_count-1.
+  - socket_count:
+      short: c
+      long: socket-count
+      value_name: INT
+      takes_value: true
+      about: Number of guests (sockets) to connect to. Default = 1.
+  # I2C device list on host
+  - devices:
+      short: l
+      long: device-list
+      value_name: PATH
+      takes_value: true
+      about: List of I2C bus and clients in format <bus>:<client_addr>[:<client_addr>][,<bus>:<client_addr>[:<client_addr>]]
+
+groups:
+  - required_args:
+      args:
+        - socket_path
+      args:
+        - devices
+      required: true

--- a/src/i2c/src/i2c.rs
+++ b/src/i2c/src/i2c.rs
@@ -1,0 +1,41 @@
+// Low level I2C definitions
+//
+// Copyright 2021 Linaro Ltd. All Rights Reserved.
+//          Viresh Kumar <viresh.kumar@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Result;
+
+/// I2C adapter and helpers
+pub trait I2cAdapterTrait: Send + Sync + 'static {
+}
+
+pub struct I2cAdapter {
+    bus: u32,
+    smbus: bool,
+}
+
+impl I2cAdapterTrait for I2cAdapter {
+}
+
+/// I2C map and helpers
+const MAX_I2C_VDEV: usize = 1 << 7;
+const I2C_INVALID_ADAPTER: u32 = 0xFFFFFFFF;
+
+pub struct I2cMap<A: I2cAdapterTrait> {
+    adapters: Vec<A>,
+    device_map: [u32; MAX_I2C_VDEV],
+}
+
+impl<A: I2cAdapterTrait> I2cMap<A> {
+    pub fn new(_list: &str) -> Result<Self> {
+        let device_map: [u32; MAX_I2C_VDEV] = [I2C_INVALID_ADAPTER; MAX_I2C_VDEV];
+        let adapters: Vec<A> = Vec::new();
+
+        Ok(I2cMap {
+            adapters,
+            device_map,
+        })
+    }
+}

--- a/src/i2c/src/i2c.rs
+++ b/src/i2c/src/i2c.rs
@@ -5,18 +5,383 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::Result;
+use libc::{c_ulong, ioctl, EADDRINUSE, EADDRNOTAVAIL, EINVAL};
+use std::fs::{File, OpenOptions};
+use std::os::unix::io::AsRawFd;
+use vmm_sys_util::errno::{errno_result, Error, Result};
+
+// The type of the `req` parameter is different for the `musl` library. This will enable
+// successful build for other non-musl libraries.
+#[cfg(target_env = "musl")]
+type IoctlRequest = libc::c_int;
+#[cfg(not(target_env = "musl"))]
+type IoctlRequest = c_ulong;
+
+/// Linux I2C/SMBUS definitions
+/// IOCTL commands
+
+/// NOTE: Slave address is 7 or 10 bits, but 10-bit addresses are NOT supported!
+/// (due to code brokenness)
+const I2C_SLAVE: IoctlRequest = 0x0703; // Use this slave address
+const I2C_FUNCS: IoctlRequest = 0x0705; // Get the adapter functionality mask
+const I2C_RDWR: IoctlRequest = 0x0707; // Combined R/W transfer (one STOP only)
+const I2C_SMBUS: IoctlRequest = 0x0720; // SMBus transfer
+
+/// Functions
+const I2C_FUNC_I2C: u64 = 0x00000001;
+const I2C_FUNC_SMBUS_READ_BYTE: u64 = 0x00020000;
+const I2C_FUNC_SMBUS_WRITE_BYTE: u64 = 0x00040000;
+const I2C_FUNC_SMBUS_READ_BYTE_DATA: u64 = 0x00080000;
+const I2C_FUNC_SMBUS_WRITE_BYTE_DATA: u64 = 0x00100000;
+const I2C_FUNC_SMBUS_READ_WORD_DATA: u64 = 0x00200000;
+const I2C_FUNC_SMBUS_WRITE_WORD_DATA: u64 = 0x00400000;
+
+const I2C_FUNC_SMBUS_BYTE: u64 = I2C_FUNC_SMBUS_READ_BYTE | I2C_FUNC_SMBUS_WRITE_BYTE;
+const I2C_FUNC_SMBUS_BYTE_DATA: u64 =
+    I2C_FUNC_SMBUS_READ_BYTE_DATA | I2C_FUNC_SMBUS_WRITE_BYTE_DATA;
+const I2C_FUNC_SMBUS_WORD_DATA: u64 =
+    I2C_FUNC_SMBUS_READ_WORD_DATA | I2C_FUNC_SMBUS_WRITE_WORD_DATA;
+const I2C_FUNC_SMBUS_ALL: u64 =
+    I2C_FUNC_SMBUS_BYTE | I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA;
+
+/// I2C protocol definitions
+pub const I2C_M_RD: u16 = 0x0001; // read data, from slave to master
+
+/// Copied (partially) from Linux's include/uapi/linux/i2c.h
+///
+/// I2cMsg - an I2C transaction segment beginning with START
+///
+/// @addr: Slave address, only 7 bit supported by virtio specification.
+///
+/// @flags:
+///   Supported by all adapters:
+///   %I2C_M_RD: read data (from slave to master). Guaranteed to be 0x0001!
+///
+///   Optional:
+///   These aren't supported by virtio specification yet.
+///
+/// @len: Number of data bytes in @buf being read from or written to the I2C
+///   slave address.
+///
+/// @buf: The buffer into which data is read, or from which it's written.
+///
+/// An I2cMsg is the low level representation of one segment of an I2C
+/// transaction.
+///
+/// Each transaction begins with a START.  That is followed by the slave
+/// address, and a bit encoding read versus write.  Then follow all the
+/// data bytes, possibly including a byte with SMBus PEC.  The transfer
+/// terminates with a NAK, or when all those bytes have been transferred
+/// and ACKed.  If this is the last message in a group, it is followed by
+/// a STOP.  Otherwise it is followed by the next @I2cMsg transaction
+/// segment, beginning with a (repeated) START.
+
+#[repr(C)]
+struct I2cMsg {
+    addr: u16,
+    flags: u16,
+    len: u16,
+    buf: *mut u8,
+}
+
+/// This is the structure as used in the I2C_RDWR ioctl call
+#[repr(C)]
+pub struct I2cRdwrIoctlData {
+    msgs: *mut I2cMsg,
+    nmsgs: u32,
+}
+
+/// SMBUS protocol definitions
+/// SMBUS read or write markers
+const I2C_SMBUS_WRITE: u8 = 0;
+const I2C_SMBUS_READ: u8 = 1;
+
+/// SMBus transaction types (size parameter in the above functions)
+const I2C_SMBUS_QUICK: u32 = 0;
+const I2C_SMBUS_BYTE: u32 = 1;
+const I2C_SMBUS_BYTE_DATA: u32 = 2;
+const I2C_SMBUS_WORD_DATA: u32 = 3;
+
+/// As specified in SMBus standard
+const I2C_SMBUS_BLOCK_MAX: usize = 32;
+
+#[repr(C)]
+union I2cSmbusData {
+    byte: u8,
+    word: u16,
+
+    /// block[0] is used for length, and one more for user-space compatibility
+    block: [u8; I2C_SMBUS_BLOCK_MAX + 2],
+}
+
+/// This is the structure as used in the I2C_SMBUS ioctl call
+#[repr(C)]
+pub struct I2cSmbusIoctlData {
+    read_write: u8,
+    command: u8,
+    size: u32,
+    data: *mut I2cSmbusData,
+}
+
+impl I2cSmbusIoctlData {
+    /// Based on Linux's drivers/i2c/i2c-core-smbus.c:i2c_smbus_xfer_emulated().
+    ///
+    /// These smbus related functions try to reverse what Linux does, only
+    /// support basic modes (up to word transfer).
+    fn new(reqs: &mut [I2cReq]) -> Result<I2cSmbusIoctlData> {
+        let mut data = I2cSmbusData {
+            block: [0; I2C_SMBUS_BLOCK_MAX + 2],
+        };
+        let read_write: u8;
+        let size: u32;
+
+        // Write messages have only one request message, while read messages
+        // will have two (except for few special cases of I2C_SMBUS_QUICK and
+        // I2C_SMBUS_BYTE, where only one request messages is sent).
+        match reqs.len() {
+            // Write requests (with some exceptions as mentioned above)
+            1 => {
+                if (reqs[0].flags & I2C_M_RD) != 0 {
+                    // Special Read requests, reqs[0].len can be 0 or 1 only.
+                    if reqs[0].len > 1 {
+                        println!(
+                            "Incorrect message length for read operation: {}",
+                            reqs[0].len
+                        );
+                        return Err(Error::new(EINVAL));
+                    }
+                    read_write = I2C_SMBUS_READ;
+                } else {
+                    read_write = I2C_SMBUS_WRITE;
+                }
+
+                size = match reqs[0].len {
+                    // Special Read requests
+                    0 => I2C_SMBUS_QUICK,
+                    1 => I2C_SMBUS_BYTE,
+
+                    // Write requests
+                    2 => {
+                        data.byte = reqs[0].buf[1];
+                        I2C_SMBUS_BYTE_DATA
+                    }
+                    3 => {
+                        data.word = reqs[0].buf[1] as u16 | ((reqs[0].buf[2] as u16) << 8);
+                        I2C_SMBUS_WORD_DATA
+                    }
+                    _ => {
+                        println!(
+                            "Message length not supported for write operation: {}",
+                            reqs[0].len
+                        );
+                        return Err(Error::new(EINVAL));
+                    }
+                }
+            }
+
+            // Read requests
+            2 => {
+                // The first request contains the command, so its length must be
+                // set to 1 and shouldn't have I2C_M_RD set in flags.
+                //
+                // The second request contains the read buffer, so must have its
+                // I2C_M_RD flag set. We don't support block transfers yet and
+                // so its length shouldn't be greater than 2.
+                if ((reqs[0].flags & I2C_M_RD) != 0)
+                    || ((reqs[1].flags & I2C_M_RD) == 0)
+                    || (reqs[0].len != 1)
+                    || (reqs[1].len > 2)
+                {
+                    println!(
+                        "Expecting a valid read smbus transfer: {:?}",
+                        (reqs.len(), reqs[0].len, reqs[1].len)
+                    );
+                    return Err(Error::new(EINVAL));
+                }
+                read_write = I2C_SMBUS_READ;
+
+                if reqs[1].len == 1 {
+                    size = I2C_SMBUS_BYTE_DATA;
+                } else {
+                    size = I2C_SMBUS_WORD_DATA;
+                }
+            }
+
+            _ => {
+                println!("Invalid number of messages for smbus xfer: {}", reqs.len());
+                return Err(Error::new(EINVAL));
+            }
+        }
+
+        Ok(I2cSmbusIoctlData {
+            read_write,
+            command: reqs[0].buf[0],
+            size,
+            data: &mut data,
+        })
+    }
+}
+
+/// I2C definitions
+pub struct I2cReq {
+    pub addr: u16,
+    pub flags: u16,
+    pub len: u16,
+    pub buf: Vec<u8>,
+}
 
 /// I2C adapter and helpers
 pub trait I2cAdapterTrait: Send + Sync + 'static {
+    fn new(bus: &str) -> Result<Self>
+    where
+        Self: Sized;
+
+    fn bus(&self) -> u32;
+    fn is_smbus(&self) -> bool;
+
+    /// Sets device's address for an I2C adapter.
+    fn set_device_addr(&self, addr: usize) -> Result<()>;
+
+    /// Gets adapter's functionality
+    fn get_func(&mut self) -> Result<()>;
+
+    /// Transfer data
+    fn do_i2c_transfer(&self, data: &I2cRdwrIoctlData, addr: u16) -> Result<()>;
+
+    fn do_smbus_transfer(&self, data: &I2cSmbusIoctlData, addr: u16) -> Result<()>;
+
+    /// Perform I2C_RDWR transfer
+    fn i2c_transfer(&self, reqs: &mut [I2cReq]) -> Result<()> {
+        let mut msgs: Vec<I2cMsg> = Vec::with_capacity(reqs.len());
+        let len = reqs.len();
+        let addr = reqs[0].addr;
+
+        for req in reqs {
+            msgs.push(I2cMsg {
+                addr: req.addr,
+                flags: req.flags,
+                len: req.len,
+                buf: req.buf.as_mut_ptr(),
+            });
+        }
+
+        let data = I2cRdwrIoctlData {
+            msgs: msgs.as_mut_ptr(),
+            nmsgs: len as u32,
+        };
+
+        self.do_i2c_transfer(&data, addr)
+    }
+
+    /// Perform I2C_SMBUS transfer
+    fn smbus_transfer(&self, reqs: &mut [I2cReq]) -> Result<()> {
+        let smbus_data = I2cSmbusIoctlData::new(reqs)?;
+
+        self.do_smbus_transfer(&smbus_data, reqs[0].addr)?;
+
+        if smbus_data.read_write == I2C_SMBUS_READ {
+            unsafe {
+                match smbus_data.size {
+                    I2C_SMBUS_BYTE => reqs[0].buf[0] = (*smbus_data.data).byte,
+                    I2C_SMBUS_BYTE_DATA => reqs[1].buf[0] = (*smbus_data.data).byte,
+                    I2C_SMBUS_WORD_DATA => {
+                        reqs[1].buf[0] = ((*smbus_data.data).word & 0xff) as u8;
+                        reqs[1].buf[1] = ((*smbus_data.data).word >> 8) as u8;
+                    }
+
+                    _ => {
+                        println!("Invalid SMBUS command: {}", smbus_data.size);
+                        return Err(Error::new(EINVAL));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 pub struct I2cAdapter {
+    fd: File,
     bus: u32,
     smbus: bool,
 }
 
 impl I2cAdapterTrait for I2cAdapter {
+    fn new(bus: &str) -> Result<I2cAdapter> {
+        let i2cdev = String::from("/dev/i2c-") + bus;
+
+        Ok(I2cAdapter {
+            bus: bus.parse::<u32>().map_err(|_| Error::new(EINVAL))?,
+            smbus: false,
+            fd: OpenOptions::new().read(true).write(true).open(i2cdev)?,
+        })
+    }
+
+    fn bus(&self) -> u32 {
+        self.bus
+    }
+
+    fn is_smbus(&self) -> bool {
+        self.smbus
+    }
+
+    /// Sets device's address for an I2C adapter.
+    fn set_device_addr(&self, addr: usize) -> Result<()> {
+        let ret = unsafe { ioctl(self.fd.as_raw_fd(), I2C_SLAVE, addr as c_ulong) };
+
+        if ret == -1 {
+            println!("Failed to set device addr to {:x}", addr);
+            errno_result()
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Gets adapter's functionality
+    fn get_func(&mut self) -> Result<()> {
+        let func: u64 = I2C_FUNC_SMBUS_ALL;
+
+        let ret = unsafe { ioctl(self.fd.as_raw_fd(), I2C_FUNCS, &func) };
+
+        if ret == -1 {
+            println!("Failed to get I2C function");
+            return errno_result();
+        }
+
+        if (func & I2C_FUNC_I2C) != 0 {
+            self.smbus = false;
+        } else if (func & I2C_FUNC_SMBUS_ALL) != 0 {
+            self.smbus = true;
+        } else {
+            println!("Invalid functionality {:x}", func);
+            return Err(Error::new(EINVAL));
+        }
+
+        Ok(())
+    }
+
+    /// Transfer data
+    fn do_i2c_transfer(&self, data: &I2cRdwrIoctlData, addr: u16) -> Result<()> {
+        let ret = unsafe { ioctl(self.fd.as_raw_fd(), I2C_RDWR, data) };
+
+        if ret == -1 {
+            println!("Failed to transfer i2c data to device addr to {:x}", addr);
+            errno_result()
+        } else {
+            Ok(())
+        }
+    }
+
+    fn do_smbus_transfer(&self, data: &I2cSmbusIoctlData, addr: u16) -> Result<()> {
+        let ret = unsafe { ioctl(self.fd.as_raw_fd(), I2C_SMBUS, data) };
+
+        if ret == -1 {
+            println!("Failed to transfer smbus data to device addr to {:x}", addr);
+            return errno_result();
+        }
+
+        Ok(())
+    }
 }
 
 /// I2C map and helpers
@@ -29,13 +394,75 @@ pub struct I2cMap<A: I2cAdapterTrait> {
 }
 
 impl<A: I2cAdapterTrait> I2cMap<A> {
-    pub fn new(_list: &str) -> Result<Self> {
-        let device_map: [u32; MAX_I2C_VDEV] = [I2C_INVALID_ADAPTER; MAX_I2C_VDEV];
-        let adapters: Vec<A> = Vec::new();
+    pub fn new(list: &str) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut device_map: [u32; MAX_I2C_VDEV] = [I2C_INVALID_ADAPTER; MAX_I2C_VDEV];
+        let mut adapters: Vec<A> = Vec::new();
+        let busses: Vec<&str> = list.split(',').collect();
+
+        for (i, businfo) in busses.iter().enumerate() {
+            let list: Vec<&str> = businfo.split(':').collect();
+            let mut adapter = A::new(list[0])?;
+            let devices = &list[1..];
+
+            adapter.get_func()?;
+
+            for device in devices {
+                let device = device.parse::<usize>().map_err(|_| Error::new(EINVAL))?;
+
+                if device > MAX_I2C_VDEV {
+                    println!("Invalid device address {}", device);
+                    return Err(Error::new(EADDRNOTAVAIL));
+                }
+
+                if device_map[device] != I2C_INVALID_ADAPTER {
+                    println!(
+                        "Client address {} is already used by {}",
+                        device,
+                        adapters[device_map[device] as usize].bus()
+                    );
+                    return Err(Error::new(EADDRINUSE));
+                }
+
+                adapter.set_device_addr(device)?;
+                device_map[device] = i as u32;
+            }
+
+            println!(
+                "Added I2C master with bus id: {:x} for devices: {:?}",
+                adapter.bus(),
+                devices
+            );
+
+            adapters.push(adapter);
+        }
 
         Ok(I2cMap {
             adapters,
             device_map,
         })
+    }
+
+    pub fn transfer(&self, reqs: &mut [I2cReq]) -> Result<()> {
+        let device = reqs[0].addr as usize;
+        let index = self.device_map[device];
+
+        // This can happen a lot while scanning the bus, don't print any errors.
+        if index == I2C_INVALID_ADAPTER {
+            return Err(Error::new(EINVAL));
+        }
+
+        let adapter = &self.adapters[index as usize];
+
+        // Set device's address
+        adapter.set_device_addr(device)?;
+
+        if adapter.is_smbus() {
+            adapter.smbus_transfer(reqs)
+        } else {
+            adapter.i2c_transfer(reqs)
+        }
     }
 }

--- a/src/i2c/src/main.rs
+++ b/src/i2c/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/i2c/src/main.rs
+++ b/src/i2c/src/main.rs
@@ -1,3 +1,92 @@
-fn main() {
-    println!("Hello, world!");
+// VIRTIO I2C Emulation via vhost-user
+//
+// Copyright 2021 Linaro Ltd. All Rights Reserved.
+//          Viresh Kumar <viresh.kumar@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod i2c;
+mod vhu_i2c;
+
+use clap::{load_yaml, App, ArgMatches};
+use i2c::{I2cAdapter, I2cAdapterTrait, I2cMap};
+use std::sync::{Arc, RwLock};
+use std::thread::spawn;
+use vhost::{vhost_user, vhost_user::Listener};
+use vhost_user_backend::VhostUserDaemon;
+use vhu_i2c::VhostUserI2cBackend;
+
+fn start_backend<T: I2cAdapterTrait>(cmd_args: ArgMatches) -> Result<(), String> {
+    let mut handles = Vec::new();
+
+    let path = cmd_args
+        .value_of("socket_path")
+        .ok_or("Invalid socket path")?;
+
+    let count = cmd_args
+        .value_of("socket_count")
+        .unwrap_or("1")
+        .parse::<u32>()
+        .map_err(|_| "Invalid socket_count")?;
+
+    let list = cmd_args.value_of("devices").ok_or("Invalid devices list")?;
+
+    // The same i2c_map structure instance is shared between all the guests
+    let i2c_map =
+        Arc::new(I2cMap::<T>::new(list).map_err(|e| format!("Failed to create i2c_map ({})", e))?);
+
+    for i in 0..count {
+        let socket = path.to_owned() + &i.to_string();
+        let i2c_map = i2c_map.clone();
+
+        let handle = spawn(move || loop {
+            let backend = Arc::new(RwLock::new(
+                VhostUserI2cBackend::new(i2c_map.clone()).unwrap(),
+            ));
+            let listener = Listener::new(socket.clone(), true).unwrap();
+
+            let mut daemon =
+                VhostUserDaemon::new(String::from("vhost-device-i2c-backend"), backend.clone())
+                    .unwrap();
+
+            daemon.start(listener).unwrap();
+
+            match daemon.wait() {
+                Ok(()) => {
+                    println!("Stopping cleanly.");
+                }
+                Err(vhost_user_backend::Error::HandleRequest(
+                    vhost_user::Error::PartialMessage,
+                )) => {
+                    println!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
+                }
+                Err(e) => {
+                    println!("Error running daemon: {:?}", e);
+                }
+            }
+
+            // No matter the result, we need to shut down the worker thread.
+            backend
+                .read()
+                .unwrap()
+                .exit_event
+                .write(1)
+                .expect("Shutting down worker thread");
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().map_err(|_| "Failed to join threads")?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
+    let yaml = load_yaml!("cli.yaml");
+    let cmd_args = App::from(yaml).get_matches();
+
+    start_backend::<I2cAdapter>(cmd_args)
 }

--- a/src/i2c/src/vhu_i2c.rs
+++ b/src/i2c/src/vhu_i2c.rs
@@ -1,0 +1,153 @@
+// vhost device i2c
+//
+// Copyright 2021 Linaro Ltd. All Rights Reserved.
+//          Viresh Kumar <viresh.kumar@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::i2c::*;
+use std::sync::{Arc, RwLock};
+use std::{convert, error, fmt, io};
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackend, Vring};
+use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+
+const QUEUE_SIZE: usize = 1024;
+const NUM_QUEUES: usize = 1;
+
+type Result<T> = std::result::Result<T, Error>;
+type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
+
+#[derive(Debug)]
+/// Errors related to vhost-device-i2c daemon.
+pub enum Error {
+    /// Failed to handle event other than input event.
+    HandleEventNotEpollIn,
+    /// Failed to handle unknown event.
+    HandleEventUnknownEvent,
+}
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "vhost-device-i2c error: {:?}", self)
+    }
+}
+
+impl convert::From<Error> for io::Error {
+    fn from(e: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
+pub struct VhostUserI2cBackend<A: I2cAdapterTrait> {
+    i2c_map: Arc<I2cMap<A>>,
+    event_idx: bool,
+    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    pub exit_event: EventFd,
+}
+
+impl<A: I2cAdapterTrait> VhostUserI2cBackend<A> {
+    pub fn new(i2c_map: Arc<I2cMap<A>>) -> Result<Self> {
+        Ok(VhostUserI2cBackend {
+            i2c_map,
+            event_idx: false,
+            mem: None,
+            exit_event: EventFd::new(EFD_NONBLOCK).expect("Creating exit eventfd"),
+        })
+    }
+
+    /// Process the messages in the vring and dispatch replies
+    fn process_queue(&self, _vring: &mut Vring) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+/// VhostUserBackend trait methods
+impl<A: I2cAdapterTrait> VhostUserBackend for VhostUserI2cBackend<A> {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        // this matches the current libvhost defaults except VHOST_F_LOG_ALL
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        dbg!(self.event_idx = enabled);
+    }
+
+    fn update_memory(
+        &mut self,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> VhostUserBackendResult<()> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &self,
+        device_event: u16,
+        evset: epoll::Events,
+        vrings: &[Arc<RwLock<Vring>>],
+        _thread_id: usize,
+    ) -> VhostUserBackendResult<bool> {
+        if evset != epoll::Events::EPOLLIN {
+            return Err(Error::HandleEventNotEpollIn.into());
+        }
+
+        match device_event {
+            0 => {
+                let mut vring = vrings[0].write().unwrap();
+
+                if self.event_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        vring.mut_queue().disable_notification().unwrap();
+                        self.process_queue(&mut vring)?;
+                        if !vring.mut_queue().enable_notification().unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    self.process_queue(&mut vring)?;
+                }
+            }
+
+            _ => {
+                dbg!("unhandled device_event:", device_event);
+                return Err(Error::HandleEventUnknownEvent.into());
+            }
+        }
+        Ok(false)
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventFd, Option<u16>)> {
+        Some((
+            self.exit_event.try_clone().expect("Cloning exit eventfd"),
+            None,
+        ))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,0 @@
-#![deny(missing_docs)]
-//! Dummy crate needs high-level documentation.
-/// Dummy public function needs documentation.
-pub fn it_works() {
-    assert!(true);
-}


### PR DESCRIPTION
Hi @andreeaflorescu 

Earlier discussion: https://github.com/rust-vmm/community/issues/106 

I have tried to migrate my existing i2c work over to this repository and did whatever made sense to me (in respect to the workspace thing). There are high chances that I might have made some mistakes here.

I know there would be a lot of things that would require improvement in the i2c code as well as I am really a newbie to the rust world, apologies in advance for reviewing not so great code.

Thanks