### PR TITLE
update I2cAdapter to allow setting a mock device

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 49.6,
+  "coverage_score": 48.8,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Before the constructor of this function was opening the device
corresponding to the passed path. This did not allow for properly
mocking the device functionality. Now the device is passed as a
parameter instead, which allows us to tweak what the device returns for
ioctl calls, and we can thus test multiple scenarios.