### PR TITLE
Add `vhost-user-sound` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8512c9117059663fb5606788fbca3619e2a91dac0e3fe516242eab1fa6be5e44"
+dependencies = [
+ "alsa-sys",
+ "bitflags 1.3.2",
+ "libc",
+ "nix 0.24.3",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +795,17 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
@@ -945,7 +978,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
+ "nix 0.26.2",
  "once_cell",
  "pipewire-sys",
  "thiserror",
@@ -1617,6 +1650,7 @@ dependencies = [
 name = "vhost-user-sound"
 version = "0.1.0"
 dependencies = [
+ "alsa",
  "bindgen 0.64.0",
  "clap",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,13 +85,13 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -105,6 +111,28 @@ name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags 1.3.2",
  "cexpr",
@@ -165,6 +193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "215c0072ecc28f92eeb0eea38ba63ddfcb65c2828c46311d646f1a3ff5f9841c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -194,13 +232,12 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -214,7 +251,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -244,9 +281,15 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "cpufeatures"
@@ -429,7 +472,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -521,9 +564,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -569,21 +612,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.2",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aa48fab2893d8a49caa94082ae8488f4e1050d73b367881dcd2198f4199fd8"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "json5"
@@ -633,8 +675,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa282e1da652deaeed776f6ef36d443689aeda19e5c0a3a2335c50b4611ce489"
 dependencies = [
- "bindgen",
- "system-deps",
+ "bindgen 0.63.0",
+ "system-deps 2.0.3",
 ]
 
 [[package]]
@@ -648,6 +690,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667dfbb50c3d1f7ee1d33afdc04d1255923ece7642db3303046e7d63d997d77d"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cookie-factory",
+ "errno 0.3.1",
+ "libc",
+ "libspa-sys",
+ "nom",
+ "system-deps 6.1.1",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5b88f52534df7ca88d451ae9628e22124e3cc5c60966465a7db479534c7a"
+dependencies = [
+ "bindgen 0.64.0",
+ "cc",
+ "system-deps 6.1.1",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +727,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -682,10 +757,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+ "static_assertions",
+]
 
 [[package]]
 name = "nom"
@@ -809,7 +907,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -825,15 +923,44 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipewire"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc2180a4a84b855be86e6cd72fa6fd4318278871d2b1082e7cd05fe64b135ccb"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "errno 0.3.1",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a95290eedb7fb6aa3922fdc0261cd0ddeb940abcdbdef28778928106554d2123"
+dependencies = [
+ "bindgen 0.64.0",
+ "libspa-sys",
+ "system-deps 6.1.1",
+]
 
 [[package]]
 name = "pkg-config"
@@ -859,18 +986,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -968,15 +1095,28 @@ dependencies = [
  "errno 0.3.1",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno 0.3.1",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "scopeguard"
@@ -986,32 +1126,41 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
  "serde",
 ]
 
@@ -1030,6 +1179,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive 1.0.0",
+]
+
+[[package]]
+name = "serial_test"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
@@ -1039,7 +1202,18 @@ dependencies = [
  "lazy_static",
  "log",
  "parking_lot",
- "serial_test_derive",
+ "serial_test_derive 2.0.0",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1050,7 +1224,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1084,6 +1258,12 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1122,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,9 +1322,28 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
- "toml",
- "version-compare",
+ "toml 0.5.11",
+ "version-compare 0.0.11",
 ]
+
+[[package]]
+name = "system-deps"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c2de8a4d8f4b823d634affc9cd2a74ec98c53a756f317e529a48046cbf71f3"
+dependencies = [
+ "cfg-expr",
+ "heck 0.4.1",
+ "pkg-config",
+ "toml 0.7.5",
+ "version-compare 0.1.1",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1c7f239eb94671427157bd93b3694320f3668d4e1eff08c7285366fd777fac"
 
 [[package]]
 name = "tempfile"
@@ -1156,7 +1355,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.37.22",
  "windows-sys",
 ]
 
@@ -1186,7 +1385,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1199,10 +1398,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1211,6 +1425,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -1229,9 +1445,9 @@ checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1258,10 +1474,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c18c859eead79d8b95d09e4678566e8d70105c4e7b251f707a03df32442661b"
 
 [[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vhost"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b791c5b0717a0558888a4cf7240cea836f39a99cb342e12ce633dcaa078072"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "vm-memory 0.10.0",
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "vhost"
@@ -1271,7 +1505,7 @@ checksum = "84f81f436bca4541f4d33172e1202882c9d437db34ed17fc6d84c8ff2bde21f5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "vm-memory",
+ "vm-memory 0.11.0",
  "vmm-sys-util",
 ]
 
@@ -1285,11 +1519,11 @@ dependencies = [
  "libgpiod",
  "log",
  "thiserror",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.7.0",
+ "vhost-user-backend 0.9.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
+ "vm-memory 0.11.0",
  "vmm-sys-util",
 ]
 
@@ -1302,11 +1536,11 @@ dependencies = [
  "libc",
  "log",
  "thiserror",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.7.0",
+ "vhost-user-backend 0.9.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
+ "vm-memory 0.11.0",
  "vmm-sys-util",
 ]
 
@@ -1322,11 +1556,11 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.7.0",
+ "vhost-user-backend 0.9.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
+ "vm-memory 0.11.0",
  "vmm-sys-util",
 ]
 
@@ -1341,11 +1575,26 @@ dependencies = [
  "num_enum",
  "tempfile",
  "thiserror",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.7.0",
+ "vhost-user-backend 0.9.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
+ "vm-memory 0.11.0",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-user-backend"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f237b91db4ac339d639fb43398b52d785fa51e3c7760ac9425148863c1f4303"
+dependencies = [
+ "libc",
+ "log",
+ "vhost 0.6.0",
+ "virtio-bindings 0.1.0",
+ "virtio-queue 0.7.1",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -1357,10 +1606,31 @@ checksum = "a5d3b7affe04f61d19b03c5db823287855789b687218fec139699a0c7f7f2790"
 dependencies = [
  "libc",
  "log",
- "vhost",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "vhost 0.7.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
+ "vm-memory 0.11.0",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-user-sound"
+version = "0.1.0"
+dependencies = [
+ "bindgen 0.64.0",
+ "clap",
+ "env_logger",
+ "libspa",
+ "libspa-sys",
+ "log",
+ "pipewire",
+ "pipewire-sys",
+ "serial_test 1.0.0",
+ "thiserror",
+ "vhost 0.6.0",
+ "vhost-user-backend 0.8.0",
+ "virtio-bindings 0.2.1",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -1377,16 +1647,22 @@ dependencies = [
  "log",
  "serde",
  "serde_yaml",
- "serial_test",
+ "serial_test 2.0.0",
  "thiserror",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
+ "vhost 0.7.0",
+ "vhost-user-backend 0.9.0",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.8.0",
  "virtio-vsock",
- "vm-memory",
+ "vm-memory 0.11.0",
  "vmm-sys-util",
 ]
+
+[[package]]
+name = "virtio-bindings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-bindings"
@@ -1396,25 +1672,60 @@ checksum = "c18d7b74098a946470ea265b5bacbbf877abc3373021388454de0d47735a5b98"
 
 [[package]]
 name = "virtio-queue"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
+dependencies = [
+ "log",
+ "virtio-bindings 0.1.0",
+ "vm-memory 0.10.0",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "virtio-queue"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91aebb1df33db33cbf04d4c2445e4f78d0b0c8e65acfd16a4ee95ef63ca252f8"
 dependencies = [
  "log",
- "virtio-bindings",
- "vm-memory",
+ "virtio-bindings 0.2.1",
+ "vm-memory 0.11.0",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "virtio-queue"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35aca00da06841bd99162c381ec65893cace23ca0fb89254302cfe4bec4c300f"
+dependencies = [
+ "log",
+ "virtio-bindings 0.2.1",
+ "vm-memory 0.12.0",
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "virtio-vsock"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb198c4dd87bf0b4f6b5d8cb41284fca13763a5a1a7e5b8a7ccce45e46d4cf73"
+checksum = "c92d1d0c0db339e03dc275e86e5de2654ed94b351f02d405a3a0260dfc1b839f"
 dependencies = [
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.1",
+ "virtio-queue 0.9.0",
+ "vm-memory 0.12.0",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+dependencies = [
+ "arc-swap",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1425,6 +1736,17 @@ checksum = "9d6ea57fe00f9086c59eeeb68e102dd611686bc3c28520fa465996d4d4bdce07"
 dependencies = [
  "arc-swap",
  "libc",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77c7a0891cbac53618f5f6eec650ed1dc4f7e506bbe14877aff49d94b8408b0"
+dependencies = [
+ "libc",
+ "thiserror",
  "winapi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,6 +1630,7 @@ dependencies = [
  "vhost 0.6.0",
  "vhost-user-backend 0.8.0",
  "virtio-bindings 0.2.1",
+ "virtio-queue 0.7.1",
  "vm-memory 0.10.0",
  "vmm-sys-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "crates/i2c",
     "crates/rng",
     "crates/scsi",
+    "crates/sound",
     "crates/vsock",
 ]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Here is the list of device backends that we support:
 - [GPIO](https://github.com/rust-vmm/vhost-device/blob/main/crates/gpio/README.md)
 - [I2C](https://github.com/rust-vmm/vhost-device/blob/main/crates/i2c/README.md)
 - [RNG](https://github.com/rust-vmm/vhost-device/blob/main/crates/rng/README.md)
+- [Sound](https://github.com/rust-vmm/vhost-device/blob/main/crates/sound/README.md)
 - [VSOCK](https://github.com/rust-vmm/vhost-device/blob/main/crates/vsock/README.md)
 
 ## Testing and Code Coverage

--- a/crates/sound/CHANGELOG.md
+++ b/crates/sound/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Upcoming Release
+
+- First initial daemon implementation.

--- a/crates/sound/Cargo.toml
+++ b/crates/sound/Cargo.toml
@@ -10,11 +10,13 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [features]
-default = ["null-backend"]
+default = ["null-backend", "alsa-backend", "pw-backend"]
 null-backend = []
+alsa-backend = ["dep:alsa"]
 pw-backend = ["pipewire", "libspa", "pipewire-sys", "libspa-sys", "bindgen"]
 
 [dependencies]
+alsa = { version = "0.7", optional = true }
 bindgen = { version = "0.64.0", optional = true }
 clap = { version = "4.1", features = ["derive"] }
 env_logger = "0.10"

--- a/crates/sound/Cargo.toml
+++ b/crates/sound/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "vhost-user-sound"
+version = "0.1.0"
+authors = ["Manos Pitsidianakis <manos.pitsidianakis@linaro.org>"]
+description = "A virtio-sound device using the vhost-user protocol."
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["vhost", "sound", "virtio-sound", "virtio-snd", "vhost-user", "virtio"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2018"
+
+[features]
+default = ["null-backend"]
+null-backend = []
+pw-backend = ["pipewire", "libspa", "pipewire-sys", "libspa-sys", "bindgen"]
+
+[dependencies]
+bindgen = { version = "0.64.0", optional = true }
+clap = { version = "4.1", features = ["derive"] }
+env_logger = "0.10"
+libspa = { version = "0.6.0", optional = true }
+libspa-sys = { version = "0.6.0", optional = true }
+log = "0.4"
+pipewire = { version = "0.6.0", optional = true }
+pipewire-sys = { version = "0.6.0", optional = true }
+thiserror = "1.0"
+vhost = { version = "0.6", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.8"
+virtio-bindings = "0.2"
+vm-memory = "0.10"
+vmm-sys-util = "0.11"
+
+[dev-dependencies]
+serial_test = "1.0"

--- a/crates/sound/Cargo.toml
+++ b/crates/sound/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 vhost = { version = "0.6", features = ["vhost-user-slave"] }
 vhost-user-backend = "0.8"
 virtio-bindings = "0.2"
+virtio-queue = "0.7"
 vm-memory = "0.10"
 vmm-sys-util = "0.11"
 

--- a/crates/sound/LICENSE-APACHE
+++ b/crates/sound/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/sound/LICENSE-BSD-3-Clause
+++ b/crates/sound/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/sound/README.md
+++ b/crates/sound/README.md
@@ -1,0 +1,48 @@
+# vhost-user-sound
+
+<!--
+generated with help2man target/debug/vhost-user-sound |mandoc
+-->
+## Synopsis
+       vhost-user-sound --socket <SOCKET> --backend <BACKEND>
+
+## Description
+       A virtio-sound device using the vhost-user protocol.
+
+## Options
+
+```text
+     --socket <SOCKET>
+            vhost-user Unix domain socket path
+
+     --backend <BACKEND>
+            audio backend to be used (supported: null)
+
+     -h, --help
+            Print help
+
+     -V, --version
+            Print version
+```
+
+## Examples
+
+Launch the backend on the host machine:
+
+```shell
+host# vhost-user-sound --socket /tmp/snd.sock --backend null
+```
+
+With QEMU, you can add a `virtio` device that uses the backend's socket with the following flags:
+
+```text
+-chardev socket,id=vsnd,path=/tmp/snd.sock \
+-device vhost-user-snd-pci,chardev=vsnd,id=snd
+```
+
+## License
+
+This project is licensed under either of
+
+- [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0
+- [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)

--- a/crates/sound/rustfmt.toml
+++ b/crates/sound/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2018"
+format_generated_files = false
+format_code_in_doc_comments = true
+format_strings = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+wrap_comments = true

--- a/crates/sound/src/audio_backends.rs
+++ b/crates/sound/src/audio_backends.rs
@@ -1,0 +1,30 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+#[cfg(feature = "null-backend")]
+mod null;
+
+#[cfg(feature = "pw-backend")]
+mod pipewire;
+
+#[cfg(feature = "null-backend")]
+use self::null::NullBackend;
+#[cfg(feature = "pw-backend")]
+use self::pipewire::PwBackend;
+use crate::{Error, Result, SoundRequest};
+
+pub trait AudioBackend {
+    fn write(&self, req: &SoundRequest) -> Result<()>;
+
+    fn read(&self, req: &mut SoundRequest) -> Result<()>;
+}
+
+pub fn alloc_audio_backend(name: String) -> Result<Box<dyn AudioBackend + Send + Sync>> {
+    match name.as_str() {
+        #[cfg(feature = "null-backend")]
+        "null" => Ok(Box::new(NullBackend::new())),
+        #[cfg(feature = "pw-backend")]
+        "pipewire" => Ok(Box::new(PwBackend::new())),
+        _ => Err(Error::AudioBackendNotSupported),
+    }
+}

--- a/crates/sound/src/audio_backends.rs
+++ b/crates/sound/src/audio_backends.rs
@@ -1,6 +1,8 @@
 // Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
+#[cfg(feature = "alsa-backend")]
+mod alsa;
 #[cfg(feature = "null-backend")]
 mod null;
 
@@ -9,6 +11,8 @@ mod pipewire;
 
 use std::sync::{Arc, RwLock};
 
+#[cfg(feature = "alsa-backend")]
+use self::alsa::AlsaBackend;
 #[cfg(feature = "null-backend")]
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
@@ -51,6 +55,8 @@ pub fn alloc_audio_backend(
         "null" => Ok(Box::new(NullBackend::new(streams))),
         #[cfg(feature = "pw-backend")]
         "pipewire" => Ok(Box::new(PwBackend::new(streams))),
+        #[cfg(feature = "alsa-backend")]
+        "alsa" => Ok(Box::new(AlsaBackend::new(streams))),
         _ => Err(Error::AudioBackendNotSupported),
     }
 }

--- a/crates/sound/src/audio_backends.rs
+++ b/crates/sound/src/audio_backends.rs
@@ -7,25 +7,50 @@ mod null;
 #[cfg(feature = "pw-backend")]
 mod pipewire;
 
+use std::sync::{Arc, RwLock};
+
 #[cfg(feature = "null-backend")]
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{Error, Result, SoundRequest};
+use crate::{device::ControlMessage, stream::Stream, Error, Result};
 
 pub trait AudioBackend {
-    fn write(&self, req: &SoundRequest) -> Result<()>;
+    fn write(&self, stream_id: u32) -> Result<()>;
 
-    fn read(&self, req: &mut SoundRequest) -> Result<()>;
+    fn read(&self, stream_id: u32) -> Result<()>;
+
+    fn set_parameters(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+        Ok(())
+    }
+
+    fn prepare(&self, _stream_id: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn release(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+        Ok(())
+    }
+
+    fn start(&self, _stream_id: u32) -> Result<()> {
+        Ok(())
+    }
+
+    fn stop(&self, _stream_id: u32) -> Result<()> {
+        Ok(())
+    }
 }
 
-pub fn alloc_audio_backend(name: String) -> Result<Box<dyn AudioBackend + Send + Sync>> {
+pub fn alloc_audio_backend(
+    name: String,
+    streams: Arc<RwLock<Vec<Stream>>>,
+) -> Result<Box<dyn AudioBackend + Send + Sync>> {
     log::trace!("allocating audio backend {}", name);
     match name.as_str() {
         #[cfg(feature = "null-backend")]
-        "null" => Ok(Box::new(NullBackend::new())),
+        "null" => Ok(Box::new(NullBackend::new(streams))),
         #[cfg(feature = "pw-backend")]
-        "pipewire" => Ok(Box::new(PwBackend::new())),
+        "pipewire" => Ok(Box::new(PwBackend::new(streams))),
         _ => Err(Error::AudioBackendNotSupported),
     }
 }

--- a/crates/sound/src/audio_backends.rs
+++ b/crates/sound/src/audio_backends.rs
@@ -20,6 +20,7 @@ pub trait AudioBackend {
 }
 
 pub fn alloc_audio_backend(name: String) -> Result<Box<dyn AudioBackend + Send + Sync>> {
+    log::trace!("allocating audio backend {}", name);
     match name.as_str() {
         #[cfg(feature = "null-backend")]
         "null" => Ok(Box::new(NullBackend::new())),

--- a/crates/sound/src/audio_backends/alsa.rs
+++ b/crates/sound/src/audio_backends/alsa.rs
@@ -1,0 +1,555 @@
+/// Alsa backend
+//
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::mpsc::{channel, Receiver, Sender},
+    sync::{Arc, Mutex, RwLock},
+    thread,
+    thread::sleep,
+    time::Duration,
+};
+
+use alsa::{
+    pcm::{Access, Format, HwParams, State, PCM},
+    Direction, PollDescriptors, ValueOr,
+};
+use virtio_queue::Descriptor;
+use vm_memory::Bytes;
+
+use super::AudioBackend;
+use crate::{
+    device::ControlMessage,
+    stream::Stream,
+    virtio_sound::{
+        VirtioSndPcmSetParams, VIRTIO_SND_D_INPUT, VIRTIO_SND_D_OUTPUT, VIRTIO_SND_S_BAD_MSG,
+        VIRTIO_SND_S_NOT_SUPP,
+    },
+    Result as CrateResult,
+};
+
+type AResult<T> = std::result::Result<T, alsa::Error>;
+
+#[derive(Clone, Debug)]
+pub struct AlsaBackend {
+    sender: Arc<Mutex<Sender<AlsaAction>>>,
+}
+
+#[derive(Debug)]
+enum AlsaAction {
+    SetParameters(usize, ControlMessage),
+    Prepare(usize),
+    Release(usize, ControlMessage),
+    Start(usize),
+    Stop(usize),
+    Write(usize),
+    Read(usize),
+}
+
+fn update_pcm(
+    pcm_: &Arc<Mutex<PCM>>,
+    stream_id: usize,
+    streams: &RwLock<Vec<Stream>>,
+) -> AResult<()> {
+    *pcm_.lock().unwrap() = {
+        let streams = streams.read().unwrap();
+        let s = &streams[stream_id];
+        let pcm = PCM::new(
+            "default",
+            match s.direction {
+                d if d == VIRTIO_SND_D_OUTPUT => Direction::Playback,
+                d if d == VIRTIO_SND_D_INPUT => Direction::Capture,
+                other => panic!("Invalid virtio-sound stream: {}", other),
+            },
+            false,
+        )?;
+
+        {
+            let hwp = HwParams::any(&pcm)?;
+            hwp.set_channels(s.params.channels.into())?;
+            hwp.set_rate(
+                match s.params.rate {
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_5512 => 5512,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_8000 => 8000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_11025 => 11025,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_16000 => 16000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_22050 => 22050,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_32000 => 32000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_44100 => 44100,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_48000 => 48000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_64000 => 64000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_88200 => 88200,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_96000 => 96000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_176400 => 176400,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_192000 => 192000,
+                    crate::virtio_sound::VIRTIO_SND_PCM_RATE_384000 => 384000,
+                    _ => 44100,
+                },
+                ValueOr::Nearest,
+            )?;
+            hwp.set_format(match s.params.format {
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_IMA_ADPCM => Format::ImaAdPCM,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_MU_LAW => Format::MuLaw,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_A_LAW => Format::ALaw,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S8 => Format::S8,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U8 => Format::U8,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S16 => Format::s16(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U16 => Format::r#u16(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S18_3 => Format::S183LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U18_3 => Format::U183LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S20_3 => Format::S203LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U20_3 => Format::U203LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S24_3 => Format::S24LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U24_3 => Format::U24LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S20 => Format::s20_3(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U20 => Format::u20_3(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S24 => Format::s24(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U24 => Format::u24(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_S32 => Format::s32(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_U32 => Format::r#u32(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT => Format::float(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT64 => Format::float64(),
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U8 => Format::DSDU8,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U16 => Format::DSDU16LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U32 => Format::DSDU32LE,
+                crate::virtio_sound::VIRTIO_SND_PCM_FMT_IEC958_SUBFRAME => {
+                    Format::iec958_subframe()
+                }
+                _ => Format::Unknown,
+            })?;
+
+            hwp.set_access(Access::RWInterleaved)?;
+
+            // > A period is the number of frames in between each hardware interrupt.
+            // - https://www.alsa-project.org/wiki/FramesPeriods
+
+            // FIXME
+            if let Err(err) = hwp.set_buffer_size(4096) {
+                log::error!("Could not set buffer size of 4096 bytes: {}.", err,);
+            }
+            pcm.hw_params(&hwp)?;
+        }
+
+        // FIXME
+        //if let Err(err) = hwp.set_period_size(_, ValueOr::Greater) {
+        //        log::error!(
+        //            "Could not set period size: {}",
+        //            err,
+        //        );
+        //    }
+        //}
+
+        /*
+        //  {
+        // Make sure we don't start the stream too early
+        let hwp = pcm.hw_params_current()?;
+        let swp = pcm.sw_params_current()?;
+        //swp.set_start_threshold(hwp.get_buffer_size()?)?;
+        //swp.set_stop_threshold(hwp.get_buffer_size()?)?;
+        pcm.sw_params(&swp)?;
+        }
+        */
+        pcm
+    };
+    Ok(())
+}
+
+fn write_samples_direct(
+    pcm: &alsa::PCM,
+    stream: &mut Stream,
+    mmap: &mut alsa::direct::pcm::MmapPlayback<u8>,
+) -> AResult<bool> {
+    while mmap.avail() > 0 {
+        // Write samples to DMA area from iterator
+        //
+        let Some(buffer) = stream.buffers.front_mut() else {
+            return Ok(false);
+        };
+        let mut iter = buffer.bytes[buffer.pos..].iter().cloned();
+        let frames = mmap.write(&mut iter);
+        let written_bytes = pcm.frames_to_bytes(frames);
+        if let Ok(written_bytes) = usize::try_from(written_bytes) {
+            buffer.pos += written_bytes;
+        }
+        if buffer.pos >= buffer.bytes.len() {
+            stream.buffers.pop_front();
+        }
+    }
+    match mmap.status().state() {
+        State::Running => {
+            return Ok(false);
+        } // All fine
+        State::Prepared => {
+            //log::trace!("Starting audio output stream");
+            //p.start()?
+        }
+        State::XRun => {
+            log::trace!("Underrun in audio output stream!");
+            pcm.prepare()?
+        }
+        State::Suspended => {
+            //log::trace!("Resuming audio output stream");
+            //p.resume()?
+        }
+        n => panic!("Unexpected pcm state {:?}", n),
+    }
+    Ok(true) // Call us again, please, there might be more data to write
+}
+
+fn write_samples_io(
+    p: &alsa::PCM,
+
+    stream: &mut Stream,
+    io: &mut alsa::pcm::IO<u8>,
+) -> AResult<bool> {
+    macro_rules! avail {
+        () => {{
+            (match p.avail_update() {
+                Ok(n) => n,
+                Err(err) => {
+                    log::trace!("Recovering from {}", err);
+                    p.recover(err.errno() as std::os::raw::c_int, true)?;
+                    p.avail_update()?
+                }
+            }) as usize
+        }};
+    }
+
+    loop {
+        let avail = avail!();
+        if avail == 0 {
+            break;
+        }
+        let written = io.mmap(avail, |buf| {
+            let Some(buffer) = stream.buffers.front_mut() else {
+                return 0;
+            };
+            let mut iter = buffer.bytes[buffer.pos..].iter().cloned();
+
+            let mut written_bytes = 0;
+            for (sample, byte) in buf.iter_mut().zip(&mut iter) {
+                *sample = byte;
+                written_bytes += 1;
+            }
+            buffer.pos += written_bytes as usize;
+            if buffer.pos >= buffer.bytes.len() {
+                stream.buffers.pop_front();
+            }
+            p.bytes_to_frames(written_bytes)
+                .try_into()
+                .unwrap_or_default()
+        })?;
+        if written == 0 {
+            break;
+        };
+    }
+
+    match p.state() {
+        State::Suspended | State::Running => Ok(false), // All fine
+        State::Prepared => {
+            //p.start()?;
+            Ok(false)
+        }
+        State::XRun => Ok(true), // Recover from this in next round
+        n => panic!("Unexpected pcm state {:?}", n),
+    }
+}
+
+fn alsa_worker(
+    pcm: Arc<Mutex<PCM>>,
+    streams: Arc<RwLock<Vec<Stream>>>,
+    receiver: &Receiver<bool>,
+    stream_id: usize,
+) -> AResult<()> {
+    loop {
+        let Ok(do_write) = receiver.recv() else {
+            return Ok(());
+        };
+        if do_write {
+            loop {
+                if matches!(receiver.try_recv(), Ok(false)) {
+                    break;
+                }
+
+                let mut fds = {
+                    let lck = pcm.lock().unwrap();
+                    if matches!(lck.state(), State::Running | State::Prepared | State::XRun) {
+                        let mut mmap = lck.direct_mmap_playback::<u8>().ok();
+
+                        if let Some(ref mut mmap) = mmap {
+                            if write_samples_direct(
+                                &lck,
+                                &mut streams.write().unwrap()[stream_id],
+                                mmap,
+                            )? {
+                                continue;
+                            }
+                        } else {
+                            let mut io = lck.io_bytes();
+                            // Direct mode unavailable, use alsa-lib's mmap emulation instead
+                            if write_samples_io(
+                                &lck,
+                                &mut streams.write().unwrap()[stream_id],
+                                &mut io,
+                            )? {
+                                continue;
+                            }
+                        }
+                        lck.get()?
+                    } else {
+                        drop(lck);
+                        sleep(Duration::from_millis(500));
+                        continue;
+                    }
+                };
+                // Nothing to do, let's sleep until woken up by the kernel.
+                alsa::poll::poll(&mut fds, 100)?;
+            }
+        }
+    }
+}
+
+impl AlsaBackend {
+    pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
+        let (sender, receiver) = channel();
+        let sender = Arc::new(Mutex::new(sender));
+
+        thread::spawn(move || {
+            if let Err(err) = Self::run(streams, receiver) {
+                log::error!("Main thread exited with error: {}", err);
+            }
+        });
+
+        Self { sender }
+    }
+
+    fn run(
+        streams: Arc<RwLock<Vec<Stream>>>,
+        receiver: Receiver<AlsaAction>,
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let streams_no: usize;
+
+        let (mut pcms, senders) = {
+            let lck = streams.read().unwrap();
+            streams_no = lck.len();
+            let mut vec = Vec::with_capacity(streams_no);
+            let mut senders = Vec::with_capacity(streams_no);
+            for i in 0..streams_no {
+                let (sender, receiver) = channel();
+                let pcm = Arc::new(Mutex::new(PCM::new("default", Direction::Playback, false)?));
+
+                let mtx = Arc::clone(&pcm);
+                let streams = Arc::clone(&streams);
+                thread::spawn(move || {
+                    // TODO: exponential backoff? send fatal error to daemon?
+                    while let Err(err) = alsa_worker(mtx.clone(), streams.clone(), &receiver, i) {
+                        log::error!(
+                            "Worker thread exited with error: {}, sleeping for 500ms",
+                            err
+                        );
+                        sleep(Duration::from_millis(500));
+                    }
+                });
+
+                senders.push(sender);
+                vec.push(pcm);
+            }
+            (vec, senders)
+        };
+        for (i, pcm) in pcms.iter_mut().enumerate() {
+            update_pcm(pcm, i, &streams)?;
+        }
+
+        while let Ok(action) = receiver.recv() {
+            match action {
+                AlsaAction::Read(_) => {}
+                AlsaAction::Write(stream_id) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received Write action for stream id {} but there are only {} PCM \
+                             streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        continue;
+                    };
+                    if matches!(
+                        streams.write().unwrap()[stream_id].state,
+                        crate::stream::PCMState::Start | crate::stream::PCMState::Prepare
+                    ) {
+                        senders[stream_id].send(true).unwrap();
+                    }
+                }
+                AlsaAction::Start(stream_id) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received Start action for stream id {} but there are only {} PCM \
+                             streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        continue;
+                    };
+
+                    let start_result = streams.write().unwrap()[stream_id].state.start();
+                    if let Err(err) = start_result {
+                        log::error!("Stream {} start {}", stream_id, err);
+                    } else {
+                        let pcm = &pcms[stream_id];
+                        let lck = pcm.lock().unwrap();
+                        match lck.state() {
+                            State::Running => {}
+                            _ => lck.start()?,
+                        }
+                    }
+                }
+                AlsaAction::Stop(stream_id) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received Stop action for stream id {} but there are only {} PCM \
+                             streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        continue;
+                    };
+                    let stop_result = streams.write().unwrap()[stream_id].state.stop();
+                    if let Err(err) = stop_result {
+                        log::error!("Stream {} stop {}", stream_id, err);
+                    }
+                }
+                AlsaAction::Prepare(stream_id) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received Prepare action for stream id {} but there are only {} PCM \
+                             streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        continue;
+                    };
+                    let prepare_result = streams.write().unwrap()[stream_id].state.prepare();
+                    if let Err(err) = prepare_result {
+                        log::error!("Stream {} prepare {}", stream_id, err);
+                    } else {
+                        let pcm = &pcms[stream_id];
+                        let lck = pcm.lock().unwrap();
+                        match lck.state() {
+                            State::Running => {}
+                            _ => lck.prepare()?,
+                        }
+                    }
+                }
+                AlsaAction::Release(stream_id, mut msg) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received Release action for stream id {} but there are only {} PCM \
+                             streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        msg.code = VIRTIO_SND_S_BAD_MSG;
+                        continue;
+                    };
+                    let release_result = streams.write().unwrap()[stream_id].state.release();
+                    if let Err(err) = release_result {
+                        log::error!("Stream {} release {}", stream_id, err);
+                        msg.code = VIRTIO_SND_S_BAD_MSG;
+                    } else {
+                        senders[stream_id].send(false).unwrap();
+                        let mut streams = streams.write().unwrap();
+                        std::mem::take(&mut streams[stream_id].buffers);
+                    }
+                }
+                AlsaAction::SetParameters(stream_id, mut msg) => {
+                    if stream_id >= streams_no {
+                        log::error!(
+                            "Received SetParameters action for stream id {} but there are only {} \
+                             PCM streams.",
+                            stream_id,
+                            pcms.len()
+                        );
+                        msg.code = VIRTIO_SND_S_BAD_MSG;
+                        continue;
+                    };
+                    let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
+                    let desc_request = &descriptors[0];
+                    let request = msg
+                        .desc_chain
+                        .memory()
+                        .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
+                        .unwrap();
+                    {
+                        let mut streams = streams.write().unwrap();
+                        let st = &mut streams[stream_id];
+                        if let Err(err) = st.state.set_parameters() {
+                            log::error!("Stream {} set_parameters {}", stream_id, err);
+                            msg.code = VIRTIO_SND_S_BAD_MSG;
+                            continue;
+                        } else if !st.supports_format(request.format)
+                            || !st.supports_rate(request.rate)
+                        {
+                            msg.code = VIRTIO_SND_S_NOT_SUPP;
+                            continue;
+                        } else {
+                            st.params.features = request.features;
+                            st.params.buffer_bytes = request.buffer_bytes;
+                            st.params.period_bytes = request.period_bytes;
+                            st.params.channels = request.channels;
+                            st.params.format = request.format;
+                            st.params.rate = request.rate;
+                            st.params.period_bytes = request.period_bytes;
+                            st.params.buffer_bytes = request.buffer_bytes;
+                        }
+                    }
+                    drop(msg);
+                    update_pcm(&pcms[stream_id], stream_id, &streams)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+macro_rules! send_action {
+    ($($fn_name:ident $action:tt),+$(,)?) => {
+        $(
+            fn $fn_name(&self, id: u32) -> CrateResult<()> {
+                self.sender
+                    .lock()
+                    .unwrap()
+                    .send(AlsaAction::$action(id as usize))
+                    .unwrap();
+                Ok(())
+            }
+        )*
+    };
+    ($(ctrl $fn_name:ident $action:tt),+$(,)?) => {
+        $(
+            fn $fn_name(&self, id: u32, msg: ControlMessage) -> CrateResult<()> {
+                self.sender
+                    .lock()
+                    .unwrap()
+                    .send(AlsaAction::$action(id as usize, msg))
+                    .unwrap();
+                Ok(())
+            }
+        )*
+    }
+}
+
+impl AudioBackend for AlsaBackend {
+    send_action! {
+        write Write,
+        read Read,
+        prepare Prepare,
+        start Start,
+        stop Stop,
+    }
+    send_action! {
+        ctrl set_parameters SetParameters,
+        ctrl release Release,
+    }
+}

--- a/crates/sound/src/audio_backends/null.rs
+++ b/crates/sound/src/audio_backends/null.rs
@@ -1,29 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-use super::AudioBackend;
-use crate::{Error, Result, SoundRequest};
+use std::sync::{Arc, RwLock};
 
-pub struct NullBackend {}
+use super::AudioBackend;
+use crate::{Result, Stream};
+
+pub struct NullBackend {
+    streams: Arc<RwLock<Vec<Stream>>>,
+}
 
 impl NullBackend {
-    pub fn new() -> Self {
-        NullBackend {}
+    pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
+        Self { streams }
     }
 }
 
 impl AudioBackend for NullBackend {
-    fn write(&self, _req: &SoundRequest) -> Result<()> {
-        log::trace!("NullBackend writing {:?}", _req);
+    fn write(&self, stream_id: u32) -> Result<()> {
+        log::trace!("NullBackend write stream_id {}", stream_id);
         Ok(())
     }
 
-    fn read(&self, req: &mut SoundRequest) -> Result<()> {
-        log::trace!("NullBackend reading {:?}", req);
-        let buf = req.data_slice().ok_or(Error::SoundReqMissingData)?;
-        let zero_mem = vec![0u8; buf.len()];
-
-        buf.copy_from(&zero_mem);
-
+    fn read(&self, _id: u32) -> Result<()> {
+        log::trace!("NullBackend read stream_id {}", _id);
         Ok(())
     }
 }

--- a/crates/sound/src/audio_backends/null.rs
+++ b/crates/sound/src/audio_backends/null.rs
@@ -18,6 +18,7 @@ impl NullBackend {
 impl AudioBackend for NullBackend {
     fn write(&self, stream_id: u32) -> Result<()> {
         log::trace!("NullBackend write stream_id {}", stream_id);
+        _ = std::mem::take(&mut self.streams.write().unwrap()[stream_id as usize].buffers);
         Ok(())
     }
 

--- a/crates/sound/src/audio_backends/null.rs
+++ b/crates/sound/src/audio_backends/null.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use super::AudioBackend;
+use crate::{Error, Result, SoundRequest};
+
+pub struct NullBackend {}
+
+impl NullBackend {
+    pub fn new() -> Self {
+        NullBackend {}
+    }
+}
+
+impl AudioBackend for NullBackend {
+    fn write(&self, _req: &SoundRequest) -> Result<()> {
+        Ok(())
+    }
+
+    fn read(&self, req: &mut SoundRequest) -> Result<()> {
+        let buf = req.data_slice().ok_or(Error::SoundReqMissingData)?;
+        let zero_mem = vec![0u8; buf.len()];
+
+        buf.copy_from(&zero_mem);
+
+        Ok(())
+    }
+}

--- a/crates/sound/src/audio_backends/null.rs
+++ b/crates/sound/src/audio_backends/null.rs
@@ -13,10 +13,12 @@ impl NullBackend {
 
 impl AudioBackend for NullBackend {
     fn write(&self, _req: &SoundRequest) -> Result<()> {
+        log::trace!("NullBackend writing {:?}", _req);
         Ok(())
     }
 
     fn read(&self, req: &mut SoundRequest) -> Result<()> {
+        log::trace!("NullBackend reading {:?}", req);
         let buf = req.data_slice().ok_or(Error::SoundReqMissingData)?;
         let zero_mem = vec![0u8; buf.len()];
 

--- a/crates/sound/src/audio_backends/pipewire.rs
+++ b/crates/sound/src/audio_backends/pipewire.rs
@@ -19,6 +19,7 @@ impl PwBackend {
 impl AudioBackend for PwBackend {
     fn write(&self, stream_id: u32) -> Result<()> {
         log::trace!("PipewireBackend write stream_id {}", stream_id);
+        _ = std::mem::take(&mut self.streams.write().unwrap()[stream_id as usize].buffers);
         Ok(())
     }
 

--- a/crates/sound/src/audio_backends/pipewire.rs
+++ b/crates/sound/src/audio_backends/pipewire.rs
@@ -1,28 +1,29 @@
 // Pipewire backend device
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-use super::AudioBackend;
-use crate::{Error, Result, SoundRequest};
+use std::sync::{Arc, RwLock};
 
-pub struct PwBackend {}
+use super::AudioBackend;
+use crate::{Result, Stream};
+
+pub struct PwBackend {
+    streams: Arc<RwLock<Vec<Stream>>>,
+}
 
 impl PwBackend {
-    pub fn new() -> Self {
-        PwBackend {}
+    pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
+        Self { streams }
     }
 }
 
 impl AudioBackend for PwBackend {
-    fn write(&self, _req: &SoundRequest) -> Result<()> {
+    fn write(&self, stream_id: u32) -> Result<()> {
+        log::trace!("PipewireBackend write stream_id {}", stream_id);
         Ok(())
     }
 
-    fn read(&self, req: &mut SoundRequest) -> Result<()> {
-        let buf = req.data_slice().ok_or(Error::SoundReqMissingData)?;
-        let zero_mem = vec![0u8; buf.len()];
-
-        buf.copy_from(&zero_mem);
-
+    fn read(&self, _id: u32) -> Result<()> {
+        log::trace!("PipewireBackend read stream_id {}", _id);
         Ok(())
     }
 }

--- a/crates/sound/src/audio_backends/pipewire.rs
+++ b/crates/sound/src/audio_backends/pipewire.rs
@@ -1,0 +1,28 @@
+// Pipewire backend device
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use super::AudioBackend;
+use crate::{Error, Result, SoundRequest};
+
+pub struct PwBackend {}
+
+impl PwBackend {
+    pub fn new() -> Self {
+        PwBackend {}
+    }
+}
+
+impl AudioBackend for PwBackend {
+    fn write(&self, _req: &SoundRequest) -> Result<()> {
+        Ok(())
+    }
+
+    fn read(&self, req: &mut SoundRequest) -> Result<()> {
+        let buf = req.data_slice().ok_or(Error::SoundReqMissingData)?;
+        let zero_mem = vec![0u8; buf.len()];
+
+        buf.copy_from(&zero_mem);
+
+        Ok(())
+    }
+}

--- a/crates/sound/src/device.rs
+++ b/crates/sound/src/device.rs
@@ -1,0 +1,215 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// Stefano Garzarella <sgarzare@redhat.com>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{io::Result as IoResult, sync::RwLock, u16, u32, u64, u8};
+
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackend, VringRwLock};
+use virtio_bindings::bindings::{
+    virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
+    virtio_ring::{VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC},
+};
+use vm_memory::{ByteValued, GuestMemoryAtomic, GuestMemoryMmap};
+use vmm_sys_util::{
+    epoll::EventSet,
+    eventfd::{EventFd, EFD_NONBLOCK},
+};
+
+use crate::{
+    audio_backends::{alloc_audio_backend, AudioBackend},
+    virtio_sound::*,
+    Error, Result, SoundConfig,
+};
+
+struct VhostUserSoundThread {
+    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    event_idx: bool,
+    queue_indexes: Vec<u16>,
+}
+
+impl VhostUserSoundThread {
+    pub fn new(mut queue_indexes: Vec<u16>) -> Result<Self> {
+        queue_indexes.sort();
+
+        Ok(VhostUserSoundThread {
+            event_idx: false,
+            mem: None,
+            queue_indexes,
+        })
+    }
+
+    fn queues_per_thread(&self) -> u64 {
+        let mut queues_per_thread = 0u64;
+
+        for idx in self.queue_indexes.iter() {
+            queues_per_thread |= 1u64 << idx
+        }
+
+        queues_per_thread
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.event_idx = enabled;
+    }
+
+    fn update_memory(&mut self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(&self, device_event: u16, vrings: &[VringRwLock]) -> IoResult<bool> {
+        let vring = &vrings[device_event as usize];
+        let queue_idx = self.queue_indexes[device_event as usize];
+
+        match queue_idx {
+            CONTROL_QUEUE_IDX => self.process_control(vring),
+            EVENT_QUEUE_IDX => self.process_event(vring),
+            TX_QUEUE_IDX => self.process_tx(vring),
+            RX_QUEUE_IDX => self.process_rx(vring),
+            _ => Err(Error::HandleUnknownEvent.into()),
+        }
+    }
+
+    fn process_control(&self, _vring: &VringRwLock) -> IoResult<bool> {
+        Ok(false)
+    }
+
+    fn process_event(&self, _vring: &VringRwLock) -> IoResult<bool> {
+        Ok(false)
+    }
+
+    fn process_tx(&self, _vring: &VringRwLock) -> IoResult<bool> {
+        Ok(false)
+    }
+
+    fn process_rx(&self, _vring: &VringRwLock) -> IoResult<bool> {
+        Ok(false)
+    }
+}
+
+pub struct VhostUserSoundBackend {
+    threads: Vec<RwLock<VhostUserSoundThread>>,
+    virtio_cfg: VirtioSoundConfig,
+    exit_event: EventFd,
+    _audio_backend: RwLock<Box<dyn AudioBackend + Send + Sync>>,
+}
+
+impl VhostUserSoundBackend {
+    pub fn new(config: SoundConfig) -> Result<Self> {
+        let threads = if config.multi_thread {
+            vec![
+                RwLock::new(VhostUserSoundThread::new(vec![
+                    CONTROL_QUEUE_IDX,
+                    EVENT_QUEUE_IDX,
+                ])?),
+                RwLock::new(VhostUserSoundThread::new(vec![TX_QUEUE_IDX])?),
+                RwLock::new(VhostUserSoundThread::new(vec![RX_QUEUE_IDX])?),
+            ]
+        } else {
+            vec![RwLock::new(VhostUserSoundThread::new(vec![
+                CONTROL_QUEUE_IDX,
+                EVENT_QUEUE_IDX,
+                TX_QUEUE_IDX,
+                RX_QUEUE_IDX,
+            ])?)]
+        };
+
+        let audio_backend = alloc_audio_backend(config.audio_backend_name)?;
+
+        Ok(Self {
+            threads,
+            virtio_cfg: VirtioSoundConfig {
+                jacks: 0.into(),
+                streams: 1.into(),
+                chmaps: 0.into(),
+            },
+            exit_event: EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?,
+            _audio_backend: RwLock::new(audio_backend),
+        })
+    }
+
+    pub fn send_exit_event(&self) {
+        self.exit_event.write(1).unwrap();
+    }
+}
+
+impl VhostUserBackend<VringRwLock, ()> for VhostUserSoundBackend {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES as usize
+    }
+
+    fn max_queue_size(&self) -> usize {
+        256
+    }
+
+    fn features(&self) -> u64 {
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        VhostUserProtocolFeatures::CONFIG
+    }
+
+    fn set_event_idx(&self, enabled: bool) {
+        for thread in self.threads.iter() {
+            thread.write().unwrap().set_event_idx(enabled);
+        }
+    }
+
+    fn update_memory(&self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {
+        for thread in self.threads.iter() {
+            thread.write().unwrap().update_memory(mem.clone())?;
+        }
+
+        Ok(())
+    }
+
+    fn handle_event(
+        &self,
+        device_event: u16,
+        evset: EventSet,
+        vrings: &[VringRwLock],
+        thread_id: usize,
+    ) -> IoResult<bool> {
+        if evset != EventSet::IN {
+            return Err(Error::HandleEventNotEpollIn.into());
+        }
+
+        self.threads[thread_id]
+            .read()
+            .unwrap()
+            .handle_event(device_event, vrings)
+    }
+
+    fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
+        let offset = offset as usize;
+        let size = size as usize;
+
+        let buf = self.virtio_cfg.as_slice();
+
+        if offset + size > buf.len() {
+            return Vec::new();
+        }
+
+        buf[offset..offset + size].to_vec()
+    }
+
+    fn queues_per_thread(&self) -> Vec<u64> {
+        let mut vec = Vec::with_capacity(self.threads.len());
+
+        for thread in self.threads.iter() {
+            vec.push(thread.read().unwrap().queues_per_thread())
+        }
+
+        vec
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+        self.exit_event.try_clone().ok()
+    }
+}

--- a/crates/sound/src/device.rs
+++ b/crates/sound/src/device.rs
@@ -2,16 +2,22 @@
 // Stefano Garzarella <sgarzare@redhat.com>
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-use std::{io::Result as IoResult, sync::RwLock, u16, u32, u64, u8};
+use std::{
+    convert::TryFrom,
+    io::Result as IoResult,
+    sync::{Arc, RwLock},
+};
 
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost_user_backend::{VhostUserBackend, VringRwLock, VringT};
-use virtio_bindings::bindings::{
-    virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
+use virtio_bindings::{
+    bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
     virtio_ring::{VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC},
 };
-use virtio_queue::QueueOwnedT;
-use vm_memory::{ByteValued, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
+use virtio_queue::{DescriptorChain, QueueOwnedT};
+use vm_memory::{
+    ByteValued, Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
+};
 use vmm_sys_util::{
     epoll::EventSet,
     eventfd::{EventFd, EFD_NONBLOCK},
@@ -19,35 +25,35 @@ use vmm_sys_util::{
 
 use crate::{
     audio_backends::{alloc_audio_backend, AudioBackend},
+    stream::{Error as StreamError, Stream},
     virtio_sound::*,
-    Error, Result, SoundConfig,
+    ControlMessageKind, Error, Result, SoundConfig,
 };
 
 struct VhostUserSoundThread {
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     event_idx: bool,
     queue_indexes: Vec<u16>,
+    streams: Arc<RwLock<Vec<Stream>>>,
+    streams_no: usize,
 }
 
-#[cfg(debug_assertions)]
-const fn queue_idx_as_str(q: u16) -> &'static str {
-    match q {
-        CONTROL_QUEUE_IDX => stringify!(CONTROL_QUEUE_IDX),
-        EVENT_QUEUE_IDX => stringify!(EVENT_QUEUE_IDX),
-        TX_QUEUE_IDX => stringify!(TX_QUEUE_IDX),
-        RX_QUEUE_IDX => stringify!(RX_QUEUE_IDX),
-        _ => "unknown queue idx",
-    }
-}
+type SoundDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
 
 impl VhostUserSoundThread {
-    pub fn new(mut queue_indexes: Vec<u16>) -> Result<Self> {
+    pub fn new(
+        mut queue_indexes: Vec<u16>,
+        streams: Arc<RwLock<Vec<Stream>>>,
+        streams_no: usize,
+    ) -> Result<Self> {
         queue_indexes.sort();
 
         Ok(VhostUserSoundThread {
             event_idx: false,
             mem: None,
             queue_indexes,
+            streams,
+            streams_no,
         })
     }
 
@@ -70,36 +76,280 @@ impl VhostUserSoundThread {
         Ok(())
     }
 
-    fn handle_event(&self, device_event: u16, vrings: &[VringRwLock]) -> IoResult<bool> {
-        log::trace!("handle_event device_event {}", device_event);
-
+    fn handle_event(
+        &self,
+        device_event: u16,
+        vrings: &[VringRwLock],
+        audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
+    ) -> IoResult<bool> {
         let vring = &vrings[device_event as usize];
         let queue_idx = self.queue_indexes[device_event as usize];
-        log::trace!(
-            "handle_event queue_idx {} == {}",
-            queue_idx,
-            queue_idx_as_str(queue_idx)
-        );
-
-        dbg!(match queue_idx {
-            CONTROL_QUEUE_IDX => self.process_control(vring),
-            EVENT_QUEUE_IDX => self.process_event(vring),
-            TX_QUEUE_IDX => self.process_tx(vring),
-            RX_QUEUE_IDX => self.process_rx(vring),
-            _ => Err(Error::HandleUnknownEvent.into()),
-        })
+        if self.event_idx {
+            // vm-virtio's Queue implementation only checks avail_index
+            // once, so to properly support EVENT_IDX we need to keep
+            // calling process_request_queue() until it stops finding
+            // new requests on the queue.
+            loop {
+                vring.disable_notification().unwrap();
+                match queue_idx {
+                    CONTROL_QUEUE_IDX => self.process_control(vring, audio_backend),
+                    EVENT_QUEUE_IDX => self.process_event(vring),
+                    TX_QUEUE_IDX => self.process_tx(vring, audio_backend),
+                    RX_QUEUE_IDX => self.process_rx(vring, audio_backend),
+                    _ => Err(Error::HandleUnknownEvent.into()),
+                }?;
+                if !vring.enable_notification().unwrap() {
+                    break;
+                }
+            }
+        } else {
+            // Without EVENT_IDX, a single call is enough.
+            match queue_idx {
+                CONTROL_QUEUE_IDX => self.process_control(vring, audio_backend),
+                EVENT_QUEUE_IDX => self.process_event(vring),
+                TX_QUEUE_IDX => self.process_tx(vring, audio_backend),
+                RX_QUEUE_IDX => self.process_rx(vring, audio_backend),
+                _ => Err(Error::HandleUnknownEvent.into()),
+            }?;
+        }
+        Ok(false)
     }
 
-    fn process_control(&self, _vring: &VringRwLock) -> IoResult<bool> {
-        let requests: Vec<_> = _vring
+    fn process_control(
+        &self,
+        vring: &VringRwLock,
+        audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
+    ) -> IoResult<bool> {
+        let requests: Vec<SoundDescriptorChain> = vring
             .get_mut()
             .get_queue_mut()
             .iter(self.mem.as_ref().unwrap().memory())
             .map_err(|_| Error::DescriptorNotFound)?
             .collect();
-        dbg!(&requests);
 
-        Ok(true)
+        if requests.is_empty() {
+            return Ok(true);
+        }
+
+        // Reply to some requests right away, and defer others to the audio backend (for
+        // example PcmRelease needs to complete all I/O before replying.
+        //
+        // Mark `any` as true if we need to reply to any request right away so we can
+        // signal the queue as used.
+        let mut any = false;
+
+        for desc_chain in requests {
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+            // Request descriptor.
+            let desc_request = descriptors[0];
+            if desc_request.is_write_only() {
+                return Err(Error::UnexpectedWriteOnlyDescriptor(0).into());
+            }
+
+            let request = desc_chain
+                .memory()
+                .read_obj::<VirtioSoundHeader>(desc_request.addr())
+                .map_err(|_| Error::DescriptorReadFailed)?;
+
+            // Keep track of bytes that will be written in the VQ.
+            let mut len = 0;
+
+            // Reply header descriptor.
+            let desc_hdr = descriptors[1];
+            if !desc_hdr.is_write_only() {
+                return Err(Error::UnexpectedReadableDescriptor(1).into());
+            }
+            len += desc_hdr.len();
+
+            let mut resp = VirtioSoundHeader {
+                code: VIRTIO_SND_S_OK.into(),
+            };
+
+            let code = ControlMessageKind::try_from(request.code).map_err(Error::from)?;
+            match code {
+                ControlMessageKind::JackInfo => {
+                    resp.code = VIRTIO_SND_S_NOT_SUPP.into();
+                }
+                ControlMessageKind::JackRemap => {
+                    resp.code = VIRTIO_SND_S_NOT_SUPP.into();
+                }
+                ControlMessageKind::PcmInfo => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSoundQueryInfo>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+
+                    let start_id = u32::from(request.start_id) as usize;
+                    let count = u32::from(request.count) as usize;
+                    let streams = self.streams.read().unwrap();
+                    if streams.len() <= start_id || streams.len() <= start_id + count {
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let desc_response = descriptors[2];
+                        if !desc_response.is_write_only() {
+                            return Err(Error::UnexpectedReadableDescriptor(2).into());
+                        }
+
+                        let mut buf = vec![];
+                        let mut p: VirtioSoundPcmInfo;
+
+                        for s in streams
+                            .iter()
+                            .skip(u32::from(request.start_id) as usize)
+                            .take(u32::from(request.count) as usize)
+                        {
+                            p = VirtioSoundPcmInfo::default();
+                            p.hdr.hda_fn_nid = 0.into();
+                            p.features = s.params.features;
+                            p.formats = s.formats;
+                            p.rates = s.rates;
+                            p.direction = s.direction;
+                            p.channels_min = s.channels_min;
+                            p.channels_max = s.channels_max;
+                            buf.extend_from_slice(p.as_slice());
+                        }
+                        desc_chain
+                            .memory()
+                            .write_slice(&buf, desc_response.addr())
+                            .map_err(|_| Error::DescriptorWriteFailed)?;
+                        len += desc_response.len();
+                    }
+                }
+                ControlMessageKind::PcmSetParams => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+                    let stream_id: u32 = request.hdr.stream_id.into();
+
+                    if stream_id as usize >= self.streams_no {
+                        log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let b = audio_backend.read().unwrap();
+                        b.set_parameters(
+                            stream_id,
+                            ControlMessage {
+                                kind: code,
+                                code: VIRTIO_SND_S_OK,
+                                desc_chain,
+                                descriptor: desc_hdr,
+                                vring: vring.clone(),
+                            },
+                        )
+                        .unwrap();
+
+                        // PcmSetParams needs check valid formats/rates; the audio backend will
+                        // reply when it drops the ControlMessage.
+                        continue;
+                    }
+                }
+                ControlMessageKind::PcmPrepare => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSoundPcmHeader>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+                    let stream_id = request.stream_id.into();
+
+                    if stream_id as usize >= self.streams_no {
+                        log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let b = audio_backend.write().unwrap();
+                        b.prepare(stream_id).unwrap();
+                    }
+                }
+                ControlMessageKind::PcmRelease => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSoundPcmHeader>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+                    let stream_id = request.stream_id.into();
+
+                    if stream_id as usize >= self.streams_no {
+                        log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let b = audio_backend.write().unwrap();
+                        b.release(
+                            stream_id,
+                            ControlMessage {
+                                kind: code,
+                                code: VIRTIO_SND_S_OK,
+                                desc_chain,
+                                descriptor: desc_hdr,
+                                vring: vring.clone(),
+                            },
+                        )
+                        .unwrap();
+
+                        // PcmRelease needs to flush IO messages; the audio backend will reply when
+                        // it drops the ControlMessage.
+                        continue;
+                    }
+                }
+                ControlMessageKind::PcmStart => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSoundPcmHeader>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+                    let stream_id = request.stream_id.into();
+
+                    if stream_id as usize >= self.streams_no {
+                        log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let b = audio_backend.write().unwrap();
+                        b.start(stream_id).unwrap();
+                    }
+                }
+                ControlMessageKind::PcmStop => {
+                    let request = desc_chain
+                        .memory()
+                        .read_obj::<VirtioSoundPcmHeader>(desc_request.addr())
+                        .map_err(|_| Error::DescriptorReadFailed)?;
+                    let stream_id = request.stream_id.into();
+
+                    if stream_id as usize >= self.streams_no {
+                        log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
+                        resp.code = VIRTIO_SND_S_BAD_MSG.into();
+                    } else {
+                        let b = audio_backend.write().unwrap();
+                        b.stop(stream_id).unwrap();
+                    }
+                }
+                ControlMessageKind::ChmapInfo => {
+                    resp.code = VIRTIO_SND_S_NOT_SUPP.into();
+                }
+            }
+            log::trace!(
+                "returned {} for ctrl msg {:?}",
+                match u32::from(resp.code) {
+                    v if v == VIRTIO_SND_S_OK => "OK",
+                    v if v == VIRTIO_SND_S_BAD_MSG => "BAD_MSG",
+                    v if v == VIRTIO_SND_S_NOT_SUPP => "NOT_SUPP",
+                    v if v == VIRTIO_SND_S_IO_ERR => "IO_ERR",
+                    _ => unreachable!(),
+                },
+                code
+            );
+            desc_chain
+                .memory()
+                .write_obj(resp, desc_hdr.addr())
+                .map_err(|_| Error::DescriptorWriteFailed)?;
+
+            if vring.add_used(desc_chain.head_index(), len).is_err() {
+                log::error!("Couldn't return used descriptors to the ring");
+            }
+            any |= true;
+        }
+
+        // Send notification if any request was processed
+        if any && vring.signal_used_queue().is_err() {
+            log::error!("Couldn't signal used queue");
+        }
+
+        Ok(!any)
     }
 
     fn process_event(&self, _vring: &VringRwLock) -> IoResult<bool> {
@@ -107,12 +357,20 @@ impl VhostUserSoundThread {
         Ok(false)
     }
 
-    fn process_tx(&self, _vring: &VringRwLock) -> IoResult<bool> {
+    fn process_tx(
+        &self,
+        _vring: &VringRwLock,
+        _audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
+    ) -> IoResult<bool> {
         log::trace!("process_tx");
         Ok(false)
     }
 
-    fn process_rx(&self, _vring: &VringRwLock) -> IoResult<bool> {
+    fn process_rx(
+        &self,
+        _vring: &VringRwLock,
+        _audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
+    ) -> IoResult<bool> {
         log::trace!("process_rx");
         Ok(false)
     }
@@ -122,31 +380,58 @@ pub struct VhostUserSoundBackend {
     threads: Vec<RwLock<VhostUserSoundThread>>,
     virtio_cfg: VirtioSoundConfig,
     exit_event: EventFd,
-    _audio_backend: RwLock<Box<dyn AudioBackend + Send + Sync>>,
+    audio_backend: RwLock<Box<dyn AudioBackend + Send + Sync>>,
 }
 
 impl VhostUserSoundBackend {
     pub fn new(config: SoundConfig) -> Result<Self> {
+        let streams = vec![
+            Stream {
+                id: 0,
+                direction: VIRTIO_SND_D_OUTPUT,
+                ..Stream::default()
+            },
+            Stream {
+                id: 1,
+                direction: VIRTIO_SND_D_INPUT,
+                ..Stream::default()
+            },
+        ];
+        let streams_no = streams.len();
+        let streams = Arc::new(RwLock::new(streams));
         log::trace!("VhostUserSoundBackend::new config {:?}", &config);
-        let threads = if dbg!(config.multi_thread) {
+        let threads = if config.multi_thread {
             vec![
-                RwLock::new(VhostUserSoundThread::new(vec![
-                    CONTROL_QUEUE_IDX,
-                    EVENT_QUEUE_IDX,
-                ])?),
-                RwLock::new(VhostUserSoundThread::new(vec![TX_QUEUE_IDX])?),
-                RwLock::new(VhostUserSoundThread::new(vec![RX_QUEUE_IDX])?),
+                RwLock::new(VhostUserSoundThread::new(
+                    vec![CONTROL_QUEUE_IDX, EVENT_QUEUE_IDX],
+                    streams.clone(),
+                    streams_no,
+                )?),
+                RwLock::new(VhostUserSoundThread::new(
+                    vec![TX_QUEUE_IDX],
+                    streams.clone(),
+                    streams_no,
+                )?),
+                RwLock::new(VhostUserSoundThread::new(
+                    vec![RX_QUEUE_IDX],
+                    streams.clone(),
+                    streams_no,
+                )?),
             ]
         } else {
-            vec![RwLock::new(VhostUserSoundThread::new(vec![
-                CONTROL_QUEUE_IDX,
-                EVENT_QUEUE_IDX,
-                TX_QUEUE_IDX,
-                RX_QUEUE_IDX,
-            ])?)]
+            vec![RwLock::new(VhostUserSoundThread::new(
+                vec![
+                    CONTROL_QUEUE_IDX,
+                    EVENT_QUEUE_IDX,
+                    TX_QUEUE_IDX,
+                    RX_QUEUE_IDX,
+                ],
+                streams.clone(),
+                streams_no,
+            )?)]
         };
 
-        let audio_backend = alloc_audio_backend(config.audio_backend_name)?;
+        let audio_backend = alloc_audio_backend(config.audio_backend_name, streams)?;
 
         Ok(Self {
             threads,
@@ -156,7 +441,7 @@ impl VhostUserSoundBackend {
                 chmaps: 0.into(),
             },
             exit_event: EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?,
-            _audio_backend: RwLock::new(audio_backend),
+            audio_backend: RwLock::new(audio_backend),
         })
     }
 
@@ -171,7 +456,7 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserSoundBackend {
     }
 
     fn max_queue_size(&self) -> usize {
-        256
+        64
     }
 
     fn features(&self) -> u64 {
@@ -187,14 +472,12 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserSoundBackend {
     }
 
     fn set_event_idx(&self, enabled: bool) {
-        log::trace!("set_event_idx enabled {:?}", enabled);
         for thread in self.threads.iter() {
             thread.write().unwrap().set_event_idx(enabled);
         }
     }
 
     fn update_memory(&self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {
-        log::trace!("update_memory");
         for thread in self.threads.iter() {
             thread.write().unwrap().update_memory(mem.clone())?;
         }
@@ -209,19 +492,18 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserSoundBackend {
         vrings: &[VringRwLock],
         thread_id: usize,
     ) -> IoResult<bool> {
-        log::trace!("handle_event device_event {}", device_event);
         if evset != EventSet::IN {
             return Err(Error::HandleEventNotEpollIn.into());
         }
 
-        self.threads[thread_id]
-            .read()
-            .unwrap()
-            .handle_event(device_event, vrings)
+        self.threads[thread_id].read().unwrap().handle_event(
+            device_event,
+            vrings,
+            &self.audio_backend,
+        )
     }
 
     fn get_config(&self, offset: u32, size: u32) -> Vec<u8> {
-        log::trace!("get_config offset {} size {}", offset, size);
         let offset = offset as usize;
         let size = size as usize;
 
@@ -245,7 +527,61 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserSoundBackend {
     }
 
     fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
-        log::trace!("exit_event");
         self.exit_event.try_clone().ok()
+    }
+}
+
+pub struct ControlMessage {
+    pub kind: ControlMessageKind,
+    pub code: u32,
+    pub desc_chain: SoundDescriptorChain,
+    pub descriptor: virtio_queue::Descriptor,
+    pub vring: VringRwLock,
+}
+
+impl std::fmt::Debug for ControlMessage {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct(stringify!(ControlMessage))
+            .field("kind", &self.kind)
+            .field("code", &self.code)
+            .finish()
+    }
+}
+
+impl Drop for ControlMessage {
+    fn drop(&mut self) {
+        log::trace!(
+            "dropping ControlMessage {:?} reply = {}",
+            self.kind,
+            match self.code {
+                crate::virtio_sound::VIRTIO_SND_S_OK => "VIRTIO_SND_S_OK",
+                crate::virtio_sound::VIRTIO_SND_S_BAD_MSG => "VIRTIO_SND_S_BAD_MSG",
+                crate::virtio_sound::VIRTIO_SND_S_NOT_SUPP => "VIRTIO_SND_S_NOT_SUPP",
+                crate::virtio_sound::VIRTIO_SND_S_IO_ERR => "VIRTIO_SND_S_IO_ERR",
+                _ => "other",
+            }
+        );
+        let resp = VirtioSoundHeader {
+            code: self.code.into(),
+        };
+
+        if let Err(err) = self
+            .desc_chain
+            .memory()
+            .write_obj(resp, self.descriptor.addr())
+        {
+            log::error!("Error::DescriptorWriteFailed: {}", err);
+            return;
+        }
+        if self
+            .vring
+            .add_used(self.desc_chain.head_index(), resp.as_slice().len() as u32)
+            .is_err()
+        {
+            log::error!("Couldn't add used");
+        }
+        if self.vring.signal_used_queue().is_err() {
+            log::error!("Couldn't signal used queue");
+        }
     }
 }

--- a/crates/sound/src/lib.rs
+++ b/crates/sound/src/lib.rs
@@ -1,0 +1,119 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+pub mod audio_backends;
+pub mod device;
+pub mod virtio_sound;
+
+use std::{
+    io::{Error as IoError, ErrorKind},
+    sync::Arc,
+};
+
+use log::{info, warn};
+use thiserror::Error as ThisError;
+use vhost::{vhost_user, vhost_user::Listener};
+use vhost_user_backend::VhostUserDaemon;
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap, VolatileSlice};
+
+use crate::device::VhostUserSoundBackend;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Custom error types
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Failed to handle event other than EPOLLIN event")]
+    HandleEventNotEpollIn,
+    #[error("Failed to handle unknown event")]
+    HandleUnknownEvent,
+    #[error("Failed to create a new EventFd")]
+    EventFdCreate(IoError),
+    #[error("Request missing data buffer")]
+    SoundReqMissingData,
+    #[error("Audio backend not supported")]
+    AudioBackendNotSupported,
+}
+
+impl std::convert::From<Error> for IoError {
+    fn from(e: Error) -> Self {
+        IoError::new(ErrorKind::Other, e)
+    }
+}
+
+#[derive(Debug, Clone)]
+/// This structure is the public API through which an external program
+/// is allowed to configure the backend.
+pub struct SoundConfig {
+    /// vhost-user Unix domain socket
+    socket: String,
+    /// use multiple threads to hanlde the virtqueues
+    multi_thread: bool,
+    /// audio backend name
+    audio_backend_name: String,
+}
+
+impl SoundConfig {
+    /// Create a new instance of the SoundConfig struct, containing the
+    /// parameters to be fed into the sound-backend server.
+    pub fn new(socket: String, multi_thread: bool, audio_backend_name: String) -> Self {
+        Self {
+            socket,
+            multi_thread,
+            audio_backend_name,
+        }
+    }
+
+    /// Return the path of the unix domain socket which is listening to
+    /// requests from the guest.
+    pub fn get_socket_path(&self) -> String {
+        String::from(&self.socket)
+    }
+}
+
+pub type SoundBitmap = ();
+
+#[derive(Debug)]
+pub struct SoundRequest<'a> {
+    data_slice: Option<VolatileSlice<'a, SoundBitmap>>,
+}
+
+impl<'a> SoundRequest<'a> {
+    pub fn data_slice(&self) -> Option<&VolatileSlice<'a, SoundBitmap>> {
+        self.data_slice.as_ref()
+    }
+}
+
+/// This is the public API through which an external program starts the
+/// vhost-user-sound backend server.
+pub fn start_backend_server(config: SoundConfig) {
+    let listener = Listener::new(config.get_socket_path(), true).unwrap();
+    let backend = Arc::new(VhostUserSoundBackend::new(config).unwrap());
+
+    let mut daemon = VhostUserDaemon::new(
+        String::from("vhost-user-sound"),
+        backend.clone(),
+        GuestMemoryAtomic::new(GuestMemoryMmap::<SoundBitmap>::new()),
+    )
+    .unwrap();
+
+    daemon.start(listener).unwrap();
+
+    match daemon.wait() {
+        Ok(()) => {
+            info!("Stopping cleanly");
+        }
+        Err(vhost_user_backend::Error::HandleRequest(vhost_user::Error::PartialMessage)) => {
+            info!(
+                "vhost-user connection closed with partial message. If the VM is shutting down, \
+                 this is expected behavior; otherwise, it might be a bug."
+            );
+        }
+        Err(e) => {
+            warn!("Error running daemon: {:?}", e);
+        }
+    }
+
+    // No matter the result, we need to shut down the worker thread.
+    backend.send_exit_event();
+}

--- a/crates/sound/src/lib.rs
+++ b/crates/sound/src/lib.rs
@@ -3,41 +3,194 @@
 
 pub mod audio_backends;
 pub mod device;
+pub mod stream;
 pub mod virtio_sound;
 
 use std::{
+    convert::TryFrom,
     io::{Error as IoError, ErrorKind},
     sync::Arc,
 };
 
 use log::{info, warn};
+pub use stream::Stream;
 use thiserror::Error as ThisError;
 use vhost::{vhost_user, vhost_user::Listener};
-use vhost_user_backend::VhostUserDaemon;
-use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap, VolatileSlice};
+use vhost_user_backend::{VhostUserDaemon, VringRwLock, VringT};
+use virtio_sound::*;
+use vm_memory::{
+    ByteValued, Bytes, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap, Le32,
+    VolatileSlice,
+};
 
 use crate::device::VhostUserSoundBackend;
 
+pub const SUPPORTED_FORMATS: u64 = 1 << VIRTIO_SND_PCM_FMT_U8
+    | 1 << VIRTIO_SND_PCM_FMT_S16
+    | 1 << VIRTIO_SND_PCM_FMT_S24
+    | 1 << VIRTIO_SND_PCM_FMT_S32;
+
+pub const SUPPORTED_RATES: u64 = 1 << VIRTIO_SND_PCM_RATE_8000
+    | 1 << VIRTIO_SND_PCM_RATE_11025
+    | 1 << VIRTIO_SND_PCM_RATE_16000
+    | 1 << VIRTIO_SND_PCM_RATE_22050
+    | 1 << VIRTIO_SND_PCM_RATE_32000
+    | 1 << VIRTIO_SND_PCM_RATE_44100
+    | 1 << VIRTIO_SND_PCM_RATE_48000;
+
+use virtio_queue::DescriptorChain;
+pub type SoundDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Custom error types
 #[derive(Debug, ThisError)]
 pub enum Error {
+    #[error("Notification send failed")]
+    SendNotificationFailed,
+    #[error("Descriptor not found")]
+    DescriptorNotFound,
+    #[error("Descriptor read failed")]
+    DescriptorReadFailed,
+    #[error("Descriptor write failed")]
+    DescriptorWriteFailed,
     #[error("Failed to handle event other than EPOLLIN event")]
     HandleEventNotEpollIn,
     #[error("Failed to handle unknown event")]
     HandleUnknownEvent,
+    #[error("Invalid control message code {0}")]
+    InvalidControlMessage(u32),
     #[error("Failed to create a new EventFd")]
     EventFdCreate(IoError),
     #[error("Request missing data buffer")]
     SoundReqMissingData,
     #[error("Audio backend not supported")]
     AudioBackendNotSupported,
+    #[error("Invalid virtio_snd_hdr size, expected: {0}, found: {1}")]
+    UnexpectedSoundHeaderSize(usize, u32),
+    #[error("Received unexpected write only descriptor at index {0}")]
+    UnexpectedWriteOnlyDescriptor(usize),
+    #[error("Received unexpected readable descriptor at index {0}")]
+    UnexpectedReadableDescriptor(usize),
+    #[error("Invalid descriptor count {0}")]
+    UnexpectedDescriptorCount(usize),
+    #[error("Invalid descriptor size, expected: {0}, found: {1}")]
+    UnexpectedDescriptorSize(usize, u32),
+    #[error("Protocol or device error: {0}")]
+    Stream(stream::Error),
 }
 
-impl std::convert::From<Error> for IoError {
+impl From<Error> for IoError {
     fn from(e: Error) -> Self {
-        IoError::new(ErrorKind::Other, e)
+        Self::new(ErrorKind::Other, e)
+    }
+}
+
+impl From<stream::Error> for Error {
+    fn from(val: stream::Error) -> Self {
+        Self::Stream(val)
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidControlMessage(u32);
+
+impl std::fmt::Display for InvalidControlMessage {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "Invalid control message code {}", self.0)
+    }
+}
+
+impl From<InvalidControlMessage> for crate::Error {
+    fn from(val: InvalidControlMessage) -> Self {
+        Self::InvalidControlMessage(val.0)
+    }
+}
+
+#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ControlMessageKind {
+    JackInfo = 1,
+    JackRemap = 2,
+    PcmInfo = 0x0100,
+    PcmSetParams = 0x0101,
+    PcmPrepare = 0x0102,
+    PcmRelease = 0x0103,
+    PcmStart = 0x0104,
+    PcmStop = 0x0105,
+    ChmapInfo = 0x0200,
+}
+
+impl TryFrom<Le32> for ControlMessageKind {
+    type Error = InvalidControlMessage;
+
+    fn try_from(val: Le32) -> std::result::Result<Self, Self::Error> {
+        Ok(match u32::from(val) {
+            VIRTIO_SND_R_JACK_INFO => Self::JackInfo,
+            VIRTIO_SND_R_JACK_REMAP => Self::JackRemap,
+            VIRTIO_SND_R_PCM_INFO => Self::PcmInfo,
+            VIRTIO_SND_R_PCM_SET_PARAMS => Self::PcmSetParams,
+            VIRTIO_SND_R_PCM_PREPARE => Self::PcmPrepare,
+            VIRTIO_SND_R_PCM_RELEASE => Self::PcmRelease,
+            VIRTIO_SND_R_PCM_START => Self::PcmStart,
+            VIRTIO_SND_R_PCM_STOP => Self::PcmStop,
+            VIRTIO_SND_R_CHMAP_INFO => Self::ChmapInfo,
+            other => return Err(InvalidControlMessage(other)),
+        })
+    }
+}
+
+pub struct ControlMessage {
+    pub kind: ControlMessageKind,
+    pub code: u32,
+    pub desc_chain: SoundDescriptorChain,
+    pub descriptor: virtio_queue::Descriptor,
+    pub vring: VringRwLock,
+}
+
+impl std::fmt::Debug for ControlMessage {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct(stringify!(ControlMessage))
+            .field("kind", &self.kind)
+            .field("code", &self.code)
+            .finish()
+    }
+}
+
+impl Drop for ControlMessage {
+    fn drop(&mut self) {
+        log::trace!(
+            "dropping ControlMessage {:?} reply = {}",
+            self.kind,
+            match self.code {
+                crate::virtio_sound::VIRTIO_SND_S_OK => "VIRTIO_SND_S_OK",
+                crate::virtio_sound::VIRTIO_SND_S_BAD_MSG => "VIRTIO_SND_S_BAD_MSG",
+                crate::virtio_sound::VIRTIO_SND_S_NOT_SUPP => "VIRTIO_SND_S_NOT_SUPP",
+                crate::virtio_sound::VIRTIO_SND_S_IO_ERR => "VIRTIO_SND_S_IO_ERR",
+                _ => "other",
+            }
+        );
+        let resp = VirtioSoundHeader {
+            code: self.code.into(),
+        };
+
+        if let Err(err) = self
+            .desc_chain
+            .memory()
+            .write_obj(resp, self.descriptor.addr())
+        {
+            log::error!("Error::DescriptorWriteFailed: {}", err);
+            return;
+        }
+        if self
+            .vring
+            .add_used(self.desc_chain.head_index(), resp.as_slice().len() as u32)
+            .is_err()
+        {
+            log::error!("Couldn't add used");
+        }
+        if self.vring.signal_used_queue().is_err() {
+            log::error!("Couldn't signal used queue");
+        }
     }
 }
 
@@ -87,6 +240,7 @@ impl<'a> SoundRequest<'a> {
 /// This is the public API through which an external program starts the
 /// vhost-user-sound backend server.
 pub fn start_backend_server(config: SoundConfig) {
+    log::trace!("Using config {:?}", &config);
     let listener = Listener::new(config.get_socket_path(), true).unwrap();
     let backend = Arc::new(VhostUserSoundBackend::new(config).unwrap());
 
@@ -97,6 +251,7 @@ pub fn start_backend_server(config: SoundConfig) {
     )
     .unwrap();
 
+    log::trace!("Starting daemon");
     daemon.start(listener).unwrap();
 
     match daemon.wait() {

--- a/crates/sound/src/main.rs
+++ b/crates/sound/src/main.rs
@@ -1,0 +1,67 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// Stefano Garzarella <sgarzare@redhat.com>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+use std::convert::TryFrom;
+
+use clap::Parser;
+use vhost_user_sound::{start_backend_server, Error, Result, SoundConfig};
+
+#[derive(Parser, Debug)]
+#[clap(version, about, long_about = None)]
+struct SoundArgs {
+    /// vhost-user Unix domain socket path.
+    #[clap(long)]
+    socket: String,
+    /// audio backend to be used (supported: null)
+    #[clap(long)]
+    backend: String,
+}
+
+impl TryFrom<SoundArgs> for SoundConfig {
+    type Error = Error;
+
+    fn try_from(cmd_args: SoundArgs) -> Result<Self> {
+        let socket = cmd_args.socket.trim().to_string();
+        let backend = cmd_args.backend.trim().to_string();
+
+        Ok(SoundConfig::new(socket, false, backend))
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let config = SoundConfig::try_from(SoundArgs::parse()).unwrap();
+
+    loop {
+        start_backend_server(config.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+
+    impl SoundArgs {
+        fn from_args(socket: &str) -> Self {
+            SoundArgs {
+                socket: socket.to_string(),
+                backend: "null".to_string(),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_vsock_config_setup() {
+        let args = SoundArgs::from_args("/tmp/vhost-sound.socket");
+
+        let config = SoundConfig::try_from(args);
+        assert!(config.is_ok());
+
+        let config = config.unwrap();
+        assert_eq!(config.get_socket_path(), "/tmp/vhost-sound.socket");
+    }
+}

--- a/crates/sound/src/stream.rs
+++ b/crates/sound/src/stream.rs
@@ -1,0 +1,269 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use thiserror::Error as ThisError;
+use vm_memory::{Le32, Le64};
+
+use crate::{virtio_sound::*, SUPPORTED_FORMATS, SUPPORTED_RATES};
+
+/// Stream errors.
+#[derive(Debug, ThisError)]
+pub enum Error {
+    #[error("Guest driver request an invalid stream state transition from {0} to {1}.")]
+    InvalidStateTransition(PCMState, PCMState),
+    #[error("Guest requested an invalid stream id: {0}")]
+    InvalidStreamId(u32),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// PCM stream state machine.
+///
+/// ## 5.14.6.6.1 PCM Command Lifecycle
+///
+/// A PCM stream has the following command lifecycle:
+///
+/// - `SET PARAMETERS`
+///
+///   The driver negotiates the stream parameters (format, transport, etc) with
+/// the device.
+///
+///   Possible valid transitions: `SET PARAMETERS`, `PREPARE`.
+///
+/// - `PREPARE`
+///
+///   The device prepares the stream (allocates resources, etc).
+///
+///   Possible valid transitions: `SET PARAMETERS`, `PREPARE`, `START`,
+/// `RELEASE`.   Output only: the driver transfers data for pre-buffing.
+///
+/// - `START`
+///
+///   The device starts the stream (unmute, putting into running state, etc).
+///
+///   Possible valid transitions: `STOP`.
+///   The driver transfers data to/from the stream.
+///
+/// - `STOP`
+///
+///   The device stops the stream (mute, putting into non-running state, etc).
+///
+///   Possible valid transitions: `START`, `RELEASE`.
+///
+/// - `RELEASE`
+///
+///   The device releases the stream (frees resources, etc).
+///
+///   Possible valid transitions: `SET PARAMETERS`, `PREPARE`.
+///
+/// ```text
+/// +---------------+ +---------+ +---------+ +-------+ +-------+
+/// | SetParameters | | Prepare | | Release | | Start | | Stop  |
+/// +---------------+ +---------+ +---------+ +-------+ +-------+
+///         |              |           |          |         |
+///         |-             |           |          |         |
+///         ||             |           |          |         |
+///         |<             |           |          |         |
+///         |              |           |          |         |
+///         |------------->|           |          |         |
+///         |              |           |          |         |
+///         |<-------------|           |          |         |
+///         |              |           |          |         |
+///         |              |-          |          |         |
+///         |              ||          |          |         |
+///         |              |<          |          |         |
+///         |              |           |          |         |
+///         |              |--------------------->|         |
+///         |              |           |          |         |
+///         |              |---------->|          |         |
+///         |              |           |          |         |
+///         |              |           |          |-------->|
+///         |              |           |          |         |
+///         |              |           |          |<--------|
+///         |              |           |          |         |
+///         |              |           |<-------------------|
+///         |              |           |          |         |
+///         |<-------------------------|          |         |
+///         |              |           |          |         |
+///         |              |<----------|          |         |
+/// ```
+#[derive(Debug, Default, Copy, Clone)]
+pub enum PCMState {
+    #[default]
+    #[doc(alias = "VIRTIO_SND_R_PCM_SET_PARAMS")]
+    SetParameters,
+    #[doc(alias = "VIRTIO_SND_R_PCM_PREPARE")]
+    Prepare,
+    #[doc(alias = "VIRTIO_SND_R_PCM_RELEASE")]
+    Release,
+    #[doc(alias = "VIRTIO_SND_R_PCM_START")]
+    Start,
+    #[doc(alias = "VIRTIO_SND_R_PCM_STOP")]
+    Stop,
+}
+
+macro_rules! set_new_state {
+    ($new_state_fn:ident, $new_state:expr, $($valid_source_states:tt)*) => {
+        pub fn $new_state_fn(&mut self) -> Result<()> {
+            if !matches!(self, $($valid_source_states)*) {
+                return Err(Error::InvalidStateTransition(*self, $new_state));
+            }
+            *self = $new_state;
+            Ok(())
+        }
+    };
+}
+
+impl PCMState {
+    pub fn new() -> Self {
+        Self::SetParameters
+    }
+
+    set_new_state!(
+        set_parameters,
+        Self::SetParameters,
+        Self::SetParameters | Self::Prepare | Self::Release
+    );
+
+    set_new_state!(
+        prepare,
+        Self::Prepare,
+        Self::SetParameters | Self::Prepare | Self::Release
+    );
+
+    set_new_state!(start, Self::Start, Self::Prepare | Self::Stop);
+
+    set_new_state!(stop, Self::Stop, Self::Start);
+
+    set_new_state!(release, Self::Release, Self::Prepare | Self::Stop);
+}
+
+impl std::fmt::Display for PCMState {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use PCMState::*;
+        match *self {
+            SetParameters => {
+                write!(fmt, "VIRTIO_SND_R_PCM_SET_PARAMS")
+            }
+            Prepare => {
+                write!(fmt, "VIRTIO_SND_R_PCM_PREPARE")
+            }
+            Release => {
+                write!(fmt, "VIRTIO_SND_R_PCM_RELEASE")
+            }
+            Start => {
+                write!(fmt, "VIRTIO_SND_R_PCM_START")
+            }
+            Stop => {
+                write!(fmt, "VIRTIO_SND_R_PCM_STOP")
+            }
+        }
+    }
+}
+
+/// Internal state of a PCM stream of the VIRTIO Sound device.
+#[derive(Debug)]
+pub struct Stream {
+    pub id: usize,
+    pub params: PcmParams,
+    pub formats: Le64,
+    pub rates: Le64,
+    pub direction: u8,
+    pub channels_min: u8,
+    pub channels_max: u8,
+    pub state: PCMState,
+}
+
+impl Default for Stream {
+    fn default() -> Self {
+        Self {
+            id: 0,
+            direction: VIRTIO_SND_D_OUTPUT,
+            formats: SUPPORTED_FORMATS.into(),
+            rates: SUPPORTED_RATES.into(),
+            params: PcmParams::default(),
+            channels_min: 1,
+            channels_max: 6,
+            state: Default::default(),
+        }
+    }
+}
+
+impl Stream {
+    #[inline]
+    pub fn supports_format(&self, format: u8) -> bool {
+        let formats: u64 = self.formats.into();
+        (formats & (1_u64 << format)) != 0
+    }
+
+    #[inline]
+    pub fn supports_rate(&self, rate: u8) -> bool {
+        let rates: u64 = self.rates.into();
+        (rates & (1_u64 << rate)) != 0
+    }
+}
+
+/// Stream params
+#[derive(Debug)]
+pub struct PcmParams {
+    pub features: Le32,
+    /// size of hardware buffer in bytes
+    pub buffer_bytes: Le32,
+    /// size of hardware period in bytes
+    pub period_bytes: Le32,
+    pub channels: u8,
+    pub format: u8,
+    pub rate: u8,
+}
+
+impl Default for PcmParams {
+    fn default() -> Self {
+        Self {
+            features: 0.into(),
+            buffer_bytes: 8192.into(),
+            period_bytes: 4096.into(),
+            channels: 1,
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_44100,
+        }
+    }
+}
+
+impl PcmParams {
+    pub fn sample_bytes(&self) -> usize {
+        match self.format {
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_IMA_ADPCM
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_MU_LAW
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_A_LAW
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_S8
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U8 => 1,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_S16 => 2,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_U16 => 2,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_S18_3
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U18_3
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_S20_3
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U20_3
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_S24_3
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U24_3 => 3,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_S20 => 3,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_U20 => 3,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_S24
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U24
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_S32
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_U32 => 4,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT => 4,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT64 => 8,
+            crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U8
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U16
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U32
+            | crate::virtio_sound::VIRTIO_SND_PCM_FMT_IEC958_SUBFRAME => {
+                todo!()
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn frame(&self) -> usize {
+        self.sample_bytes() * self.channels as usize
+    }
+}

--- a/crates/sound/src/virtio_sound.rs
+++ b/crates/sound/src/virtio_sound.rs
@@ -46,8 +46,8 @@ pub const VIRTIO_SND_S_IO_ERR: u32 = 0x8003;
 
 // device data flow directions
 
-pub const VIRTIO_SND_D_OUTPUT: u32 = 0;
-pub const VIRTIO_SND_D_INPUT: u32 = 1;
+pub const VIRTIO_SND_D_OUTPUT: u8 = 0;
+pub const VIRTIO_SND_D_INPUT: u8 = 1;
 
 // supported jack features
 

--- a/crates/sound/src/virtio_sound.rs
+++ b/crates/sound/src/virtio_sound.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+use vm_memory::{ByteValued, Le32, Le64};
+
+// virtqueues
+
+pub const CONTROL_QUEUE_IDX: u16 = 0;
+pub const EVENT_QUEUE_IDX: u16 = 1;
+pub const TX_QUEUE_IDX: u16 = 2;
+pub const RX_QUEUE_IDX: u16 = 3;
+pub const NUM_QUEUES: u16 = 4;
+
+// jack control request types
+
+pub const VIRTIO_SND_R_JACK_INFO: u32 = 1;
+pub const VIRTIO_SND_R_JACK_REMAP: u32 = 2;
+
+// PCM control request types
+
+pub const VIRTIO_SND_R_PCM_INFO: u32 = 0x0100;
+pub const VIRTIO_SND_R_PCM_SET_PARAMS: u32 = 0x0101;
+pub const VIRTIO_SND_R_PCM_PREPARE: u32 = 0x0102;
+pub const VIRTIO_SND_R_PCM_RELEASE: u32 = 0x0103;
+pub const VIRTIO_SND_R_PCM_START: u32 = 0x0104;
+pub const VIRTIO_SND_R_PCM_STOP: u32 = 0x0105;
+
+// channel map control request types
+
+pub const VIRTIO_SND_R_CHMAP_INFO: u32 = 0x0200;
+
+// jack event types
+
+pub const VIRTIO_SND_EVT_JACK_CONNECTED: u32 = 0x1000;
+pub const VIRTIO_SND_EVT_JACK_DISCONNECTED: u32 = 0x1001;
+
+// PCM event types
+
+pub const VIRTIO_SND_EVT_PCM_PERIOD_ELAPSED: u32 = 0x1100;
+pub const VIRTIO_SND_EVT_PCM_XRUN: u32 = 0x1101;
+
+// common status codes
+
+pub const VIRTIO_SND_S_OK: u32 = 0x8000;
+pub const VIRTIO_SND_S_BAD_MSG: u32 = 0x8001;
+pub const VIRTIO_SND_S_NOT_SUPP: u32 = 0x8002;
+pub const VIRTIO_SND_S_IO_ERR: u32 = 0x8003;
+
+// device data flow directions
+
+pub const VIRTIO_SND_D_OUTPUT: u32 = 0;
+pub const VIRTIO_SND_D_INPUT: u32 = 1;
+
+// supported jack features
+
+pub const VIRTIO_SND_JACK_F_REMAP: u32 = 0;
+
+// supported PCM stream features
+
+pub const VIRTIO_SND_PCM_F_SHMEM_HOST: u8 = 0;
+pub const VIRTIO_SND_PCM_F_SHMEM_GUEST: u8 = 1;
+pub const VIRTIO_SND_PCM_F_MSG_POLLING: u8 = 2;
+pub const VIRTIO_SND_PCM_F_EVT_SHMEM_PERIODS: u8 = 3;
+pub const VIRTIO_SND_PCM_F_EVT_XRUNS: u8 = 4;
+
+// supported PCM sample formats
+
+pub const VIRTIO_SND_PCM_FMT_IMA_ADPCM: u8 = 0;
+pub const VIRTIO_SND_PCM_FMT_MU_LAW: u8 = 1;
+pub const VIRTIO_SND_PCM_FMT_A_LAW: u8 = 2;
+pub const VIRTIO_SND_PCM_FMT_S8: u8 = 3;
+pub const VIRTIO_SND_PCM_FMT_U8: u8 = 4;
+pub const VIRTIO_SND_PCM_FMT_S16: u8 = 5;
+pub const VIRTIO_SND_PCM_FMT_U16: u8 = 6;
+pub const VIRTIO_SND_PCM_FMT_S18_3: u8 = 7;
+pub const VIRTIO_SND_PCM_FMT_U18_3: u8 = 8;
+pub const VIRTIO_SND_PCM_FMT_S20_3: u8 = 9;
+pub const VIRTIO_SND_PCM_FMT_U20_3: u8 = 10;
+pub const VIRTIO_SND_PCM_FMT_S24_3: u8 = 11;
+pub const VIRTIO_SND_PCM_FMT_U24_3: u8 = 12;
+pub const VIRTIO_SND_PCM_FMT_S20: u8 = 13;
+pub const VIRTIO_SND_PCM_FMT_U20: u8 = 14;
+pub const VIRTIO_SND_PCM_FMT_S24: u8 = 15;
+pub const VIRTIO_SND_PCM_FMT_U24: u8 = 16;
+pub const VIRTIO_SND_PCM_FMT_S32: u8 = 17;
+pub const VIRTIO_SND_PCM_FMT_U32: u8 = 18;
+pub const VIRTIO_SND_PCM_FMT_FLOAT: u8 = 19;
+pub const VIRTIO_SND_PCM_FMT_FLOAT64: u8 = 20;
+// digital formats (width / physical width)
+pub const VIRTIO_SND_PCM_FMT_DSD_U8: u8 = 21;
+pub const VIRTIO_SND_PCM_FMT_DSD_U16: u8 = 22;
+pub const VIRTIO_SND_PCM_FMT_DSD_U32: u8 = 23;
+pub const VIRTIO_SND_PCM_FMT_IEC958_SUBFRAME: u8 = 24;
+
+// supported PCM frame rates
+
+pub const VIRTIO_SND_PCM_RATE_5512: u8 = 0;
+pub const VIRTIO_SND_PCM_RATE_8000: u8 = 1;
+pub const VIRTIO_SND_PCM_RATE_11025: u8 = 2;
+pub const VIRTIO_SND_PCM_RATE_16000: u8 = 3;
+pub const VIRTIO_SND_PCM_RATE_22050: u8 = 4;
+pub const VIRTIO_SND_PCM_RATE_32000: u8 = 5;
+pub const VIRTIO_SND_PCM_RATE_44100: u8 = 6;
+pub const VIRTIO_SND_PCM_RATE_48000: u8 = 7;
+pub const VIRTIO_SND_PCM_RATE_64000: u8 = 8;
+pub const VIRTIO_SND_PCM_RATE_88200: u8 = 9;
+pub const VIRTIO_SND_PCM_RATE_96000: u8 = 10;
+pub const VIRTIO_SND_PCM_RATE_176400: u8 = 11;
+pub const VIRTIO_SND_PCM_RATE_192000: u8 = 12;
+pub const VIRTIO_SND_PCM_RATE_384000: u8 = 13;
+
+// standard channel position definition
+
+pub const VIRTIO_SND_CHMAP_NONE: u8 = 0; /* undefined */
+pub const VIRTIO_SND_CHMAP_NA: u8 = 1; /* silent */
+pub const VIRTIO_SND_CHMAP_MONO: u8 = 2; /* mono stream */
+pub const VIRTIO_SND_CHMAP_FL: u8 = 3; /* front left */
+pub const VIRTIO_SND_CHMAP_FR: u8 = 4; /* front right */
+pub const VIRTIO_SND_CHMAP_RL: u8 = 5; /* rear left */
+pub const VIRTIO_SND_CHMAP_RR: u8 = 6; /* rear right */
+pub const VIRTIO_SND_CHMAP_FC: u8 = 7; /* front center */
+pub const VIRTIO_SND_CHMAP_LFE: u8 = 8; /* low frequency (LFE) */
+pub const VIRTIO_SND_CHMAP_SL: u8 = 9; /* side left */
+pub const VIRTIO_SND_CHMAP_SR: u8 = 10; /* side right */
+pub const VIRTIO_SND_CHMAP_RC: u8 = 11; /* rear center */
+pub const VIRTIO_SND_CHMAP_FLC: u8 = 12; /* front left center */
+pub const VIRTIO_SND_CHMAP_FRC: u8 = 13; /* front right center */
+pub const VIRTIO_SND_CHMAP_RLC: u8 = 14; /* rear left center */
+pub const VIRTIO_SND_CHMAP_RRC: u8 = 15; /* rear right center */
+pub const VIRTIO_SND_CHMAP_FLW: u8 = 16; /* front left wide */
+pub const VIRTIO_SND_CHMAP_FRW: u8 = 17; /* front right wide */
+pub const VIRTIO_SND_CHMAP_FLH: u8 = 18; /* front left high */
+pub const VIRTIO_SND_CHMAP_FCH: u8 = 19; /* front center high */
+pub const VIRTIO_SND_CHMAP_FRH: u8 = 20; /* front right high */
+pub const VIRTIO_SND_CHMAP_TC: u8 = 21; /* top center */
+pub const VIRTIO_SND_CHMAP_TFL: u8 = 22; /* top front left */
+pub const VIRTIO_SND_CHMAP_TFR: u8 = 23; /* top front right */
+pub const VIRTIO_SND_CHMAP_TFC: u8 = 24; /* top front center */
+pub const VIRTIO_SND_CHMAP_TRL: u8 = 25; /* top rear left */
+pub const VIRTIO_SND_CHMAP_TRR: u8 = 26; /* top rear right */
+pub const VIRTIO_SND_CHMAP_TRC: u8 = 27; /* top rear center */
+pub const VIRTIO_SND_CHMAP_TFLC: u8 = 28; /* top front left center */
+pub const VIRTIO_SND_CHMAP_TFRC: u8 = 29; /* top front right center */
+pub const VIRTIO_SND_CHMAP_TSL: u8 = 34; /* top side left */
+pub const VIRTIO_SND_CHMAP_TSR: u8 = 35; /* top side right */
+pub const VIRTIO_SND_CHMAP_LLFE: u8 = 36; /* left LFE */
+pub const VIRTIO_SND_CHMAP_RLFE: u8 = 37; /* right LFE */
+pub const VIRTIO_SND_CHMAP_BC: u8 = 38; /* bottom center */
+pub const VIRTIO_SND_CHMAP_BLC: u8 = 39; /* bottom left center */
+pub const VIRTIO_SND_CHMAP_BRC: u8 = 40; /* bottom right center */
+// maximum possible number of channels
+pub const VIRTIO_SND_CHMAP_MAX_SIZE: usize = 18;
+
+/// Virtio Sound Configuration
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundConfig {
+    /// total number of all available jacks
+    pub jacks: Le32,
+    /// total number of all available PCM streams
+    pub streams: Le32,
+    /// total number of all available channel maps
+    pub chmaps: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundConfig {}
+
+/// Virtio Sound Request / Response common header
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundHeader {
+    /// request type / response status
+    pub code: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundHeader {}
+
+/// Virtio Sound event notification
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundEvent {
+    /// PCM stream event type
+    pub hdr: VirtioSoundHeader,
+    /// PCM stream identifier from 0 to streams - 1
+    pub data: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundEvent {}
+
+/// Virtio Sound request information about any kind of configuration item
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundQueryInfo {
+    /// item request type (VIRTIO_SND_R_*_INFO)
+    pub hdr: VirtioSoundHeader,
+    /// starting identifier for the item
+    pub start_id: Le32,
+    /// number of items for which information is requested
+    pub count: Le32,
+    /// size of the structure containing information for one item
+    pub size: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundQueryInfo {}
+
+/// Virtio Sound response common information header
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundInfo {
+    /// function group node identifier
+    pub hda_fn_nid: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundInfo {}
+
+/// Jack control request / Jack common header
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundJackHeader {
+    /// jack request type (VIRTIO_SND_R_JACK_*)
+    pub hdr: VirtioSoundHeader,
+    /// jack identifier
+    pub jack_id: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundJackHeader {}
+
+/// Jack response information about available jacks
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundJackInfo {
+    /// jack response header type
+    pub hdr: VirtioSoundInfo,
+    /// supported feature bit map (VIRTIO_SND_JACK_F_XXX)
+    pub feature: Le32,
+    /// pin default configuration value
+    pub hda_reg_defconf: Le32,
+    /// pin capabilities value
+    pub hda_reg_caps: Le32,
+    /// current jack connection status
+    pub connected: u8,
+    pub padding: [u8; 7],
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundJackInfo {}
+
+///If the VIRTIO_SND_JACK_F_REMAP feature bit is set in the jack information
+/// Remap control request
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundJackRemap {
+    pub hdr: VirtioSoundJackHeader, /* .code = VIRTIO_SND_R_JACK_REMAP */
+    pub association: Le32,
+    pub sequence: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundJackRemap {}
+
+/// PCM control request / PCM common header
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundPcmHeader {
+    pub hdr: VirtioSoundHeader,
+    pub stream_id: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundPcmHeader {}
+
+/// PCM response information
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundPcmInfo {
+    pub hdr: VirtioSoundInfo,
+    pub features: Le32, /* 1 << VIRTIO_SND_PCM_F_XXX */
+    pub formats: Le64,  /* 1 << VIRTIO_SND_PCM_FMT_XXX */
+    pub rates: Le64,    /* 1 << VIRTIO_SND_PCM_RATE_XXX */
+    pub direction: u8,
+    pub channels_min: u8,
+    pub channels_max: u8,
+
+    pub padding: [u8; 5],
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundPcmInfo {}
+
+/// Set selected stream parameters for the specified stream ID
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSndPcmSetParams {
+    pub hdr: VirtioSoundPcmHeader,
+    pub buffer_bytes: Le32,
+    pub period_bytes: Le32,
+    pub features: Le32, /* 1 << VIRTIO_SND_PCM_F_XXX */
+    pub channels: u8,
+    pub format: u8,
+    pub rate: u8,
+    pub padding: u8,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSndPcmSetParams {}
+
+/// PCM I/O header
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundPcmXfer {
+    pub stream_id: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundPcmXfer {}
+
+/// PCM I/O status
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundPcmStatus {
+    pub status: Le32,
+    pub latency_bytes: Le32,
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundPcmStatus {}
+
+/// channel maps response information
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct VirtioSoundChmapInfo {
+    pub hdr: VirtioSoundInfo,
+    pub direction: u8,
+    pub channels: u8,
+    pub positions: [u8; VIRTIO_SND_CHMAP_MAX_SIZE],
+}
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioSoundChmapInfo {}


### PR DESCRIPTION
### Summary of the PR

This PR adds a new crate, `vhost-user-sound`, that provides a `vhost-user` backend daemon for the VIRTIO Sound device as specified in the VIRTIO Spec v.1.2 [^0]

Supported features are:

- One input stream, one output stream (hard-coded).
- Playback with ALSA backend (on host machine).
  Buffer/period settings need some tuning, the first period seems to come up short; I'm not familiar with ALSA programming at all.
- Playback with a "null" backend that just consumes audio without actual playback.

What remains to be done:

- There are various places where micro-refactors make sense
- Audio capture
- Add more audio backends.
- Add logic for setting up the default sound device stream information on startup from the audio backend, instead of hardcoding one input stream and one output stream.

[^0]:  [Virtual I/O Device (VIRTIO) Version 1.2 Committee Specification Draft 01 09 May 2022 ](https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-52900014)

### Usage / Testing functionality

This PR was tested with QEMU, with a proposed patchset that enables generic `vhost-user` devices in virtualized guests [^1], contributed by @stsquad.

[^1]: https://patchew.org/QEMU/20230418162140.373219-1-alex.bennee@linaro.org/

The following command line invocations were used:

#### Run the `vhost-device` daemon

```shell
cargo run -- --socket /tmp/snd.sock --backend alsa
```

#### Run a guest in QEMU

1. Apply the patchset [^1].
3. Apply these patches to create a `vhost-user-snd` and `vhost-user-snd-pci` device [^2].

   - [`[PATCH] Add virtio-sound and virtio-sound-pci devices`](https://github.com/epilys/qemu-virtio-snd/commit/6fbca9fe0396c473bb16726f3d10bd4b5483447e.patch)
   - [`[PATCH] Add vhost-user-snd and vhost-user-snd-pci devices`](https://github.com/epilys/qemu-virtio-snd/commit/54ae1cdd15fef2d88e9e387a175f099a38c636f4.patch)

   [^2]: <https://github.com/epilys/qemu-virtio-snd/commits/54ae1cdd15fef2d88e9e387a175f099a38c636f4>

2. Build for desired target architecture, e.g. `x86_64`.
3. Get/build kernel configured with `CONFIG_SND_VIRTIO`.
4. Launch QEMU with

   ```shell
   $ export VHOST_USER_SOCK=/tmp/snd.sock
   $ /path/to/qemu-system-x86_64  \
       [... snip ...] \
     -chardev socket,id=vsnd,path="$VHOST_USER_SOCK" \
     -device vhost-user-snd-pci,chardev=vsnd,id=snd \
     [... snip ...]
   ```
5. Use `speaker-test -l 1` to play some pink noise for one loop (`-l N`) or `speaker-test -t wav -w /path/to/file.wav -l 1`.

### Requirements

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
