### PR TITLE
Updates crates to use virtio_config bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
  "thiserror",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.0",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -832,7 +832,7 @@ dependencies = [
  "thiserror",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.0",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -852,7 +852,7 @@ dependencies = [
  "thiserror",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.0",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -867,7 +867,7 @@ dependencies = [
  "libc",
  "log",
  "vhost",
- "virtio-bindings",
+ "virtio-bindings 0.1.0",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -887,7 +887,7 @@ dependencies = [
  "thiserror",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.0",
  "virtio-queue",
  "virtio-vsock",
  "vm-memory",
@@ -901,13 +901,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9084faf91b9aa9676ae2cac8f1432df2839d9566e6f19f29dbc13a8b831dff"
+
+[[package]]
 name = "virtio-queue"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e927d93d54c365034fd7f31a5f458a1f540de4a37c52e892670dad9692173c"
 dependencies = [
  "log",
- "virtio-bindings",
+ "virtio-bindings 0.1.0",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -918,7 +924,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba7254bb0f6111fa84cb24bbf1dfb327ad02b1056ce8ed7f13962b8d0ca3aaa2"
 dependencies = [
- "virtio-bindings",
+ "virtio-bindings 0.1.0",
  "virtio-queue",
  "vm-memory",
 ]

--- a/crates/gpio/Cargo.toml
+++ b/crates/gpio/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
-virtio-bindings = "0.1"
+virtio-bindings = "0.2"
 virtio-queue = "0.7"
 vm-memory = "0.10"
 vmm-sys-util = "0.11"

--- a/crates/gpio/src/vhu_gpio.rs
+++ b/crates/gpio/src/vhu_gpio.rs
@@ -18,7 +18,7 @@ use std::{
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
-use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
 use virtio_bindings::bindings::virtio_ring::{
     VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };

--- a/crates/i2c/Cargo.toml
+++ b/crates/i2c/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
-virtio-bindings = "0.1"
+virtio-bindings = "0.2"
 virtio-queue = "0.7"
 vm-memory = "0.10"
 vmm-sys-util = "0.11"

--- a/crates/i2c/src/vhu_i2c.rs
+++ b/crates/i2c/src/vhu_i2c.rs
@@ -16,7 +16,7 @@ use std::{
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
-use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
 use virtio_bindings::bindings::virtio_ring::{
     VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -20,7 +20,7 @@ tempfile = "3.2"
 thiserror = "1.0"
 vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
-virtio-bindings = "0.1"
+virtio-bindings = "0.2"
 virtio-queue = "0.7"
 vm-memory = "0.10"
 vmm-sys-util = "0.11"

--- a/crates/rng/src/vhu_rng.rs
+++ b/crates/rng/src/vhu_rng.rs
@@ -15,7 +15,7 @@ use std::{convert, io, result};
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
-use virtio_bindings::bindings::virtio_net::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
 use virtio_bindings::bindings::virtio_ring::{
     VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
-virtio-bindings = "0.1"
+virtio-bindings = "0.2"
 virtio-queue = "0.7"
 virtio-vsock = "0.2.1"
 vm-memory = "0.10"

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -10,7 +10,7 @@ use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_user_backend::{VhostUserBackendMut, VringRwLock};
 use virtio_bindings::bindings::{
-    virtio_net::VIRTIO_F_NOTIFY_ON_EMPTY, virtio_net::VIRTIO_F_VERSION_1,
+    virtio_config::VIRTIO_F_NOTIFY_ON_EMPTY, virtio_config::VIRTIO_F_VERSION_1,
     virtio_ring::VIRTIO_RING_F_EVENT_IDX,
 };
 use vm_memory::{ByteValued, GuestMemoryAtomic, GuestMemoryMmap, Le64};


### PR DESCRIPTION
Rather incongruously the common VIRTIO feature flags where part of the net binding. We need to update to using the correct location once the changes:

  https://github.com/rust-vmm/vm-virtio/pull/215

get released.

Signed-off-by: Alex Bennée <alex.bennee@linaro.org>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ x] All added/changed functionality has a corresponding unit/integration
  test.
- [x ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ x] Any newly added `unsafe` code is properly documented.
