### PR TITLE
Initial implementation of vhost-device-rng (V2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 
 members = [
     "src/i2c",
+    "src/rng",
 ]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ crates.
 Here is the list of device backends that we support:
 
 - [I2C](https://github.com/rust-vmm/vhost-device/blob/master/src/i2c/README.md)
+- [RNG](https://github.com/rust-vmm/vhost-device/blob/master/src/rng/README.md)

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 36.3,
+  "coverage_score": 27.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/src/rng/Cargo.toml
+++ b/src/rng/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vhost-device-rng"
+version = "0.1.0"
+authors = ["Mathieu Poirier <mathieu.poirier@linaro.org>"]
+description = "vhost RNG backend device"
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["rng", "vhost", "virt", "backend"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+[dependencies]
+clap = { version = "3.0.0-beta.2",  features = ["yaml"] }
+epoll = "4.3"
+libc = ">=0.2.95"
+log = ">=0.4.6"
+vhost = { version = "0.1", features = ["vhost-user-slave"] }
+vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "f0af5f7fc22a345e050123dc048c0639965fe652" }
+virtio-bindings = ">=0.1"
+vm-memory = ">=0.6"
+vmm-sys-util = ">=0.8.0"

--- a/src/rng/README.md
+++ b/src/rng/README.md
@@ -1,0 +1,72 @@
+# vhost-device-rng - RNG emulation backend daemon
+
+## Description
+This program is a vhost-user backend that emulates a VirtIO random number
+generator (RNG).  It uses the host's random number generator pool,
+/dev/urandom by default but configurable at will, to satisfy requests from
+guests.
+
+The daemon is designed to respect limitation on possible random generator
+hardware using the --max-bytes and --period options.  As such 5 kilobyte per
+second would translate to "--max-bytes 5000 --period 1000".  If an application
+requests more bytes than the allowed limit the thread will block until the
+start of a new period.  The daemon will automatically split the available
+bandwidth equally between the guest when several threads are requested.
+
+Thought developed and tested with QEMU, the implemenation is based on the
+vhost-user protocol and as such should be interoperable with other virtual
+machine managers.  Please see below for working examples.
+
+## Synopsis
+
+**vhost-device-rng** [*OPTIONS*]
+
+## Options
+
+.. program:: vhost-device-rng
+
+.. option:: -h, --help
+
+  Print help.
+
+.. option:: -s, --socket-path=PATH
+
+  Location of vhost-user Unix domain sockets, this path will be suffixed with
+  0,1,2..socket_count-1.
+
+.. option:: -f, --filename
+  Random number generator source file, defaults to /dev/urandom.
+
+.. option:: -c, --socket-count=INT
+
+  Number of guests (sockets) to attach to, default set to 1.
+
+.. option:: -p, --period
+
+  Rate, in milliseconds, at which the RNG hardware can generate random data.
+  Used in conjunction with the --max-bytes option.
+
+.. option:: -m, --max-bytes
+
+  In conjuction with the --period parameter, provides the maximum number of byte
+  per milliseconds a RNG device can generate.
+
+## Examples
+
+The daemon should be started first:
+
+::
+
+  host# vhost-device-rng --socket-path=rng.sock -c 1 -m 512 -p 1000
+
+The QEMU invocation needs to create a chardev socket the device can
+use to communicate as well as share the guests memory over a memfd.
+
+::
+
+  host# qemu-system -M virt						    	\
+      -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on 	\
+      -chardev socket,path=rng.sock,id=rng0					\
+      -device vhost-user-rng-pci,chardev=rng0                         		\
+      -numa node,memdev=mem							\
+      ...

--- a/src/rng/src/cli.yaml
+++ b/src/rng/src/cli.yaml
@@ -1,0 +1,47 @@
+name: vhost-device-rng
+version: "0.1.0"
+author: "Mathieu Poirier <mathieu.poirier@linaro.org>"
+about: Virtio RNG backend daemon.
+
+settings:
+    - ArgRequiredElseHelp
+
+args:
+  # Connection to sockets
+  - socket_path:
+      short: s
+      long: socket-path
+      value_name: FILE
+      takes_value: true
+      help: Location of vhost-user Unix domain socket. This is suffixed by 0,1,2..socket_count-1.
+  - socket_count:
+      short: c
+      long: socket-count
+      value_name: INT
+      takes_value: true
+      help: Number of guests (sockets) to connect to. Default = 1.
+  # Where to get the RNG data from
+  - rng_source:
+      short: f
+      long: filename
+      value_name: PATH
+      takes_value: true
+      help: Where to get the RNG data from. Defaults to /dev/urandom.
+  - period:
+      short: p
+      long: period
+      value_name: INT
+      takes_value: true
+      help: Time needed (in ms) to transfer max-bytes amount of byte.
+  - max_bytes:
+      short: m
+      long: max-bytes
+      value_name: INT
+      takes_value: true
+      help: Maximum amount of byte that can be transferred in a period.
+
+groups:
+  - required_args:
+      args:
+        - socket_path
+      required: true

--- a/src/rng/src/main.rs
+++ b/src/rng/src/main.rs
@@ -1,0 +1,157 @@
+// VIRTIO RNG Emulation via vhost-user
+//
+// Copyright 2021 Linaro Ltd. All Rights Reserved.
+// Mathieu Poirier <mathieu.poirier@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod vhu_rng;
+
+use clap::{load_yaml, App};
+use std::fs::File;
+use std::path::Path;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use vhost::{vhost_user, vhost_user::Listener};
+use vhost_user_backend::VhostUserDaemon;
+use vhu_rng::VuRngBackend;
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+
+fn start_backend(cmd_args: clap::ArgMatches) -> Result<(), String> {
+    let mut handles = Vec::new();
+
+    let path = cmd_args
+        .value_of("socket_path")
+        .ok_or("Invalid socket path")?;
+
+    let count = cmd_args
+        .value_of("socket_count")
+        .unwrap_or("1")
+        .parse::<u32>()
+        .map_err(|_| "Invalid socket_count")?;
+
+    let source = match cmd_args.value_of("rng_source") {
+        Some(source) => {
+            if Path::new(source).is_file() {
+                source.to_string()
+            } else {
+                return Err(String::from("Enable to access RNG source file"));
+            }
+        }
+        None => "/dev/urandom".to_string(),
+    };
+
+    let random_file = match File::open(source) {
+        Ok(random_file) => Arc::new(Mutex::new(random_file)),
+        Err(e) => return Err(e.to_string()),
+    };
+
+    let period_ms: u128 = match cmd_args.value_of("period") {
+        Some(period_ms) => match period_ms.parse::<u128>() {
+            Ok(value) => {
+                if value > (1 << 16) {
+                    return Err(format!(
+                        "Input period too big, maximum value is {}",
+                        1 << 16
+                    ));
+                }
+                value
+            }
+            Err(e) => {
+                return Err(e.to_string());
+            }
+        },
+        None => 1 << 16,
+    };
+
+    let mut max_bytes: usize = match cmd_args.value_of("max_bytes") {
+        Some(max_bytes) => match max_bytes.parse::<usize>() {
+            // No point in checking for a maximum value like above,
+            // the library parsing code will do that for us.
+            Ok(value) => value,
+            Err(_) => {
+                return Err(String::from("Enable to process max-bytes"));
+            }
+        },
+        None => usize::MAX,
+    };
+
+    // Divide available bandwidth by the number of threads in order
+    // to avoid overwhelming the HW.
+    max_bytes /= count as usize;
+
+    for i in 0..count {
+        let socket = path.to_owned() + &i.to_string();
+        let random = Arc::clone(&random_file);
+
+        let handle = thread::spawn(move || loop {
+            let rng_backend = match VuRngBackend::new(random.clone(), period_ms, max_bytes) {
+                Ok(rng_backend) => rng_backend,
+                Err(_) => {
+                    println!("Error creating RNG backend on thread: {}", i);
+                    return;
+                }
+            };
+
+            let vu_rng_backend = Arc::new(RwLock::new(rng_backend));
+
+            let listener = match Listener::new(socket.clone(), true) {
+                Ok(listener) => listener,
+                Err(_) => {
+                    println!("Error creating RNG listener daemon on thread: {}", i);
+                    return;
+                }
+            };
+
+            let mut daemon = match VhostUserDaemon::new(
+                String::from("vhost-user-RNG-daemon"),
+                vu_rng_backend.clone(),
+                GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+            ) {
+                Ok(daemon) => daemon,
+                Err(_) => {
+                    println!("Error creating RNG vhost user daemon on thread: {}", i);
+                    return;
+                }
+            };
+
+            if daemon.start(listener).is_err() {
+                println!("Error starting RNG vhost user daemon on thread: {}", i);
+                return;
+            }
+
+            match daemon.wait() {
+                Ok(()) => println!("Stopping cleanly."),
+                Err(vhost_user_backend::Error::HandleRequest(
+                    vhost_user::Error::PartialMessage,
+                )) => {
+                    println!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
+                }
+                Err(e) => println!("Error running daemon: {:?}", e),
+            }
+
+            // No matter the result, we need to shut down the worker thread.
+            vu_rng_backend
+                .read()
+                .unwrap()
+                .exit_event
+                .write(1)
+                .expect("Shutting down worker thread");
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().map_err(|_| "Failed to join threads")?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<(), String> {
+    let yaml = load_yaml!("cli.yaml");
+    let cmd_args = App::from(yaml).get_matches();
+
+    start_backend(cmd_args)
+}

--- a/src/rng/src/vhu_rng.rs
+++ b/src/rng/src/vhu_rng.rs
@@ -1,0 +1,293 @@
+// VIRTIO RNG Emulation via vhost-user
+//
+// Copyright 2021 Linaro Ltd. All Rights Reserved.
+//          Mathieu Poirier <mathieu.poirier@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::EFD_NONBLOCK;
+use log::warn;
+use std::fs::File;
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+use std::{convert, error, fmt, io};
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackendMut, Vring};
+use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
+use vm_memory::{Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use vmm_sys_util::eventfd::EventFd;
+
+const QUEUE_SIZE: usize = 1024;
+const NUM_QUEUES: usize = 1;
+
+type Result<T> = std::result::Result<T, Error>;
+type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
+
+#[derive(Debug)]
+/// Errors related to vhost-device-rng daemon.
+pub enum Error {
+    /// Descriptor not found
+    DescriptorNotFound,
+    /// Descriptor send failed
+    DescriptorSendFailed,
+    /// Can't create eventFd
+    EventFdError,
+    /// Failed to handle event other than input event.
+    HandleEventNotEpollIn,
+    /// Failed to handle unknown event.
+    HandleEventUnknownEvent,
+    /// Guest gave us a readable descriptor that protocol says to only write to.
+    UnexpectedReadDescriptor,
+    /// No memory configured.
+    NoMemoryConfigured,
+    /// Failed to access RNG source.
+    UnexpectedRngSourceAccessError,
+    /// Failed to read from the RNG source.
+    UnexpectedRngSourceError,
+    /// Previous Time value is later than current time.
+    UnexpectedTimerValue,
+    /// Error coming from VirtQueue
+    UnexpectedVirtQueueError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "virtiorng_error: {:?}", self)
+    }
+}
+
+impl error::Error for Error {}
+
+impl convert::From<Error> for io::Error {
+    fn from(e: Error) -> Self {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
+pub struct VuRngTimerConfig {
+    period_ms: u128,
+    period_start: Instant,
+    max_bytes: usize,
+    quota_remaining: usize,
+}
+
+impl VuRngTimerConfig {
+    pub fn new(period_ms: u128, max_bytes: usize) -> Self {
+        VuRngTimerConfig {
+            period_ms,
+            period_start: Instant::now(),
+            max_bytes,
+            quota_remaining: max_bytes,
+        }
+    }
+}
+
+pub struct VuRngBackend {
+    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    event_idx: bool,
+    timer: VuRngTimerConfig,
+    random_file: Arc<Mutex<File>>,
+    pub exit_event: EventFd,
+}
+
+impl VuRngBackend {
+    /// Create a new virtio rng device that gets random data from /dev/urandom.
+    pub fn new(
+        random_file: Arc<Mutex<File>>,
+        period_ms: u128,
+        max_bytes: usize,
+    ) -> std::result::Result<Self, std::io::Error> {
+        Ok(VuRngBackend {
+            mem: None,
+            event_idx: false,
+            random_file,
+            timer: VuRngTimerConfig::new(period_ms, max_bytes),
+            exit_event: EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdError)?,
+        })
+    }
+
+    pub fn process_queue(&mut self, vring: &Vring) -> Result<bool> {
+        // Copy the DescriptorChains to a vector.  Processing DescriptorChains
+        // one by one directly from the Vring would lead to a deadlock because
+        // the Vring's RwLock is taken once to access the DescriptorChains and
+        // once more when vring.add_used() is called.
+        let mut desc_chains: Vec<_> = vring
+            .get_mut()
+            .get_queue_mut()
+            .iter()
+            .map_err(|_| Error::DescriptorNotFound)?
+            .collect();
+
+        for desc_chain in desc_chains.iter_mut() {
+            let descriptor = match desc_chain.next() {
+                Some(descriptor) => descriptor,
+                None => continue,
+            };
+
+            let mut to_read = descriptor.len() as usize;
+            let mut timer = &mut self.timer;
+            let mut random_file = self
+                .random_file
+                .lock()
+                .map_err(|_| Error::UnexpectedRngSourceAccessError)?;
+
+            if !descriptor.is_write_only() {
+                return Err(Error::UnexpectedReadDescriptor);
+            }
+
+            // Get the current time
+            let now = Instant::now();
+
+            // Check how much time has passed since we started the last period.
+            match now.checked_duration_since(timer.period_start) {
+                Some(duration) => {
+                    let elapsed = duration.as_millis();
+
+                    if elapsed >= timer.period_ms {
+                        // More time has passed than a full period, reset time
+                        // and quota.
+                        timer.period_start = now;
+                        timer.quota_remaining = timer.max_bytes;
+                    } else {
+                        // We are out of bytes for the current period.  Block until
+                        // the start of the next period.
+                        if timer.quota_remaining == 0 {
+                            let to_sleep = timer.period_ms - elapsed;
+
+                            sleep(Duration::from_millis(to_sleep as u64));
+                            timer.period_start = Instant::now();
+                            timer.quota_remaining = timer.max_bytes;
+                        }
+                    }
+                }
+                None => return Err(Error::UnexpectedTimerValue),
+            };
+
+            let mem = match &self.mem {
+                Some(m) => m.memory(),
+                None => return Err(Error::NoMemoryConfigured),
+            };
+
+            if timer.quota_remaining < to_read {
+                to_read = timer.quota_remaining;
+            }
+
+            let len = match mem.read_from(descriptor.addr(), &mut *random_file, to_read as usize) {
+                Ok(len) => {
+                    timer.quota_remaining -= len;
+                    len
+                }
+                Err(_) => return Err(Error::UnexpectedRngSourceError),
+            };
+
+            if vring.add_used(desc_chain.head_index(), len as u32).is_err() {
+                warn!("Couldn't return used descriptors to the ring");
+            }
+
+            vring
+                .signal_used_queue()
+                .map_err(|_| Error::DescriptorSendFailed)?;
+        }
+
+        Ok(true)
+    }
+}
+
+/// VhostUserBackend trait methods
+impl VhostUserBackendMut for VuRngBackend {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        // this matches the current libvhost defaults except VHOST_F_LOG_ALL
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        dbg!(self.event_idx = enabled);
+    }
+
+    fn update_memory(
+        &mut self,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> VhostUserBackendResult<()> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: epoll::Events,
+        vrings: &[Vring<GuestMemoryAtomic<GuestMemoryMmap>>],
+        _thread_id: usize,
+    ) -> VhostUserBackendResult<bool> {
+        if evset != epoll::Events::EPOLLIN {
+            return Err(Error::HandleEventNotEpollIn.into());
+        }
+
+        match device_event {
+            0 => {
+                let vring = &vrings[0];
+
+                if self.event_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        if vring.disable_notification().is_err() {
+                            return Err(Error::UnexpectedVirtQueueError.into());
+                        }
+
+                        self.process_queue(vring)?;
+
+                        match vring.enable_notification() {
+                            Ok(enabled) => {
+                                if !enabled {
+                                    break;
+                                }
+                            }
+                            Err(_) => {
+                                return Err(Error::UnexpectedVirtQueueError.into());
+                            }
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    self.process_queue(vring)?;
+                }
+            }
+
+            _ => {
+                dbg!("unhandled device_event:", device_event);
+                return Err(Error::HandleEventUnknownEvent.into());
+            }
+        }
+        Ok(false)
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventFd, u16)> {
+        Some((
+            self.exit_event.try_clone().expect("Cloning exit eventfd"),
+            NUM_QUEUES as u16,
+        ))
+    }
+}


### PR DESCRIPTION
Hi Viresh

Here is the second iteration for the vhost-device-rng implementation.  

New for V2:
* Rebased to latest baseline.
* Addressed all warnings from the rust-vmm-ci infrastructure.
* RNG source file is shared between threads.
* Removed .unwrap() calls.
* Addressed other miscellaneous comments.

Best regards,
Mathieu