### PR TITLE
reduce credit update messages sent to guest

### DIFF
--- a/crates/vsock/src/vsock_conn.rs
+++ b/crates/vsock/src/vsock_conn.rs
@@ -52,6 +52,8 @@ pub(crate) struct VsockConnection<S> {
     pub epoll_fd: RawFd,
     /// Local tx buffer.
     pub tx_buf: LocalTxBuf,
+    /// Local tx buffer size
+    tx_buffer_size: u32,
 }
 
 impl<S: AsRawFd + Read + Write> VsockConnection<S> {
@@ -81,6 +83,7 @@ impl<S: AsRawFd + Read + Write> VsockConnection<S> {
             rx_cnt: Wrapping(0),
             epoll_fd,
             tx_buf: LocalTxBuf::new(tx_buffer_size),
+            tx_buffer_size,
         }
     }
 
@@ -114,6 +117,7 @@ impl<S: AsRawFd + Read + Write> VsockConnection<S> {
             rx_cnt: Wrapping(0),
             epoll_fd,
             tx_buf: LocalTxBuf::new(tx_buffer_size),
+            tx_buffer_size,
         }
     }
 
@@ -308,8 +312,18 @@ impl<S: AsRawFd + Read + Write> VsockConnection<S> {
         if written_count > 0 {
             // Increment forwarded count by number of bytes written to the stream
             self.fwd_cnt += Wrapping(written_count as u32);
-            // TODO: https://github.com/torvalds/linux/commit/c69e6eafff5f725bc29dcb8b52b6782dca8ea8a2
-            self.rx_queue.enqueue(RxOps::CreditUpdate);
+
+            // At what point in available credits should we send a credit update.
+            // This is set to 1/4th of the tx buffer size. If we keep it too low,
+            // we will end up sending too many credit updates. If we keep it too
+            // high, we will end up sending too few credit updates and cause stalls.
+            // Stalls are more bad than too many credit updates.
+            let free_space = self
+                .tx_buffer_size
+                .wrapping_sub((self.fwd_cnt - self.last_fwd_cnt).0);
+            if free_space < self.tx_buffer_size / 4 {
+                self.rx_queue.enqueue(RxOps::CreditUpdate);
+            }
         }
 
         if written_count != buf.len() {
@@ -332,7 +346,7 @@ impl<S: AsRawFd + Read + Write> VsockConnection<S> {
             .set_src_port(self.local_port)
             .set_dst_port(self.peer_port)
             .set_type(VSOCK_TYPE_STREAM)
-            .set_buf_alloc(self.tx_buf.get_buf_size())
+            .set_buf_alloc(self.tx_buffer_size)
             .set_fwd_cnt(self.fwd_cnt.0)
     }
 


### PR DESCRIPTION
earlier we were sending credit update messages to guest everytime data was read, now we only send it only if available space is less than which is TX_BUFF_SIZE / 4.
Signed-off-by: Ramyak Mehra <rmehra_be19@thapar.edu>

### Summary of the PR

Fixes #317 
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
