### PR TITLE
Symlink license files into crate folders

### DIFF
--- a/crates/gpio/LICENSE-APACHE
+++ b/crates/gpio/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/gpio/LICENSE-BSD-3-Clause
+++ b/crates/gpio/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/i2c/LICENSE-APACHE
+++ b/crates/i2c/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/i2c/LICENSE-BSD-3-Clause
+++ b/crates/i2c/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/rng/LICENSE-APACHE
+++ b/crates/rng/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/rng/LICENSE-BSD-3-Clause
+++ b/crates/rng/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/scsi/LICENSE-APACHE
+++ b/crates/scsi/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/scsi/LICENSE-BSD-3-Clause
+++ b/crates/scsi/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/vsock/LICENSE-APACHE
+++ b/crates/vsock/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/vsock/LICENSE-BSD-3-Clause
+++ b/crates/vsock/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause


### PR DESCRIPTION
Once we publish crates to crates.io, only the crate subfolder is uploaded. Symlink the license files in in order to include them during packaging.

`cargo package` will replace the symlinks with the actual files during packaging, so crates.io will include the license file.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
