### PR TITLE
crates: Don't warn for vhost_user::Error::Disconnected

### DIFF
--- a/crates/gpio/src/backend.rs
+++ b/crates/gpio/src/backend.rs
@@ -173,7 +173,7 @@ fn start_backend<D: 'static + GpioDevice + Send + Sync>(args: GpioArgs) -> Resul
                     info!("Stopping cleanly.");
                 }
                 Err(vhost_user_backend::Error::HandleRequest(
-                    vhost_user::Error::PartialMessage,
+                    vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
                 )) => {
                     info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
                 }

--- a/crates/i2c/src/main.rs
+++ b/crates/i2c/src/main.rs
@@ -215,7 +215,7 @@ fn start_backend<D: 'static + I2cDevice + Send + Sync>(args: I2cArgs) -> Result<
                     info!("Stopping cleanly.");
                 }
                 Err(vhost_user_backend::Error::HandleRequest(
-                    vhost_user::Error::PartialMessage,
+                    vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
                 )) => {
                     info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
                 }

--- a/crates/rng/src/main.rs
+++ b/crates/rng/src/main.rs
@@ -139,7 +139,7 @@ pub(crate) fn start_backend(config: VuRngConfig) -> Result<()> {
                     info!("Stopping cleanly.");
                 }
                 Err(vhost_user_backend::Error::HandleRequest(
-                    vhost_user::Error::PartialMessage,
+                    vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
                 )) => {
                     info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
                 }

--- a/crates/scsi/src/main.rs
+++ b/crates/scsi/src/main.rs
@@ -108,7 +108,9 @@ fn start_backend(backend: VhostUserScsiBackend, args: ScsiArgs) -> Result<()> {
         Ok(()) => {
             info!("Stopping cleanly.");
         }
-        Err(vhost_user_backend::Error::HandleRequest(vhost_user::Error::PartialMessage)) => {
+        Err(vhost_user_backend::Error::HandleRequest(
+            vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
+        )) => {
             info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
         }
         Err(e) => {

--- a/crates/vsock/src/main.rs
+++ b/crates/vsock/src/main.rs
@@ -224,7 +224,9 @@ pub(crate) fn start_backend_server(
             Ok(()) => {
                 info!("Stopping cleanly");
             }
-            Err(vhost_user_backend::Error::HandleRequest(vhost_user::Error::PartialMessage)) => {
+            Err(vhost_user_backend::Error::HandleRequest(
+                vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
+            )) => {
                 info!("vhost-user connection closed with partial message. If the VM is shutting down, this is expected behavior; otherwise, it might be a bug.");
             }
             Err(e) => {


### PR DESCRIPTION
The vhost_user::Error::Disconnected error code is returned by the daemon if the VM is shutting down. Don't Warn the user in this case but just point out that VM may be shutting down.

