### PR TITLE
deduplicate daemon start and wait logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1223,6 +1223,7 @@ dependencies = [
  "log",
  "thiserror",
  "vhost",
+ "vhost-device-utils",
  "vhost-user-backend",
  "virtio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
@@ -1240,6 +1241,7 @@ dependencies = [
  "log",
  "thiserror",
  "vhost",
+ "vhost-device-utils",
  "vhost-user-backend",
  "virtio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
@@ -1260,6 +1262,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "vhost",
+ "vhost-device-utils",
  "vhost-user-backend",
  "virtio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
@@ -1279,11 +1282,22 @@ dependencies = [
  "tempfile",
  "thiserror",
  "vhost",
+ "vhost-device-utils",
  "vhost-user-backend",
  "virtio-bindings 0.2.0 (git+https://github.com/rust-vmm/vm-virtio?rev=467c8ec99375a5f4e08b85b18257cd7e0bac1dc0)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-device-utils"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "vhost",
+ "vhost-user-backend",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1317,6 +1331,7 @@ dependencies = [
  "serial_test",
  "thiserror",
  "vhost",
+ "vhost-device-utils",
  "vhost-user-backend",
  "virtio-bindings 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "crates/i2c",
     "crates/rng",
     "crates/scsi",
+    "crates/utils",
     "crates/vsock",
 ]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 69.6,
+  "coverage_score": 70.6,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/gpio/Cargo.toml
+++ b/crates/gpio/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.7", features = ["vhost-user-slave"] }
+vhost-device-utils = { path = "../utils" }
 vhost-user-backend = "0.9"
 virtio-bindings = "0.2"
 virtio-queue = "0.8"

--- a/crates/i2c/Cargo.toml
+++ b/crates/i2c/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.7", features = ["vhost-user-slave"] }
+vhost-device-utils = { path = "../utils" }
 vhost-user-backend = "0.9"
 virtio-bindings = "0.2"
 virtio-queue = "0.8"

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -19,6 +19,7 @@ rand = "0.8.5"
 tempfile = "3.5"
 thiserror = "1.0"
 vhost = { version = "0.7", features = ["vhost-user-slave"] }
+vhost-device-utils = { path = "../utils" }
 vhost-user-backend = "0.9"
 virtio-bindings = "0.2"
 virtio-queue = "0.8"

--- a/crates/scsi/Cargo.toml
+++ b/crates/scsi/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 num_enum = "0.5"
 thiserror = "1.0"
 vhost = { version = "0.7", features = ["vhost-user-slave"] }
+vhost-device-utils = { path = "../utils" }
 vhost-user-backend = "0.9"
 # until the scsi bindings hit a release, we have to use the commit that adds them as rev.
 virtio-bindings = { git = "https://github.com/rust-vmm/vm-virtio", rev = "467c8ec99375a5f4e08b85b18257cd7e0bac1dc0" }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vhost-device-utils"
+version = "0.1.0"
+description = "vhost-device internal helper library"
+repository = "https://github.com/rust-vmm/vhost-device"
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"
+vhost = { version = "0.7", features = ["vhost-user"] }
+vhost-user-backend = "0.9"
+vm-memory = "0.11"

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,0 +1,73 @@
+use log::{info, warn};
+use std::{path::Path, sync::Arc};
+
+use vhost::vhost_user::{self, Listener};
+use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, VringT};
+use vm_memory::{mmap::NewBitmap, GuestMemoryAtomic, GuestMemoryMmap};
+
+// Generics here are horrible...
+// Hopefully once https://github.com/rust-vmm/vhost/pull/155 lands,
+// this can be simplified!
+
+/// A wrapper around a VhostUserDaemon that exposes a simpler API
+pub struct DaemonHandle<
+    S: VhostUserBackend<V, B> + 'static,
+    V: VringT<GuestMemoryAtomic<GuestMemoryMmap<B>>> + Clone + Send + Sync + 'static,
+    B: NewBitmap + Clone + Send + Sync + 'static,
+> {
+    pub backend: Arc<S>,
+    pub daemon: VhostUserDaemon<Arc<S>, V, B>,
+}
+
+impl<
+        S: VhostUserBackend<V, B> + 'static,
+        V: VringT<GuestMemoryAtomic<GuestMemoryMmap<B>>> + Clone + Send + Sync + 'static,
+        B: NewBitmap + Clone + Send + Sync + 'static,
+    > DaemonHandle<S, V, B>
+{
+    /// Lets the daemon start listening and waits until exit
+    pub fn start<P: AsRef<Path>>(mut self, socket_path: P) -> vhost_user::Result<()> {
+        self.daemon
+            .start(Listener::new(socket_path, true)?)
+            .expect("Starting daemon");
+
+        match self.daemon.wait() {
+            Ok(()) => {
+                info!("Stopping cleanly.");
+            }
+            Err(vhost_user_backend::Error::HandleRequest(vhost_user::Error::PartialMessage)) => {
+                info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
+            }
+            Err(e) => {
+                warn!("Error running daemon: {:?}", e);
+            }
+        }
+
+        // No matter the result, we need to shut down the worker thread.
+        // unwrap will only panic if we already panicked somewhere else
+        if let Some(exit_event) = self.backend.exit_event(0) {
+            exit_event.write(1).expect("Shutting down worker thread");
+        }
+
+        Ok(())
+    }
+}
+
+pub fn create_daemon<
+    S: VhostUserBackend<V, B> + 'static,
+    V: VringT<GuestMemoryAtomic<GuestMemoryMmap<B>>> + Clone + Send + Sync + 'static,
+    B: NewBitmap + Clone + Send + Sync + 'static,
+>(
+    backend: S,
+    name: &str,
+) -> DaemonHandle<S, V, B> {
+    let backend = Arc::new(backend);
+    let daemon = VhostUserDaemon::new(
+        name.into(),
+        backend.clone(),
+        GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+    )
+    .expect("Creating daemon");
+
+    DaemonHandle { backend, daemon }
+}

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3", features = ["thread-pool"] }
 log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.7", features = ["vhost-user-slave"] }
+vhost-device-utils = { path = "../utils" }
 vhost-user-backend = "0.9"
 virtio-bindings = "0.2"
 virtio-queue = "0.8"


### PR DESCRIPTION
All daemons had some variant of the same few lines. This moves the
code into a single new utils crate.

While it should already simplify the current code, further extensions
that touch all daemons also become easier (socket activation,
sd_notify, ...).

No functional changes intended.

Link: https://linaro.atlassian.net/browse/ORKO-32

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
