### PR TITLE
i2c: Trim the device list to avoid errors

### DIFF
--- a/i2c/src/main.rs
+++ b/i2c/src/main.rs
@@ -163,7 +163,7 @@ impl TryFrom<I2cArgs> for I2cConfiguration {
             return Err(Error::SocketCountInvalid(0));
         }
 
-        let devices = AdapterConfig::try_from(args.device_list.as_str())?;
+        let devices = AdapterConfig::try_from(args.device_list.trim())?;
         Ok(I2cConfiguration {
             socket_path: args.socket_path,
             socket_count: args.socket_count,
@@ -324,6 +324,11 @@ mod tests {
     fn test_parse_successful() {
         let socket_name = "vi2c.sock";
 
+        // Space before and after the device list
+        let cmd_args = I2cArgs::from_args(socket_name, " 1:4 ", 1);
+        I2cConfiguration::try_from(cmd_args).unwrap();
+
+        // Valid configuration
         let cmd_args = I2cArgs::from_args(socket_name, "1:4,2:32:21,5:5:23", 5);
         let config = I2cConfiguration::try_from(cmd_args).unwrap();
 

--- a/i2c/src/main.rs
+++ b/i2c/src/main.rs
@@ -165,7 +165,7 @@ impl TryFrom<I2cArgs> for I2cConfiguration {
 
         let devices = AdapterConfig::try_from(args.device_list.trim())?;
         Ok(I2cConfiguration {
-            socket_path: args.socket_path,
+            socket_path: args.socket_path.trim().to_string(),
             socket_count: args.socket_count,
             devices,
         })
@@ -324,9 +324,10 @@ mod tests {
     fn test_parse_successful() {
         let socket_name = "vi2c.sock";
 
-        // Space before and after the device list
-        let cmd_args = I2cArgs::from_args(socket_name, " 1:4 ", 1);
-        I2cConfiguration::try_from(cmd_args).unwrap();
+        // Space before and after the device list and socket name
+        let cmd_args = I2cArgs::from_args(" ./vi2c.sock", " 1:4 ", 1);
+        let config = I2cConfiguration::try_from(cmd_args).unwrap();
+        Listener::new(config.socket_path, true).unwrap();
 
         // Valid configuration
         let cmd_args = I2cArgs::from_args(socket_name, "1:4,2:32:21,5:5:23", 5);


### PR DESCRIPTION
If the user passes device list with whitespace before or after, like -l
" 6:32", then " 6".parse::<u32>() fails. Fix this by trimming the
argument for whitespace at start or end.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>