### PR TITLE
i2c: lock vhost-user-backend to old version

### DIFF
--- a/src/i2c/Cargo.toml
+++ b/src/i2c/Cargo.toml
@@ -17,7 +17,7 @@ epoll = "4.3"
 libc = ">=0.2.95"
 log = ">=0.4.6"
 vhost = { git = "https://github.com/rust-vmm/vhost", features = ["vhost-user-slave"] }
-vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend" }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "89fa48e000a5a1a743c00c61b16492116ac86117" }
 virtio-bindings = ">=0.1"
 vm-memory = ">=0.3.0"
 vmm-sys-util = ">=0.8.0"


### PR DESCRIPTION
This commit ensures that the i2c device is built with an older
version of vhost-user-backend, since the newer commits change
various interfaces used throughout the device.

Signed-off-by: Harshavardhan Unnibhavi <harshanavkis@gmail.com>