### PR TITLE
[i2c] Allow zero-length requests

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 59.8,
+  "coverage_score": 58.4,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
Commands like SMBUS Quick don't require a buffer for the request and are
called as zero-length requests. The specification allows such requests
under the VIRTIO_I2C_F_ZERO_LENGTH_REQUEST feature, which is mandatory
to be implemented by the devices now.

Add support for zero-length requests.

The [spec](https://github.com/oasis-tcs/virtio-spec/issues/112) changes are already approved and [linux](https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?id=94e5d5b04f8056f8eec57f8b104ec76d3e945279) code is queued too for upcoming merge window.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>