### PR TITLE
Gpio/update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "intmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee87fd093563344074bacf24faa0bb0227fb6969fb223e922db798516de924d6"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,18 +350,19 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 [[package]]
 name = "libgpiod"
 version = "0.1.0"
-source = "git+https://github.com/vireshk/libgpiod#52f16effabd5c6838d00f4d4ad054d5304e0d5d6"
+source = "git+https://github.com/vireshk/libgpiod?branch=vhost-gpio#d7b36c56170331699fd5e4e18918af81333aa64a"
 dependencies = [
+ "errno",
+ "intmap",
  "libc",
  "libgpiod-sys",
  "thiserror",
- "vmm-sys-util",
 ]
 
 [[package]]
 name = "libgpiod-sys"
 version = "0.1.0"
-source = "git+https://github.com/vireshk/libgpiod#52f16effabd5c6838d00f4d4ad054d5304e0d5d6"
+source = "git+https://github.com/vireshk/libgpiod?branch=vhost-gpio#d7b36c56170331699fd5e4e18918af81333aa64a"
 dependencies = [
  "cc",
 ]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 69.6,
+  "coverage_score": 68.9,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/gpio/Cargo.toml
+++ b/crates/gpio/Cargo.toml
@@ -25,7 +25,7 @@ vm-memory = "0.10"
 vmm-sys-util = "0.11"
 
 [target.'cfg(target_env = "gnu")'.dependencies]
-libgpiod = { git = "https://github.com/vireshk/libgpiod" }
+libgpiod = { git = "https://github.com/vireshk/libgpiod", branch = "vhost-gpio" }
 
 [dev-dependencies]
 virtio-queue = { version = "0.7", features = ["test-utils"] }

--- a/crates/gpio/src/vhu_gpio.rs
+++ b/crates/gpio/src/vhu_gpio.rs
@@ -165,7 +165,7 @@ impl<D: GpioDevice> VhostUserGpioBackend<D> {
     pub(crate) fn new(controller: GpioController<D>) -> Result<Self> {
         // Can't set a vector to all None easily
         let mut handles: Vec<Option<JoinHandle<()>>> = Vec::new();
-        handles.resize_with(controller.get_num_gpios() as usize, || None);
+        handles.resize_with(controller.num_gpios() as usize, || None);
 
         Ok(VhostUserGpioBackend {
             controller: Arc::new(controller),
@@ -289,7 +289,7 @@ impl<D: GpioDevice> VhostUserGpioBackend<D> {
 
         // Interrupt should be enabled before sending buffer and no other buffer
         // should have been received earlier for this GPIO pin.
-        if controller.get_irq_type(gpio) == VIRTIO_GPIO_IRQ_TYPE_NONE || handle.is_some() {
+        if controller.irq_type(gpio) == VIRTIO_GPIO_IRQ_TYPE_NONE || handle.is_some() {
             send_event_response(vring, desc_chain, addr, VIRTIO_GPIO_IRQ_STATUS_INVALID);
             return;
         }
@@ -412,7 +412,7 @@ impl<D: 'static + GpioDevice + Sync + Send> VhostUserBackendMut<VringRwLock, ()>
         unsafe {
             from_raw_parts(
                 self.controller
-                    .get_config()
+                    .config()
                     .as_slice()
                     .as_ptr()
                     .offset(offset as isize) as *const _ as *const _,


### PR DESCRIPTION
    gpiod: Migrate to upstreamed version of libgpiod
    
    The libgpiod rust bindings got upstreamed recently. Migrate to the
    upstreamed version.