### PR TITLE
dependabot: Allow updating crate dependencies automatically

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,13 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 3
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
Remove the incorrect file dependabot.yaml and edit the correct one to
allow crate updates on weekly basis.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>