### PR TITLE
build: Relax vm-memory dependency

### DIFF
--- a/gpio/Cargo.toml
+++ b/gpio/Cargo.toml
@@ -21,7 +21,7 @@ vhost = { version = "0.4", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.3"
 virtio-bindings = ">=0.1"
 virtio-queue = "0.2"
-vm-memory = "0.7"
+vm-memory = ">=0.7"
 vmm-sys-util = "=0.9.0"
 
 [target.'cfg(target_env = "gnu")'.dependencies]
@@ -29,4 +29,4 @@ libgpiod = { git = "https://github.com/vireshk/libgpiod" }
 
 [dev-dependencies]
 virtio-queue = { version = "0.2", features = ["test-utils"] }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/i2c/Cargo.toml
+++ b/i2c/Cargo.toml
@@ -21,9 +21,9 @@ vhost = { version = "0.4", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.3"
 virtio-bindings = ">=0.1"
 virtio-queue = "0.2"
-vm-memory = "0.7"
+vm-memory = ">=0.7"
 vmm-sys-util = "=0.9.0"
 
 [dev-dependencies]
 virtio-queue = { version = "0.2", features = ["test-utils"] }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.7.0", features = ["backend-mmap", "backend-atomic"] }

--- a/rng/Cargo.toml
+++ b/rng/Cargo.toml
@@ -27,4 +27,4 @@ vmm-sys-util = ">=0.9.0"
 
 [dev-dependencies]
 virtio-queue = { version = "0.2", features = ["test-utils"] }
-vm-memory = { version = "0.7.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = ">=0.7.0", features = ["backend-mmap", "backend-atomic"] }


### PR DESCRIPTION
This allows the use of newer versions of vm-memory and matches with
other crates (e.g. vhost, vhost-user-backend, etc) who also have such a
relaxed vm-memory dependency.

Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>