### PR TITLE
RNG: Initial vhost-device RNG implementation (v5) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "epoll"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20df693c700404f7e19d4d6fae6b15215d2913c27955d2b9d6f2c0f537511cd0"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +143,15 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -205,6 +233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +282,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -305,6 +365,25 @@ dependencies = [
  "env_logger",
  "libc",
  "log",
+ "thiserror",
+ "vhost",
+ "vhost-user-backend",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-device-rng"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "epoll",
+ "libc",
+ "log",
+ "tempfile",
  "thiserror",
  "vhost",
  "vhost-user-backend",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 
 members = [
     "i2c",
+    "rng",
 ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ crates.
 Here is the list of device backends that we support:
 
 - [I2C](https://github.com/rust-vmm/vhost-device/blob/main/i2c/README.md)
+- [RNG](https://github.com/rust-vmm/vhost-device/blob/main/rng/README.md)
 
 ## Separation of Concerns
 

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 85.5,
+  "coverage_score": 85.3,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/rng/Cargo.toml
+++ b/rng/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "vhost-device-rng"
+version = "0.1.0"
+authors = ["Mathieu Poirier <mathieu.poirier@linaro.org>"]
+description = "vhost RNG backend device"
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["rng", "vhost", "virt", "backend"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+[dependencies]
+clap = { version = ">=3.0",  features = ["derive"] }
+env_logger = ">=0.9"
+epoll = "4.3"
+libc = ">=0.2.95"
+log = ">=0.4.6"
+tempfile = "3.2.0"
+thiserror = "1.0"
+vhost = { version = "0.3", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.1"
+virtio-bindings = ">=0.1"
+virtio-queue = "0.1"
+vm-memory = ">=0.7"
+vmm-sys-util = ">=0.9.0"
+
+[dev-dependencies]
+virtio-queue = { version = "0.1", features = ["test-utils"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/rng/README.md
+++ b/rng/README.md
@@ -1,0 +1,72 @@
+# vhost-device-rng - RNG emulation backend daemon
+
+## Description
+This program is a vhost-user backend that emulates a VirtIO random number
+generator (RNG).  It uses the host's random number generator pool,
+/dev/urandom by default but configurable at will, to satisfy requests from
+guests.
+
+The daemon is designed to respect limitation on possible random generator
+hardware using the --max-bytes and --period options.  As such 5 kilobyte per
+second would translate to "--max-bytes 5000 --period 1000".  If an application
+requests more bytes than the allowed limit the thread will block until the
+start of a new period.  The daemon will automatically split the available
+bandwidth equally between the guest when several threads are requested.
+
+Thought developed and tested with QEMU, the implemenation is based on the
+vhost-user protocol and as such should be interoperable with other virtual
+machine managers.  Please see below for working examples.
+
+## Synopsis
+
+**vhost-device-rng** [*OPTIONS*]
+
+## Options
+
+.. program:: vhost-device-rng
+
+.. option:: -h, --help
+
+  Print help.
+
+.. option:: -s, --socket-path=PATH
+
+  Location of vhost-user Unix domain sockets, this path will be suffixed with
+  0,1,2..socket_count-1.
+
+.. option:: -f, --filename
+  Random number generator source file, defaults to /dev/urandom.
+
+.. option:: -c, --socket-count=INT
+
+  Number of guests (sockets) to attach to, default set to 1.
+
+.. option:: -p, --period
+
+  Rate, in milliseconds, at which the RNG hardware can generate random data.
+  Used in conjunction with the --max-bytes option.
+
+.. option:: -m, --max-bytes
+
+  In conjuction with the --period parameter, provides the maximum number of byte
+  per milliseconds a RNG device can generate.
+
+## Examples
+
+The daemon should be started first:
+
+::
+
+  host# vhost-device-rng --socket-path=rng.sock -c 1 -m 512 -p 1000
+
+The QEMU invocation needs to create a chardev socket the device can
+use to communicate as well as share the guests memory over a memfd.
+
+::
+
+  host# qemu-system -M virt						    	\
+      -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on 	\
+      -chardev socket,path=rng.sock,id=rng0					\
+      -device vhost-user-rng-pci,chardev=rng0                         		\
+      -numa node,memdev=mem							\
+      ...

--- a/rng/src/main.rs
+++ b/rng/src/main.rs
@@ -1,0 +1,170 @@
+//
+// Copyright 2022 Linaro Ltd. All Rights Reserved.
+// Mathieu Poirier <mathieu.poirier@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+mod vhu_rng;
+
+use clap::Parser;
+use log::{info, warn};
+use std::convert::TryFrom;
+use std::fs::File;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use thiserror::Error as ThisError;
+use vhost::{vhost_user, vhost_user::Listener};
+use vhost_user_backend::VhostUserDaemon;
+use vhu_rng::VuRngBackend;
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+
+// Chosen to replicate the max period found in QEMU's vhost-user-rng
+// and virtio-rng implementations.
+const VHU_RNG_MAX_PERIOD_MS: u128 = 65536;
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, PartialEq, ThisError)]
+/// Errors related to vhost-device-rng daemon.
+pub enum Error {
+    #[error("RNG source file doesn't exists or can't be accessed")]
+    AccessRngSourceFile,
+    #[error("Period is too big")]
+    InvalidPeriodInput,
+    #[error("Socket path can't be found")]
+    InvalidSocketPath,
+    #[error("Wrong socket count")]
+    InvalidSocketCount,
+    #[error("Threads can't be joined")]
+    FailedJoiningThreads,
+}
+
+#[derive(Clone, Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct RngArgs {
+    /// Time needed (in ms) to transfer max-bytes amount of byte.
+    #[clap(short, long, default_value_t = VHU_RNG_MAX_PERIOD_MS)]
+    period: u128,
+
+    /// Maximum amount of byte that can be transferred in a period.
+    #[clap(short, long, default_value_t = usize::MAX)]
+    max_bytes: usize,
+
+    /// Number of guests (sockets) to connect to.
+    #[clap(short = 'c', long, default_value_t = 1)]
+    socket_count: u32,
+
+    /// Location of vhost-user Unix domain socket. This is suffixed by 0,1,2..socket_count-1.
+    #[clap(short, long)]
+    socket_path: Option<String>,
+
+    /// Where to get the RNG data from. Defaults to /dev/urandom.
+    #[clap(short = 'f', long, default_value = "/dev/urandom")]
+    rng_source: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct VuRngConfig {
+    pub period_ms: u128,
+    pub max_bytes: usize,
+    pub count: u32,
+    pub socket_path: String,
+    pub rng_source: String,
+}
+
+impl TryFrom<RngArgs> for VuRngConfig {
+    type Error = Error;
+
+    fn try_from(args: RngArgs) -> Result<Self> {
+        if args.period > VHU_RNG_MAX_PERIOD_MS {
+            return Err(Error::InvalidPeriodInput);
+        }
+
+        if args.socket_count == 0 {
+            return Err(Error::InvalidSocketCount);
+        }
+
+        let socket_path = match args.socket_path {
+            Some(path) => path,
+            None => return Err(Error::InvalidSocketPath),
+        };
+
+        // Divide available bandwidth by the number of threads in order
+        // to avoid overwhelming the HW.
+        let max_bytes = args.max_bytes / args.socket_count as usize;
+
+        Ok(VuRngConfig {
+            period_ms: args.period,
+            max_bytes,
+            count: args.socket_count,
+            socket_path,
+            rng_source: args.rng_source,
+        })
+    }
+}
+
+pub fn start_backend(config: VuRngConfig) -> Result<()> {
+    let mut handles = Vec::new();
+    let random_file = Arc::new(Mutex::new(
+        File::open(&config.rng_source).map_err(|_| Error::AccessRngSourceFile)?,
+    ));
+
+    for i in 0..config.count {
+        let socket_path = config.socket_path.clone();
+        let socket = format!("{}{}", socket_path, i);
+        let period_ms = config.period_ms;
+        let max_bytes = config.max_bytes;
+        let random = Arc::clone(&random_file);
+
+        let handle = thread::spawn(move || loop {
+            let vu_rng_backend = Arc::new(RwLock::new(
+                VuRngBackend::new(random.clone(), period_ms, max_bytes).unwrap(),
+            ));
+
+            let mut daemon = VhostUserDaemon::new(
+                String::from("vhost-user-RNG-daemon"),
+                vu_rng_backend.clone(),
+                GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+            )
+            .unwrap();
+
+            let listener = Listener::new(socket.clone(), true).unwrap();
+            daemon.start(listener).unwrap();
+
+            match daemon.wait() {
+                Ok(()) => {
+                    info!("Stopping cleanly.");
+                }
+                Err(vhost_user_backend::Error::HandleRequest(
+                    vhost_user::Error::PartialMessage,
+                )) => {
+                    info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
+                }
+                Err(e) => {
+                    warn!("Error running daemon: {:?}", e);
+                }
+            }
+
+            // No matter the result, we need to shut down the worker thread.
+            vu_rng_backend
+                .read()
+                .unwrap()
+                .exit_event
+                .write(1)
+                .expect("Shutting down worker thread");
+        });
+
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().map_err(|_| Error::FailedJoiningThreads)?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    start_backend(VuRngConfig::try_from(RngArgs::parse()).unwrap())
+}

--- a/rng/src/vhu_rng.rs
+++ b/rng/src/vhu_rng.rs
@@ -1,0 +1,293 @@
+// VIRTIO RNG Emulation via vhost-user
+//
+// Copyright 2022 Linaro Ltd. All Rights Reserved.
+// Mathieu Poirier <mathieu.poirier@linaro.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use libc::EFD_NONBLOCK;
+use log::warn;
+use std::fs::File;
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+use std::{convert, io, result};
+use thiserror::Error as ThisError;
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
+use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
+use virtio_queue::DescriptorChain;
+use vm_memory::{
+    Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
+};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
+const QUEUE_SIZE: usize = 1024;
+const NUM_QUEUES: usize = 1;
+
+type Result<T> = std::result::Result<T, VuRngError>;
+type RngDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
+
+#[derive(Debug, PartialEq, ThisError)]
+/// Errors related to vhost-device-rng daemon.
+pub enum VuRngError {
+    #[error("Descriptor not found")]
+    DescriptorNotFound,
+    #[error("Descriptor send failed")]
+    DescriptorSendFailed,
+    #[error("Can't create eventFd")]
+    EventFdError,
+    #[error("Failed to handle event")]
+    HandleEventNotEpollIn,
+    #[error("Unknown device event")]
+    HandleEventUnknownEvent,
+    #[error("Too many descriptors")]
+    UnexpectedDescriptorCount,
+    #[error("Unexpected Read Descriptor")]
+    UnexpectedReadDescriptor,
+    #[error("No memory configured")]
+    NoMemoryConfigured,
+    #[error("Failed to access RNG source")]
+    UnexpectedRngSourceAccessError,
+    #[error("Failed to read from the RNG source")]
+    UnexpectedRngSourceError,
+    #[error("Previous Time value is later than current time")]
+    UnexpectedTimerValue,
+    #[error("Unexpected VirtQueue error")]
+    UnexpectedVirtQueueError,
+}
+
+impl convert::From<VuRngError> for io::Error {
+    fn from(e: VuRngError) -> Self {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
+pub struct VuRngTimerConfig {
+    period_ms: u128,
+    period_start: Instant,
+    max_bytes: usize,
+    quota_remaining: usize,
+}
+
+impl VuRngTimerConfig {
+    pub fn new(period_ms: u128, max_bytes: usize) -> Self {
+        VuRngTimerConfig {
+            period_ms,
+            period_start: Instant::now(),
+            max_bytes,
+            quota_remaining: max_bytes,
+        }
+    }
+}
+
+pub struct VuRngBackend {
+    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    event_idx: bool,
+    timer: VuRngTimerConfig,
+    random_file: Arc<Mutex<File>>,
+    pub exit_event: EventFd,
+}
+
+impl VuRngBackend {
+    /// Create a new virtio rng device that gets random data from /dev/urandom.
+    pub fn new(
+        random_file: Arc<Mutex<File>>,
+        period_ms: u128,
+        max_bytes: usize,
+    ) -> std::result::Result<Self, std::io::Error> {
+        Ok(VuRngBackend {
+            mem: None,
+            event_idx: false,
+            random_file,
+            timer: VuRngTimerConfig::new(period_ms, max_bytes),
+            exit_event: EventFd::new(EFD_NONBLOCK).map_err(|_| VuRngError::EventFdError)?,
+        })
+    }
+
+    pub fn process_requests(
+        &mut self,
+        requests: Vec<RngDescriptorChain>,
+        vring: Option<&VringRwLock>,
+    ) -> Result<bool> {
+        if requests.is_empty() {
+            return Ok(true);
+        }
+
+        for desc_chain in requests {
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+
+            if descriptors.len() != 1 {
+                return Err(VuRngError::UnexpectedDescriptorCount);
+            }
+
+            let descriptor = descriptors[0];
+            let mut to_read = descriptor.len() as usize;
+            let mut timer = &mut self.timer;
+            let mut random_file = self
+                .random_file
+                .lock()
+                .map_err(|_| VuRngError::UnexpectedRngSourceAccessError)?;
+
+            if !descriptor.is_write_only() {
+                return Err(VuRngError::UnexpectedReadDescriptor);
+            }
+
+            // Get the current time
+            let now = Instant::now();
+
+            // Check how much time has passed since we started the last period.
+            match now.checked_duration_since(timer.period_start) {
+                Some(duration) => {
+                    let elapsed = duration.as_millis();
+
+                    if elapsed >= timer.period_ms {
+                        // More time has passed than a full period, reset time
+                        // and quota.
+                        timer.period_start = now;
+                        timer.quota_remaining = timer.max_bytes;
+                    } else {
+                        // If we are out of bytes for the current period.  Block until
+                        // the start of the next period.
+                        if timer.quota_remaining == 0 {
+                            let to_sleep = timer.period_ms - elapsed;
+
+                            sleep(Duration::from_millis(to_sleep as u64));
+                            timer.period_start = Instant::now();
+                            timer.quota_remaining = timer.max_bytes;
+                        }
+                    }
+                }
+                None => return Err(VuRngError::UnexpectedTimerValue),
+            };
+
+            let mem = match &self.mem {
+                Some(m) => m.memory(),
+                None => return Err(VuRngError::NoMemoryConfigured),
+            };
+
+            if timer.quota_remaining < to_read {
+                to_read = timer.quota_remaining;
+            }
+
+            let len = match mem.read_from(descriptor.addr(), &mut *random_file, to_read as usize) {
+                Ok(len) => {
+                    timer.quota_remaining -= len;
+                    len
+                }
+                Err(_) => return Err(VuRngError::UnexpectedRngSourceError),
+            };
+
+            if let Some(vring) = vring {
+                if vring.add_used(desc_chain.head_index(), len as u32).is_err() {
+                    warn!("Couldn't return used descriptors to the ring");
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    /// Process the requests in the vring and dispatch replies
+    fn process_queue(&mut self, vring: &VringRwLock) -> Result<bool> {
+        let requests: Vec<_> = vring
+            .get_mut()
+            .get_queue_mut()
+            .iter()
+            .map_err(|_| VuRngError::DescriptorNotFound)?
+            .collect();
+
+        if self.process_requests(requests, Some(vring))? {
+            // Send notification once all the requests are processed
+            vring
+                .signal_used_queue()
+                .map_err(|_| VuRngError::DescriptorSendFailed)?;
+        }
+
+        Ok(true)
+    }
+}
+
+/// VhostUserBackend trait methods
+impl VhostUserBackendMut<VringRwLock, ()> for VuRngBackend {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        // this matches the current libvhost defaults except VHOST_F_LOG_ALL
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::MQ
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        dbg!(self.event_idx = enabled);
+    }
+
+    fn update_memory(
+        &mut self,
+        mem: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> result::Result<(), io::Error> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: EventSet,
+        vrings: &[VringRwLock],
+        _thread_id: usize,
+    ) -> result::Result<bool, io::Error> {
+        if evset != EventSet::IN {
+            return Err(VuRngError::HandleEventNotEpollIn.into());
+        }
+
+        match device_event {
+            0 => {
+                let vring = &vrings[0];
+
+                if self.event_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        vring.disable_notification().unwrap();
+                        self.process_queue(vring)?;
+                        if !vring.enable_notification().unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    self.process_queue(vring)?;
+                }
+            }
+
+            _ => {
+                warn!("unhandled device_event: {}", device_event);
+                return Err(VuRngError::HandleEventUnknownEvent.into());
+            }
+        }
+        Ok(false)
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+        self.exit_event.try_clone().ok()
+    }
+}

--- a/rng/src/vhu_rng.rs
+++ b/rng/src/vhu_rng.rs
@@ -211,6 +211,30 @@ impl VuRngBackend {
     }
 }
 
+#[cfg(test)]
+impl VuRngBackend {
+    // For testing purposes modify time synthetically
+    pub(crate) fn time_add(&mut self, duration: Duration) {
+        if let Some(t) = self.timer.period_start.checked_add(duration) {
+            self.timer.period_start = t;
+        }
+    }
+
+    pub(crate) fn time_sub(&mut self, duration: Duration) {
+        if let Some(t) = self.timer.period_start.checked_sub(duration) {
+            self.timer.period_start = t;
+        }
+    }
+
+    pub(crate) fn time_now(&mut self) {
+        self.timer.period_start = Instant::now();
+    }
+
+    pub(crate) fn set_quota(&mut self, quota: usize) {
+        self.timer.quota_remaining = quota;
+    }
+}
+
 /// VhostUserBackend trait methods
 impl VhostUserBackendMut<VringRwLock, ()> for VuRngBackend {
     fn num_queues(&self) -> usize {
@@ -289,5 +313,241 @@ impl VhostUserBackendMut<VringRwLock, ()> for VuRngBackend {
 
     fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
         self.exit_event.try_clone().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use tempfile::{tempdir, tempfile};
+
+    use virtio_queue::defs::{VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
+    use virtio_queue::{mock::MockSplitQueue, Descriptor};
+    use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+
+    fn build_desc_chain(count: u16, flags: u16) -> RngDescriptorChain {
+        let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let vq = MockSplitQueue::new(&mem, 16);
+
+        //Create a descriptor chain with @count descriptors.
+        for i in 0..count {
+            let desc_flags = if i < count - 1 {
+                flags | VIRTQ_DESC_F_NEXT
+            } else {
+                flags & !VIRTQ_DESC_F_NEXT
+            };
+
+            let desc = Descriptor::new((0x100 * (i + 1)) as u64, 0x200, desc_flags, i + 1);
+            vq.desc_table().store(i, desc);
+        }
+
+        // Put the descriptor index 0 in the first available ring position.
+        mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
+            .unwrap();
+
+        // Set `avail_idx` to 1.
+        mem.write_obj(1u16, vq.avail_addr().unchecked_add(2))
+            .unwrap();
+
+        // Create descriptor chain from pre-filled memory
+        vq.create_queue(GuestMemoryAtomic::<GuestMemoryMmap>::new(mem.clone()))
+            .iter()
+            .unwrap()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn verify_chain_descriptors() {
+        let random = tempfile().unwrap();
+        let random_file = Arc::new(Mutex::new(random));
+        let mut backend = VuRngBackend::new(random_file, 1000, 512).unwrap();
+
+        // The guest driver is supposed to send us only unchained descriptors
+        let desc_chain = build_desc_chain(4, VIRTQ_DESC_F_WRITE);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], None)
+                .unwrap_err(),
+            VuRngError::UnexpectedDescriptorCount
+        );
+
+        // The guest driver is supposed to send us only write descriptors
+        let desc_chain = build_desc_chain(1, 0);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], None)
+                .unwrap_err(),
+            VuRngError::UnexpectedReadDescriptor
+        );
+    }
+
+    #[test]
+    fn verify_timer() {
+        let random = tempfile().unwrap();
+        let random_file = Arc::new(Mutex::new(random));
+        let mut backend = VuRngBackend::new(random_file, 1000, 512).unwrap();
+
+        // Artificial memory
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+
+        // Artificial Vring
+        let vring = VringRwLock::new(mem.clone(), 0x1000);
+
+        // Artifically set the memory to avoid a VuRngError::NoMemoryConfigured error
+        backend.update_memory(mem).unwrap();
+
+        // Artificially set the period start time 5 seconds in the future
+        backend.time_add(Duration::from_secs(5));
+
+        // Checking for a start time in the future throws a VuRngError::UnexpectedTimerValue
+        assert_eq!(
+            backend
+                .process_requests(vec![build_desc_chain(1, VIRTQ_DESC_F_WRITE)], Some(&vring))
+                .unwrap_err(),
+            VuRngError::UnexpectedTimerValue
+        );
+
+        // Artificially set the period start time to 10 second.  This will simulate a
+        // condition where the the period has been exeeded and for the quota to be reset
+        // to its maximum value.
+        backend.time_sub(Duration::from_secs(10));
+        assert!(backend
+            .process_requests(vec![build_desc_chain(1, VIRTQ_DESC_F_WRITE)], Some(&vring))
+            .unwrap());
+
+        // Reset time to right now and set remaining quota to 0.  This will simulate a
+        // condition where the quota for a period has been exceeded and force the execution
+        // thread to wait for the start of the next period before serving requets.
+        backend.time_now();
+        backend.set_quota(0);
+        assert!(backend
+            .process_requests(vec![build_desc_chain(1, VIRTQ_DESC_F_WRITE)], Some(&vring))
+            .unwrap());
+    }
+
+    #[test]
+    fn verify_file_access() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("foo.txt");
+        let random_file = Arc::new(Mutex::new(File::create(file_path).unwrap()));
+        let mut backend = VuRngBackend::new(random_file, 1000, 512).unwrap();
+
+        // Artificial memory
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+
+        // Artificial Vring
+        let vring = VringRwLock::new(mem.clone(), 0x1000);
+
+        // Artifically set the memory to avoid a VuRngError::NoMemoryConfigured error
+        backend.update_memory(mem).unwrap();
+
+        // Reading from an empty file will throw a VuRngError::UnexpectedRngSourceError.
+        assert_eq!(
+            backend
+                .process_requests(vec![build_desc_chain(1, VIRTQ_DESC_F_WRITE)], Some(&vring))
+                .unwrap_err(),
+            VuRngError::UnexpectedRngSourceError
+        );
+    }
+
+    #[test]
+    fn verify_handle_event() {
+        let random = tempfile().unwrap();
+        let random_file = Arc::new(Mutex::new(random));
+        let mut backend = VuRngBackend::new(random_file, 1000, 512).unwrap();
+        // Artificial memory
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+
+        // Artificial Vring
+        let vring = VringRwLock::new(mem, 0x1000);
+
+        // Currently handles EventSet::IN only, otherwise an error is generated.
+        assert_eq!(
+            backend
+                .handle_event(0, EventSet::OUT, &[vring.clone()], 0)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Other
+        );
+
+        // Currently handles a single device event, anything higher than 0 will generate
+        // an error.
+        assert_eq!(
+            backend
+                .handle_event(1, EventSet::IN, &[vring.clone()], 0)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Other
+        );
+
+        // backend.event_idx is set to false by default, which will call backend.process_queue()
+        // a single time.  Since there is no descriptor in the vring backend.process_requests()
+        // will return immediately.
+        backend
+            .handle_event(0, EventSet::IN, &[vring.clone()], 0)
+            .unwrap();
+
+        // Set backend.event_idx to true in order to call backend.process_queue() multiple time
+        backend.set_event_idx(true);
+        backend.handle_event(0, EventSet::IN, &[vring], 0).unwrap();
+    }
+
+    #[test]
+    fn verify_backend() {
+        let random = tempfile().unwrap();
+        let random_file = Arc::new(Mutex::new(random));
+        let mut backend = VuRngBackend::new(random_file, 1000, 512).unwrap();
+        // Artificial memory
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+
+        // Artificial Vring
+        let vring = VringRwLock::new(mem.clone(), 0x1000);
+
+        // Empty descriptor chain should be ignored
+        assert!(backend
+            .process_requests(Vec::<RngDescriptorChain>::new(), Some(&vring))
+            .unwrap());
+
+        // The descriptor type and count are correct but no memory is configured, something
+        // that needs to generate a VuRngError::NoMemoryConfigured error.
+        let desc_chain = build_desc_chain(1, VIRTQ_DESC_F_WRITE);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], Some(&vring))
+                .unwrap_err(),
+            VuRngError::NoMemoryConfigured
+        );
+
+        // Artificially set the memory to avoid a VuRngError::NoMemoryConfigured error
+        backend.update_memory(mem).unwrap();
+
+        // The capacity of descriptors is 512 byte as set in build_desc_chain().  Set the
+        // quota value to half of that to simulate a condition where there is less antropy
+        // available than the capacity of the descriptor buffer.
+        backend.set_quota(0x100);
+        assert!(backend
+            .process_requests(vec![build_desc_chain(1, VIRTQ_DESC_F_WRITE)], Some(&vring))
+            .unwrap());
+
+        assert_eq!(backend.num_queues(), NUM_QUEUES);
+        assert_eq!(backend.max_queue_size(), QUEUE_SIZE);
+        assert_eq!(backend.features(), 0x171000000);
+        assert_eq!(backend.protocol_features(), VhostUserProtocolFeatures::MQ);
+
+        assert_eq!(backend.queues_per_thread(), vec![0xffff_ffff]);
+        assert_eq!(backend.get_config(0, 0), vec![]);
+
+        backend.set_event_idx(true);
+        assert!(backend.event_idx);
     }
 }


### PR DESCRIPTION
A fifth revision of this feature was needed to address problems inherent to moving to Rust 1.58.1.  

Those mainly revolved around the clap::load_yaml!() macro that got deprecated.  As such funtion parse_cmd_line() was completely removed to favour clap::Parser(), mandating at the same time the introcution of a new RngArgs structure and the implementation of trait TryFrom() for VuRngConfig.  That in turn allowed for the simplification of some test cases due to added functionality being built-in the clap:Parser.

The rest of the functionality remains unchanged.