### PR TITLE
vhost-device-rng: add support for standalone daemons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1305,6 +1305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "vhost"
+version = "0.8.0"
+source = "git+https://github.com/stsquad/vhost?branch=standalone/get-specs#b4313a1fcfe5aaba69efedbc7142b54891db2215"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "vhost-device-gpio"
 version = "0.1.0"
 dependencies = [
@@ -1314,8 +1325,8 @@ dependencies = [
  "libgpiod",
  "log",
  "thiserror",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
@@ -1331,8 +1342,8 @@ dependencies = [
  "libc",
  "log",
  "thiserror",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
@@ -1351,8 +1362,8 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.8.0 (git+https://github.com/stsquad/vhost?branch=standalone/get-specs)",
+ "vhost-user-backend 0.10.0 (git+https://github.com/stsquad/vhost?branch=standalone/get-specs)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
@@ -1370,8 +1381,8 @@ dependencies = [
  "num_enum",
  "tempfile",
  "thiserror",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
@@ -1386,7 +1397,21 @@ checksum = "e3ea9d5e8ec847cde4df1c04e586698a479706fd6beca37323f9d425b24b4c2f"
 dependencies = [
  "libc",
  "log",
- "vhost",
+ "vhost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-user-backend"
+version = "0.10.0"
+source = "git+https://github.com/stsquad/vhost?branch=standalone/get-specs#b4313a1fcfe5aaba69efedbc7142b54891db2215"
+dependencies = [
+ "libc",
+ "log",
+ "vhost 0.8.0 (git+https://github.com/stsquad/vhost?branch=standalone/get-specs)",
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
@@ -1408,8 +1433,8 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "thiserror",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vhost-user-backend 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-bindings",
  "virtio-queue",
  "virtio-vsock",

--- a/crates/rng/Cargo.toml
+++ b/crates/rng/Cargo.toml
@@ -21,8 +21,13 @@ log = "0.4"
 rand = "0.8.5"
 tempfile = "3.5"
 thiserror = "1.0"
-vhost = { version = "0.8", features = ["vhost-user-slave"] }
-vhost-user-backend = "0.10"
+# vhost = { version = "0.8", features = ["vhost-user-slave"] }
+# vhost-user-backend = "0.10"
+# vhost = { path = "../../../vhost.git/crates/vhost/" }
+# vhost-user-backend = { path = "../../../vhost.git/crates/vhost-user-backend/" }
+vhost = { git = "https://github.com/stsquad/vhost", branch = "standalone/get-specs" }
+vhost-user-backend = { git = "https://github.com/stsquad/vhost", branch = "standalone/get-specs" }
+
 virtio-bindings = "0.2.1"
 virtio-queue = "0.9"
 vm-memory = "0.12"


### PR DESCRIPTION
This is fairly simple for the backend we just need to implement the specs message. The handling of GET/SET_STATUS is done by vhost internals.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
