### PR TITLE
Caret requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
 
 [[package]]
 name = "cfg-if"
@@ -60,9 +60,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "4.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "60494cedb60cb47462c0ff7be53de32c0e42a6fc2c772184554fa12bd9489c03"
 dependencies = [
  "atty",
  "bitflags",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -335,9 +335,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -345,15 +345,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
 name = "parking_lot"
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -392,9 +392,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -813,43 +813,57 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/crates/gpio/Cargo.toml
+++ b/crates/gpio/Cargo.toml
@@ -12,21 +12,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = ">=3.0",  features = ["derive"] }
-env_logger = ">=0.9"
-libc = ">=0.2.95"
-log = ">=0.4.6"
+clap = { version = "4.0",  features = ["derive"] }
+env_logger = "0.9"
+libc = "0.2"
+log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.5", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.7.0"
-virtio-bindings = ">=0.1"
+vhost-user-backend = "0.7"
+virtio-bindings = "0.1"
 virtio-queue = "0.6"
-vm-memory = ">=0.8"
-vmm-sys-util = "=0.10.0"
+vm-memory = "0.9"
+vmm-sys-util = "0.10"
 
 [target.'cfg(target_env = "gnu")'.dependencies]
 libgpiod = { git = "https://github.com/vireshk/libgpiod" }
 
 [dev-dependencies]
 virtio-queue = { version = "0.6", features = ["test-utils"] }
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/i2c/Cargo.toml
+++ b/crates/i2c/Cargo.toml
@@ -12,18 +12,18 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = ">=3.0",  features = ["derive"] }
-env_logger = ">=0.9"
-libc = ">=0.2.95"
-log = ">=0.4.6"
+clap = { version = "4.0",  features = ["derive"] }
+env_logger = "0.9"
+libc = "0.2"
+log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.5", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.7.0"
-virtio-bindings = ">=0.1"
+vhost-user-backend = "0.7"
+virtio-bindings = "0.1"
 virtio-queue = "0.6"
-vm-memory = ">=0.8"
-vmm-sys-util = "=0.10.0"
+vm-memory = "0.9"
+vmm-sys-util = "0.10"
 
 [dev-dependencies]
 virtio-queue = { version = "0.6", features = ["test-utils"] }
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -10,21 +10,21 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 
 [dependencies]
-clap = { version = ">=3.0",  features = ["derive"] }
-env_logger = ">=0.9"
+clap = { version = "4.0",  features = ["derive"] }
+env_logger = "0.9"
 epoll = "4.3"
-libc = ">=0.2.95"
-log = ">=0.4.6"
-rand = ">=0.8.5"
-tempfile = "3.2.0"
+libc = "0.2"
+log = "0.4"
+rand = "0.8.5"
+tempfile = "3.2"
 thiserror = "1.0"
 vhost = { version = "0.5", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.7.0"
-virtio-bindings = ">=0.1"
+vhost-user-backend = "0.7"
+virtio-bindings = "0.1"
 virtio-queue = "0.6"
-vm-memory = ">=0.8"
-vmm-sys-util = "=0.10.0"
+vm-memory = "0.9"
+vmm-sys-util = "0.10"
 
 [dev-dependencies]
 virtio-queue = { version = "0.6", features = ["test-utils"] }
-vm-memory = { version = ">=0.8.0", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.9", features = ["backend-mmap", "backend-atomic"] }

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -11,19 +11,19 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1"
-clap = { version = ">=3.0",  features = ["derive"] }
-env_logger = ">=0.9"
+clap = { version = "4.0",  features = ["derive"] }
+env_logger = "0.9"
 epoll = "4.3.1"
 futures = { version = "0.3", features = ["thread-pool"] }
-log = ">=0.4.6"
+log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.5", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.7.0"
-virtio-bindings = ">=0.1"
+vhost-user-backend = "0.7"
+virtio-bindings = "0.1"
 virtio-queue = "0.6"
-virtio-vsock = "0.1.0"
-vm-memory = ">=0.8"
-vmm-sys-util = "=0.10.0"
+virtio-vsock = "0.1"
+vm-memory = "0.9"
+vmm-sys-util = "0.10"
 
 [dev-dependencies]
 virtio-queue = { version = "0.6", features = ["test-utils"] }


### PR DESCRIPTION
Switch to caret versions
    
Specify the dependencies with caret versions.
Fixes: rust-vmm/community#131