### PR TITLE
vsock: Increase NUM_QUEUES to 3

### DIFF
--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -37,10 +37,12 @@ const TX_QUEUE_EVENT: u16 = 1;
 const EVT_QUEUE_EVENT: u16 = 2;
 
 /// Notification coming from the backend.
-pub(crate) const BACKEND_EVENT: u16 = 3;
+/// Event range [0...num_queues] is reserved for queues and exit event.
+/// So NUM_QUEUES + 1 is used.
+pub(crate) const BACKEND_EVENT: u16 = (NUM_QUEUES + 1) as u16;
 
 /// Notification coming from the sibling VM.
-pub(crate) const SIBLING_VM_EVENT: u16 = 4;
+pub(crate) const SIBLING_VM_EVENT: u16 = BACKEND_EVENT + 1;
 
 /// CID of the host
 pub(crate) const VSOCK_HOST_CID: u64 = 2;

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -297,7 +297,9 @@ impl VhostUserBackend<VringRwLock, ()> for VhostUserVsockBackend {
             TX_QUEUE_EVENT => {
                 thread.process_tx(vring_tx, evt_idx)?;
             }
-            EVT_QUEUE_EVENT => {}
+            EVT_QUEUE_EVENT => {
+                warn!("Received an unexpected EVT_QUEUE_EVENT");
+            }
             BACKEND_EVENT => {
                 thread.process_backend_evt(evset);
                 if let Err(e) = thread.process_tx(vring_tx, evt_idx) {

--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -26,7 +26,7 @@ use crate::vhu_vsock_thread::*;
 
 pub(crate) type CidMap = HashMap<u64, (Arc<RwLock<RawPktsQ>>, EventFd)>;
 
-const NUM_QUEUES: usize = 2;
+const NUM_QUEUES: usize = 3;
 const QUEUE_SIZE: usize = 256;
 
 // New descriptors pending on the rx queue


### PR DESCRIPTION
In virtio standard, vsock uses 3 vqs(https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-4380002), and crosvm and qemu also uses 3 queues, but this vhost-user-vsock device implementation assumes that there are only 2 vqs, and it causes the problem with crosvm. (at least)

Fixes #408 