### PR TITLE
vsock: require virtio-vsock 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-vsock"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d79c8b2052025a5afaba39ca09880f5ab4623fabfe0514e587d100579d504c"
+checksum = "ba7254bb0f6111fa84cb24bbf1dfb327ad02b1056ce8ed7f13962b8d0ca3aaa2"
 dependencies = [
  "virtio-bindings",
  "virtio-queue",

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -21,7 +21,7 @@ vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
 virtio-bindings = "0.1"
 virtio-queue = "0.7"
-virtio-vsock = "0.2"
+virtio-vsock = "0.2.1"
 vm-memory = "0.10"
 vmm-sys-util = "0.11"
 


### PR DESCRIPTION
### Summary of the PR

The 0.2.1 version of virtio-vsock crate contains a [fix](https://github.com/rust-vmm/vm-virtio/pull/207) needed to properly work with the virtio-vsock driver provided by Linux v6.3 and later (originally the new driver was supposed to be in v6.2, but it was postponed).

The fix was just a quick workaround, but in the future more work will be needed in the virtio-vsock crate to not have a Linux-only specific implementation of VsockPacket, as described in [this issue ](https://github.com/rust-vmm/vm-virtio/issues/216).

Signed-off-by: Stefano Garzarella <sgarzare@redhat.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
