### PR TITLE
Remove `use std::convert::TryFrom`

### DIFF
--- a/gpio/src/backend.rs
+++ b/gpio/src/backend.rs
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use log::{info, warn};
-use std::convert::TryFrom;
 use std::num::ParseIntError;
 use std::sync::{Arc, RwLock};
 use std::thread::spawn;

--- a/i2c/src/i2c.rs
+++ b/i2c/src/i2c.rs
@@ -571,7 +571,6 @@ impl<D: I2cDevice> I2cMap<D> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::convert::TryFrom;
     use vmm_sys_util::tempfile::TempFile;
 
     // Update read-buffer of each write-buffer with index + 1 value.

--- a/i2c/src/main.rs
+++ b/i2c/src/main.rs
@@ -9,7 +9,6 @@ mod i2c;
 mod vhu_i2c;
 
 use log::{info, warn};
-use std::convert::TryFrom;
 use std::num::ParseIntError;
 use std::sync::{Arc, RwLock};
 use std::thread::spawn;

--- a/i2c/src/vhu_i2c.rs
+++ b/i2c/src/vhu_i2c.rs
@@ -356,8 +356,6 @@ impl<D: 'static + I2cDevice + Sync + Send> VhostUserBackendMut<VringRwLock, ()>
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
     use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};

--- a/rng/src/main.rs
+++ b/rng/src/main.rs
@@ -6,7 +6,6 @@
 mod vhu_rng;
 
 use log::{info, warn};
-use std::convert::TryFrom;
 use std::fs::File;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;


### PR DESCRIPTION
see https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html#details

Signed-off-by: Obei Sideg <obei.sideg@gmail.com>

### Summary of the PR

Remove `use std::convert::TryFrom`
in 2021 edition we won't need to explicitly bring it into scope
see https://doc.rust-lang.org/nightly/edition-guide/rust-2021/prelude.html#details

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
