### PR TITLE
vsock: always epoll_register with cloned stream fd

### DIFF
--- a/crates/vsock/src/thread_backend.rs
+++ b/crates/vsock/src/thread_backend.rs
@@ -290,10 +290,6 @@ impl VsockThreadBackend {
         stream: UnixStream,
         pkt: &VsockPacket<B>,
     ) -> Result<()> {
-        let stream_fd = stream.as_raw_fd();
-        self.listener_map
-            .insert(stream_fd, ConnMapKey::new(pkt.dst_port(), pkt.src_port()));
-
         let conn = VsockConnection::new_peer_init(
             stream.try_clone().map_err(Error::UnixConnect)?,
             pkt.dst_cid(),
@@ -304,6 +300,9 @@ impl VsockThreadBackend {
             pkt.buf_alloc(),
             self.tx_buffer_size,
         );
+        let stream_fd = conn.stream.as_raw_fd();
+        self.listener_map
+            .insert(stream_fd, ConnMapKey::new(pkt.dst_port(), pkt.src_port()));
 
         self.conn_map
             .insert(ConnMapKey::new(pkt.dst_port(), pkt.src_port()), conn);


### PR DESCRIPTION
VsockConnection::stream which is cloned is always used for
epoll_register, except add_new_guest_conn. Only in add_new_guest_conn,
the original stream is used.

Because a stream's raw fd is used for the key of listener_map, it cannot
find proper listener after the first packet.


Fixes #407 