### PR TITLE
gpio: Enable REPLY_ACK protocol feature

### DIFF
--- a/gpio/src/vhu_gpio.rs
+++ b/gpio/src/vhu_gpio.rs
@@ -391,7 +391,9 @@ impl<D: 'static + GpioDevice + Sync + Send> VhostUserBackendMut<VringRwLock, ()>
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::CONFIG
+        VhostUserProtocolFeatures::MQ
+            | VhostUserProtocolFeatures::CONFIG
+            | VhostUserProtocolFeatures::REPLY_ACK
     }
 
     fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
@@ -1098,7 +1100,9 @@ mod tests {
         assert_eq!(backend.features(), 0x171000001);
         assert_eq!(
             backend.protocol_features(),
-            VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::CONFIG
+            VhostUserProtocolFeatures::MQ
+                | VhostUserProtocolFeatures::CONFIG
+                | VhostUserProtocolFeatures::REPLY_ACK
         );
 
         assert_eq!(backend.queues_per_thread(), vec![0xffff_ffff]);


### PR DESCRIPTION
The virtio-gpio driver at the guest performs virtio transaction right
from its probe() routine and without this patch, there is a chance that
the backend may miss the notification from the guest, as the
notification may be sent before the eventfd is set at the backend. This
flag makes the master side wait for reply from backend before proceeding
further for each operation.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>