### PR TITLE
vsock: fix use-after-close RawFd unsafe {} use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,19 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
-dependencies = [
- "cfg-if",
- "hashbrown 0.12.3",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,16 +651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,29 +723,6 @@ checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
 ]
 
 [[package]]
@@ -1008,12 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "serde"
 version = "1.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,31 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serial_test"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
-dependencies = [
- "dashmap",
- "futures",
- "lazy_static",
- "log",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.23",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,12 +1030,6 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strsim"
@@ -1406,7 +1323,7 @@ dependencies = [
  "log",
  "serde",
  "serde_yaml",
- "serial_test",
+ "tempfile",
  "thiserror",
  "vhost",
  "vhost-user-backend",

--- a/crates/vsock/Cargo.toml
+++ b/crates/vsock/Cargo.toml
@@ -33,4 +33,4 @@ serde_yaml = "0.9"
 
 [dev-dependencies]
 virtio-queue = { version = "0.9", features = ["test-utils"] }
-serial_test = "2.0"
+tempfile = "3.6.0"

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -348,24 +348,34 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserVsockBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use std::convert::TryInto;
+    use tempfile::tempdir;
     use vhost_user_backend::VringT;
     use vm_memory::GuestAddress;
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
 
     #[test]
-    #[serial]
     fn test_vsock_backend() {
         const CID: u64 = 3;
-        const VHOST_SOCKET_PATH: &str = "test_vsock_backend.socket";
-        const VSOCK_SOCKET_PATH: &str = "test_vsock_backend.vsock";
+
+        let test_dir = tempdir().expect("Could not create a temp test directory.");
+
+        let vhost_socket_path = test_dir
+            .path()
+            .join("test_vsock_backend.socket")
+            .display()
+            .to_string();
+        let vsock_socket_path = test_dir
+            .path()
+            .join("test_vsock_backend.vsock")
+            .display()
+            .to_string();
 
         let config = VsockConfig::new(
             CID,
-            VHOST_SOCKET_PATH.to_string(),
-            VSOCK_SOCKET_PATH.to_string(),
+            vhost_socket_path.to_string(),
+            vsock_socket_path.to_string(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -426,16 +436,28 @@ mod tests {
         assert!(!ret.unwrap());
 
         // cleanup
-        let _ = std::fs::remove_file(VHOST_SOCKET_PATH);
-        let _ = std::fs::remove_file(VSOCK_SOCKET_PATH);
+        let _ = std::fs::remove_file(vhost_socket_path);
+        let _ = std::fs::remove_file(vsock_socket_path);
+
+        test_dir.close().unwrap();
     }
 
     #[test]
-    #[serial]
     fn test_vsock_backend_failures() {
         const CID: u64 = 3;
-        const VHOST_SOCKET_PATH: &str = "test_vsock_backend_failures.socket";
-        const VSOCK_SOCKET_PATH: &str = "test_vsock_backend_failures.vsock";
+
+        let test_dir = tempdir().expect("Could not create a temp test directory.");
+
+        let vhost_socket_path = test_dir
+            .path()
+            .join("test_vsock_backend_failures.socket")
+            .display()
+            .to_string();
+        let vsock_socket_path = test_dir
+            .path()
+            .join("test_vsock_backend_failures.vsock")
+            .display()
+            .to_string();
 
         let config = VsockConfig::new(
             CID,
@@ -451,8 +473,8 @@ mod tests {
 
         let config = VsockConfig::new(
             CID,
-            VHOST_SOCKET_PATH.to_string(),
-            VSOCK_SOCKET_PATH.to_string(),
+            vhost_socket_path.to_string(),
+            vsock_socket_path.to_string(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -487,7 +509,9 @@ mod tests {
         );
 
         // cleanup
-        let _ = std::fs::remove_file(VHOST_SOCKET_PATH);
-        let _ = std::fs::remove_file(VSOCK_SOCKET_PATH);
+        let _ = std::fs::remove_file(vhost_socket_path);
+        let _ = std::fs::remove_file(vsock_socket_path);
+
+        test_dir.close().unwrap();
     }
 }

--- a/crates/vsock/src/vsock_conn.rs
+++ b/crates/vsock/src/vsock_conn.rs
@@ -355,7 +355,6 @@ mod tests {
 
     use super::*;
     use crate::vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM};
-    use serial_test::serial;
     use std::io::Result as IoResult;
     use std::ops::Deref;
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
@@ -491,7 +490,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_vsock_conn_init() {
         // new locally inititated connection
         let dummy_file = VsockDummySocket::new();
@@ -540,7 +538,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_vsock_conn_credit() {
         // new locally inititated connection
         let dummy_file = VsockDummySocket::new();
@@ -571,7 +568,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_vsock_conn_init_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 10);
@@ -608,7 +604,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_vsock_conn_recv_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);
@@ -705,7 +700,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_vsock_conn_send_pkt() {
         // parameters for packet head construction
         let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);


### PR DESCRIPTION

### Summary of the PR
vsock tests could not be run in parallel because of seemingly unrelated crashes, as reported in #232. This PR fixes the bug and also adds a dev dependency to `tempfile` and creates a unique working directory for every test that was previously serialized.

Fixes #232.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
