### PR TITLE
Vsock test workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +306,16 @@ version = "0.1.0"
 source = "git+https://github.com/vireshk/libgpiod#9d8e18e2ad2d4bc4f5e315c01c9c03418ff47993"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -319,6 +354,29 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -446,6 +504,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serial_test"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92761393ee4dc3ff8f4af487bd58f4307c9329bbedea02cac0089ad9c411e153"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +543,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
@@ -618,6 +714,7 @@ dependencies = [
  "epoll",
  "futures",
  "log",
+ "serial_test",
  "thiserror",
  "vhost",
  "vhost-user-backend",
@@ -713,3 +810,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -27,3 +27,4 @@ vmm-sys-util = "=0.10.0"
 
 [dev-dependencies]
 virtio-queue = { version = "0.6", features = ["test-utils"] }
+serial_test = "0.9"

--- a/crates/vsock/src/main.rs
+++ b/crates/vsock/src/main.rs
@@ -103,6 +103,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     impl VsockArgs {
         fn from_args(guest_cid: u64, socket: &str, uds_path: &str) -> Self {
@@ -115,6 +116,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_config_setup() {
         let args = VsockArgs::from_args(3, "/tmp/vhost4.socket", "/tmp/vm4.vsock");
 
@@ -128,6 +130,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_server() {
         const CID: u64 = 3;
         const VHOST_SOCKET_PATH: &str = "test_vsock_server.socket";

--- a/crates/vsock/src/thread_backend.rs
+++ b/crates/vsock/src/thread_backend.rs
@@ -245,12 +245,14 @@ impl VsockThreadBackend {
 mod tests {
     use super::*;
     use crate::vhu_vsock::VSOCK_OP_RW;
+    use serial_test::serial;
     use std::os::unix::net::UnixListener;
     use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
 
     const DATA_LEN: usize = 16;
 
     #[test]
+    #[serial]
     fn test_vsock_thread_backend() {
         const VSOCK_SOCKET_PATH: &str = "test_vsock_thread_backend.vsock";
         const VSOCK_PEER_PORT: u32 = 1234;

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -321,11 +321,13 @@ impl VhostUserBackendMut<VringRwLock, ()> for VhostUserVsockBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::convert::TryInto;
     use vhost_user_backend::VringT;
     use vm_memory::GuestAddress;
 
     #[test]
+    #[serial]
     fn test_vsock_backend() {
         const CID: u64 = 3;
         const VHOST_SOCKET_PATH: &str = "test_vsock_backend.socket";
@@ -393,6 +395,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_backend_failures() {
         const CID: u64 = 3;
         const VHOST_SOCKET_PATH: &str = "test_vsock_backend_failures.socket";

--- a/crates/vsock/src/vhu_vsock_thread.rs
+++ b/crates/vsock/src/vhu_vsock_thread.rs
@@ -583,6 +583,7 @@ impl Drop for VhostUserVsockThread {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use vm_memory::GuestAddress;
     use vmm_sys_util::eventfd::EventFd;
 
@@ -593,6 +594,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_thread() {
         let t = VhostUserVsockThread::new("test_vsock_thread.vsock".to_string(), 3);
         assert!(t.is_ok());
@@ -645,6 +647,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_thread_failures() {
         let t = VhostUserVsockThread::new("/sys/not_allowed.vsock".to_string(), 3);
         assert!(t.is_err());

--- a/crates/vsock/src/vsock_conn.rs
+++ b/crates/vsock/src/vsock_conn.rs
@@ -352,6 +352,7 @@ mod tests {
 
     use super::*;
     use crate::vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM};
+    use serial_test::serial;
     use std::io::Result as IoResult;
     use std::ops::Deref;
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
@@ -485,6 +486,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_conn_init() {
         // new locally inititated connection
         let dummy_file = VsockDummySocket::new();
@@ -518,6 +520,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_conn_credit() {
         // new locally inititated connection
         let dummy_file = VsockDummySocket::new();
@@ -541,6 +544,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_conn_init_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 10);
@@ -570,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_conn_recv_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);
@@ -659,6 +664,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_vsock_conn_send_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);


### PR DESCRIPTION
### Summary of the PR

As pointed out in the issue https://github.com/rust-vmm/vhost-device/issues/232, vsock tests fail randomly.
From an initial analysis, it appears that using `--test-threads=1`
never happens, but using a value greater than 1, the tests fails
after a while and almost always with the creation of UDS,
or EpollFD, or on epoll_ctl.

There should be something wrong with FDs when there are multiple
threads running tests (not sure if related to O_CLOEXEC).

This is just a workaround, we will revert this commit when we
identify the root cause.

Marked as draft since it is based on #230, I'll mark it ready when we will merge it.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
