### PR TITLE
README: add reference to the scsi device

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Here is the list of device backends that we support:
 - [GPIO](https://github.com/rust-vmm/vhost-device/blob/main/crates/gpio/README.md)
 - [I2C](https://github.com/rust-vmm/vhost-device/blob/main/crates/i2c/README.md)
 - [RNG](https://github.com/rust-vmm/vhost-device/blob/main/crates/rng/README.md)
+- [SCSI](https://github.com/rust-vmm/vhost-device/blob/main/crates/scsi/README.md)
 - [VSOCK](https://github.com/rust-vmm/vhost-device/blob/main/crates/vsock/README.md)
 
 ## Testing and Code Coverage


### PR DESCRIPTION
When we merged the SCSI device, we forgot to put it in the workspace README.md and put the link to the device README.md.