### PR TITLE
i2c: Fix dependency to a working commit of backend

### DIFF
--- a/src/i2c/Cargo.toml
+++ b/src/i2c/Cargo.toml
@@ -17,7 +17,7 @@ epoll = "4.3"
 libc = ">=0.2.95"
 log = ">=0.4.6"
 vhost = { version = "0.1", features = ["vhost-user-slave"] }
-vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend" }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "f0af5f7fc22a345e050123dc048c0639965fe652" }
 virtio-bindings = ">=0.1"
 vm-memory = "0.6"
 vmm-sys-util = ">=0.8.0"


### PR DESCRIPTION
To avoid breaking the crate with a newer version of the
vhost-user-backend crate, fix the dependency to a known good version of
the crate.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>