### PR TITLE
vsock: make TX buffer size configurable

### DIFF
--- a/crates/vsock/README.md
+++ b/crates/vsock/README.md
@@ -43,6 +43,7 @@ Run the vhost-user-vsock device:
 vhost-user-vsock --guest-cid=<CID assigned to the guest> \
   --socket=<path to the Unix socket to be created to communicate with the VMM via the vhost-user protocol>
   --uds-path=<path to the Unix socket to communicate with the guest via the virtio-vsock device>
+  [--tx-buffer-size=<size of the buffer used for the TX virtqueue (guest->host packets)>]
 ```
 
 Run VMM (e.g. QEMU):
@@ -60,6 +61,10 @@ qemu-system-x86_64 \
 
 ```sh
 shell1$ vhost-user-vsock --guest-cid=4 --uds-path=/tmp/vm4.vsock --socket=/tmp/vhost4.socket
+```
+or if you want to configure the TX buffer size
+```sh
+shell1$ vhost-user-vsock --guest-cid=4 --uds-path=/tmp/vm4.vsock --socket=/tmp/vhost4.socket --tx-buffer-size=65536
 ```
 
 ```sh

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -34,10 +34,6 @@ const EVT_QUEUE_EVENT: u16 = 2;
 /// Notification coming from the backend.
 pub(crate) const BACKEND_EVENT: u16 = 3;
 
-/// Vsock connection TX buffer capacity
-/// TODO: Make this value configurable
-pub(crate) const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
-
 /// CID of the host
 pub(crate) const VSOCK_HOST_CID: u64 = 2;
 
@@ -141,16 +137,18 @@ pub(crate) struct VsockConfig {
     guest_cid: u64,
     socket: String,
     uds_path: String,
+    tx_buffer_size: u32,
 }
 
 impl VsockConfig {
     /// Create a new instance of the VsockConfig struct, containing the
     /// parameters to be fed into the vsock-backend server.
-    pub fn new(guest_cid: u64, socket: String, uds_path: String) -> Self {
+    pub fn new(guest_cid: u64, socket: String, uds_path: String, tx_buffer_size: u32) -> Self {
         Self {
             guest_cid,
             socket,
             uds_path,
+            tx_buffer_size,
         }
     }
 
@@ -169,6 +167,10 @@ impl VsockConfig {
     /// requests from the guest.
     pub fn get_socket_path(&self) -> String {
         String::from(&self.socket)
+    }
+
+    pub fn get_tx_buffer_size(&self) -> u32 {
+        self.tx_buffer_size
     }
 }
 
@@ -212,6 +214,7 @@ impl VhostUserVsockBackend {
         let thread = Mutex::new(VhostUserVsockThread::new(
             config.get_uds_path(),
             config.get_guest_cid(),
+            config.get_tx_buffer_size(),
         )?);
         let queues_per_thread = vec![QUEUE_MASK];
 
@@ -328,6 +331,8 @@ mod tests {
     use vhost_user_backend::VringT;
     use vm_memory::GuestAddress;
 
+    const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
+
     #[test]
     #[serial]
     fn test_vsock_backend() {
@@ -339,6 +344,7 @@ mod tests {
             CID,
             VHOST_SOCKET_PATH.to_string(),
             VSOCK_SOCKET_PATH.to_string(),
+            CONN_TX_BUF_SIZE,
         );
 
         let backend = VhostUserVsockBackend::new(config);
@@ -411,6 +417,7 @@ mod tests {
             CID,
             "/sys/not_allowed.socket".to_string(),
             "/sys/not_allowed.vsock".to_string(),
+            CONN_TX_BUF_SIZE,
         );
 
         let backend = VhostUserVsockBackend::new(config);
@@ -420,6 +427,7 @@ mod tests {
             CID,
             VHOST_SOCKET_PATH.to_string(),
             VSOCK_SOCKET_PATH.to_string(),
+            CONN_TX_BUF_SIZE,
         );
 
         let mut backend = VhostUserVsockBackend::new(config).unwrap();


### PR DESCRIPTION
### Summary of the PR

That buffer is used to store bytes coming from the guest before
sending them to the Unix domain socket. Some use cases might want
to increase or decrease this space, so it would be best to make it
user-customizable. Users can use "--tx-buffer-size=" to configure
TX buffer.

Fixes: https://github.com/rust-vmm/vhost-device/issues/319

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
