### PR TITLE
Preparation for upgrade to Rust version to 1.63.0

### DIFF
--- a/gpio/src/backend.rs
+++ b/gpio/src/backend.rs
@@ -22,7 +22,7 @@ use crate::vhu_gpio::VhostUserGpioBackend;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, PartialEq, ThisError)]
+#[derive(Debug, Eq, PartialEq, ThisError)]
 /// Errors related to low level GPIO helpers
 pub enum Error {
     #[error("Invalid socket count: {0}")]

--- a/i2c/src/vhu_i2c.rs
+++ b/i2c/src/vhu_i2c.rs
@@ -36,7 +36,7 @@ const NUM_QUEUES: usize = 1;
 type Result<T> = std::result::Result<T, Error>;
 type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
 
-#[derive(Copy, Clone, Debug, PartialEq, ThisError)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ThisError)]
 /// Errors related to vhost-device-i2c daemon.
 pub enum Error {
     #[error("Failed to handle event, didn't match EPOLLIN")]

--- a/rng/src/main.rs
+++ b/rng/src/main.rs
@@ -25,7 +25,7 @@ const VHU_RNG_MAX_PERIOD_MS: u128 = 65536;
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, PartialEq, ThisError)]
+#[derive(Debug, Eq, PartialEq, ThisError)]
 /// Errors related to vhost-device-rng daemon.
 pub enum Error {
     #[error("RNG source file doesn't exists or can't be accessed")]
@@ -62,7 +62,7 @@ struct RngArgs {
     rng_source: String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VuRngConfig {
     pub period_ms: u128,
     pub max_bytes: usize,

--- a/rng/src/vhu_rng.rs
+++ b/rng/src/vhu_rng.rs
@@ -32,7 +32,7 @@ const NUM_QUEUES: usize = 1;
 type Result<T> = std::result::Result<T, VuRngError>;
 type RngDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
 
-#[derive(Debug, PartialEq, ThisError)]
+#[derive(Debug, Eq, PartialEq, ThisError)]
 /// Errors related to vhost-device-rng daemon.
 pub enum VuRngError {
     #[error("Descriptor not found")]
@@ -65,7 +65,7 @@ impl convert::From<VuRngError> for io::Error {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VuRngTimerConfig {
     period_ms: u128,
     period_start: Instant,


### PR DESCRIPTION
In preparation to upgrade to Rust version 1.63.0, address clippy
warning demanding that 'Eq' be derived when 'PartialEq' is.

Signed-off-by: Mathieu Poirier <mathieu.poirier@linaro.org>

### Summary of the PR

This PR is needed to address warnings found in [PR#199](https://github.com/rust-vmm/vhost-device/pull/199).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
