### PR TITLE
vsock: Implement sibling VM communication

### DIFF
--- a/crates/vsock/src/main.rs
+++ b/crates/vsock/src/main.rs
@@ -233,7 +233,7 @@ pub(crate) fn start_backend_servers(configs: &[VsockConfig]) {
 fn main() {
     env_logger::init();
 
-    let mut configs = match Vec::<VsockConfig>::try_from(VsockArgs::parse()) {
+    let configs = match Vec::<VsockConfig>::try_from(VsockArgs::parse()) {
         Ok(c) => c,
         Err(e) => {
             println!("Error parsing arguments: {}", e);
@@ -241,11 +241,7 @@ fn main() {
         }
     };
 
-    if configs.len() == 1 {
-        start_backend_server(configs.pop().unwrap());
-    } else {
-        start_backend_servers(&configs);
-    }
+    start_backend_servers(&configs);
 }
 
 #[cfg(test)]

--- a/crates/vsock/src/vhu_vsock_thread.rs
+++ b/crates/vsock/src/vhu_vsock_thread.rs
@@ -100,7 +100,13 @@ impl VhostUserVsockThread {
             host_listener: host_sock,
             vring_worker: None,
             epoll_file,
-            thread_backend: VsockThreadBackend::new(uds_path, epoll_fd, tx_buffer_size, cid_map),
+            thread_backend: VsockThreadBackend::new(
+                uds_path,
+                epoll_fd,
+                guest_cid,
+                tx_buffer_size,
+                cid_map,
+            ),
             guest_cid,
             pool: ThreadPoolBuilder::new()
                 .pool_size(1)


### PR DESCRIPTION
Adds support for communication between sibling VMs that use the vhost-user-vsock devices from the same vhost-user-vsock application.