### PR TITLE
[libgpiod] Show build issues with container

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
+    "src/gpio",
     "src/i2c",
 ]

--- a/src/gpio/Cargo.toml
+++ b/src/gpio/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "gpio"
+version = "0.1.0"
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libgpiod = { git = "https://github.com/vireshk/libgpiod" }

--- a/src/gpio/src/main.rs
+++ b/src/gpio/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Hi @andreeaflorescu 

The containers used for builds currently don't have necessary tools to
compile buildgen stuff, which compiles few C files and create bindings.

This pull request is about highlighting those issues here.

We need these tools in the containers: libclang-dev clang musl-tools.

We also need to configure the container to pass the include path for the Linux libraries,
else we get more errors.

THIS PULL REQUEST SHOULDN'T BE MERGED.