### PR TITLE
Add scmi-vhost-user

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1260,7 @@ dependencies = [
  "assert_matches",
  "clap",
  "env_logger",
+ "itertools",
  "log",
  "thiserror",
  "vhost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "vhost-device-scmi"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "clap",
+ "env_logger",
+ "log",
+ "thiserror",
+ "vhost",
+ "vhost-user-backend",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "vhost-device-scsi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,6 @@ members = [
     "crates/i2c",
     "crates/rng",
     "crates/scsi",
+    "crates/scmi",
     "crates/vsock",
 ]

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 68.2,
+  "coverage_score": 71.0,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/scmi/CHANGELOG.md
+++ b/crates/scmi/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+## [0.1.0]
+
+First release
+

--- a/crates/scmi/Cargo.toml
+++ b/crates/scmi/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "vhost-device-scmi"
+version = "0.1.0"
+authors = ["Milan Zamazal <mzamazal@redhat.com>"]
+description = "vhost-user SCMI backend device"
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["scmi", "vhost", "virt", "backend"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.3",  features = ["derive"] }
+env_logger = "0.10"
+log = "0.4"
+thiserror = "1.0"
+vhost = { version = "0.8", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.10"
+virtio-bindings = "0.2"
+virtio-queue = "0.9"
+vm-memory = "0.12"
+vmm-sys-util = "0.11"
+
+[dev-dependencies]
+assert_matches = "1.5"
+virtio-queue = { version = "0.9", features = ["test-utils"] }

--- a/crates/scmi/Cargo.toml
+++ b/crates/scmi/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3",  features = ["derive"] }
 env_logger = "0.10"
+itertools = "0.10"
 log = "0.4"
 thiserror = "1.0"
 vhost = { version = "0.8", features = ["vhost-user-slave"] }

--- a/crates/scmi/LICENSE-APACHE
+++ b/crates/scmi/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/scmi/LICENSE-BSD-3-Clause
+++ b/crates/scmi/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -30,6 +30,7 @@ the Examples section below.
   Can be used multiple times for multiple exposed devices.
   If no device is specified then no device will be provided to the
   guest OS but VirtIO SCMI will be still available there.
+  Use `help` as the device ID to list help on all the available devices.
 
 You can set `RUST_LOG` environment variable to `debug` to get maximum
 messages on the standard error output.

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -67,6 +67,9 @@ The currently supported SCMI protocols are:
 Basically only the mandatory and necessary parts of the protocols are
 implemented.
 
+See source code (`scmi` crate) documentation for details and how to
+add more protocols, host device bindings or other functionality.
+
 ## Kernel support for testing
 
 `kernel` subdirectory contains

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -8,14 +8,6 @@ It is tested with QEMU's `-device vhost-user-scmi-pci` but should work
 with any virtual machine monitor (VMM) that supports vhost-user. See
 the Examples section below.
 
-The currently supported SCMI protocols are:
-
-- base protocol
-
-The currently supported SCMI connections on the host are:
-
-- none
-
 ## Synopsis
 
 **vhost-device-scmi** [*OPTIONS*]
@@ -55,6 +47,16 @@ use to communicate as well as share the guests memory over a memfd:
       -m 4096 \
       -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on \
       ...
+
+## Supported SCMI protocols
+
+The currently supported SCMI protocols are:
+
+- base
+- sensor management
+
+Basically only the mandatory and necessary parts of the protocols are
+implemented.
 
 ## License
 

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -1,0 +1,64 @@
+# vhost-device-scmi
+
+This program is a vhost-user backend for a VirtIO SCMI device.
+It provides SCMI access to various entities on the host; not
+necessarily only those providing an SCMI interface themselves.
+
+It is tested with QEMU's `-device vhost-user-scmi-pci` but should work
+with any virtual machine monitor (VMM) that supports vhost-user. See
+the Examples section below.
+
+The currently supported SCMI protocols are:
+
+- base protocol
+
+The currently supported SCMI connections on the host are:
+
+- none
+
+## Synopsis
+
+**vhost-device-scmi** [*OPTIONS*]
+
+## Options
+
+.. program:: vhost-device-scmi
+
+.. option:: -h, --help
+
+  Print help.
+
+.. option:: -s, --socket-path=PATH
+
+  Location of the vhost-user Unix domain sockets.
+
+You can set `RUST_LOG` environment variable to `debug` to get maximum
+messages on the standard error output.
+
+## Examples
+
+The daemon should be started first:
+
+::
+
+  host# vhost-device-scmi --socket-path=scmi.sock
+
+The QEMU invocation needs to create a chardev socket the device can
+use to communicate as well as share the guests memory over a memfd:
+
+::
+
+  host# qemu-system \
+      -chardev socket,path=scmi.sock,id=scmi \
+      -device vhost-user-scmi-pci,chardev=vscmi,id=scmi \
+      -machine YOUR-MACHINE-OPTIONS,memory-backend=mem \
+      -m 4096 \
+      -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on \
+      ...
+
+## License
+
+This project is licensed under either of
+
+- [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0
+- [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -65,9 +65,17 @@ The currently supported SCMI protocols are:
 Basically only the mandatory and necessary parts of the protocols are
 implemented.
 
+## Kernel support for testing
+
+`kernel` subdirectory contains
+[instructions](kernel/iio-dummy/README.md) how to create emulated
+industrial I/O devices for testing.
+
 ## License
 
 This project is licensed under either of
 
 - [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0
 - [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)
+
+unless specified in particular files otherwise.

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -24,6 +24,13 @@ the Examples section below.
 
   Location of the vhost-user Unix domain sockets.
 
+.. option:: -d, --device=SPEC
+
+  SCMI device specification in the format `ID,PROPERTY=VALUE,...`.
+  Can be used multiple times for multiple exposed devices.
+  If no device is specified then no device will be provided to the
+  guest OS but VirtIO SCMI will be still available there.
+
 You can set `RUST_LOG` environment variable to `debug` to get maximum
 messages on the standard error output.
 
@@ -33,7 +40,7 @@ The daemon should be started first:
 
 ::
 
-  host# vhost-device-scmi --socket-path=scmi.sock
+  host# vhost-device-scmi --socket-path=scmi.sock --device fake,name=foo
 
 The QEMU invocation needs to create a chardev socket the device can
 use to communicate as well as share the guests memory over a memfd:

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -31,7 +31,7 @@ the Examples section below.
   Can be used multiple times for multiple exposed devices.
   If no device is specified then no device will be provided to the
   guest OS but VirtIO SCMI will be still available there.
-  Use `help` as the device ID to list help on all the available devices.
+  Use `--help-devices` to list help on all the available devices.
 
 You can set `RUST_LOG` environment variable to `debug` to get maximum
 messages on the standard error output.

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -70,7 +70,25 @@ implemented.
 See source code (`scmi` crate) documentation for details and how to
 add more protocols, host device bindings or other functionality.
 
-## Kernel support for testing
+## Testing
+
+SCMI is supported only on Arm in Linux.  This restriction doesn't
+apply to the host, which can be any architecture as long as the guest
+is Arm.
+
+The easiest way to test it on the guest side is using the Linux SCMI
+Industrial I/O driver there.  If an 3-axes accelerometer or gyroscope
+VirtIO SCMI device is present and the guest kernel is compiled with
+`CONFIG_IIO_SCMI` enabled then the device should be available in
+`/sys/bus/iio/devices/`.  The vhost-device-scmi fake device is
+suitable for this.
+
+Of course, other means of accessing SCMI devices can be used too.  The
+following Linux kernel command line can be useful to obtain SCMI trace
+information, in addition to SCMI related messages in dmesg:
+`trace_event=scmi:* ftrace=function ftrace_filter=scmi*`.
+
+### Kernel support for testing
 
 `kernel` subdirectory contains
 [instructions](kernel/iio-dummy/README.md) how to create emulated

--- a/crates/scmi/README.md
+++ b/crates/scmi/README.md
@@ -26,7 +26,8 @@ the Examples section below.
 
 .. option:: -d, --device=SPEC
 
-  SCMI device specification in the format `ID,PROPERTY=VALUE,...`.
+  SCMI device specification in the format `ID,PROPERTY=VALUE,...`.  
+  For example: `-d iio,path=/sys/bus/iio/devices/iio:device0,channel=in_accel`.  
   Can be used multiple times for multiple exposed devices.
   If no device is specified then no device will be provided to the
   guest OS but VirtIO SCMI will be still available there.

--- a/crates/scmi/kernel/iio-dummy/.gitignore
+++ b/crates/scmi/kernel/iio-dummy/.gitignore
@@ -1,0 +1,7 @@
+*.cmd
+*.ko
+*.mod
+*.mod.[co]
+*.o
+Module.symvers
+modules.order

--- a/crates/scmi/kernel/iio-dummy/Makefile
+++ b/crates/scmi/kernel/iio-dummy/Makefile
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for the IIO Dummy Driver
+#
+# Modified by Milan Zamazal <mzamazal@redhat.com> in 2023 for out of
+# tree compilation.
+#
+
+obj-m += iio_modified_dummy.o
+
+on_nixos = $(wildcard /etc/NIXOS)
+ifeq ($(on_nixos), /etc/NIXOS)
+nix_prefix = $(shell nix-build -E '(import <nixpkgs> {}).linux.dev' --no-out-link)
+endif
+
+all:
+	make -C $(nix_prefix)/lib/modules/$(shell uname -r)/build M=$(PWD) modules
+clean:
+	make -C $(nix_prefix)/lib/modules/$(shell uname -r)/build M=$(PWD) clean

--- a/crates/scmi/kernel/iio-dummy/README.md
+++ b/crates/scmi/kernel/iio-dummy/README.md
@@ -1,0 +1,184 @@
+# Using emulated industrial I/O devices
+
+This is a modified version of the Linux [industrial I/O dummy
+driver](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/iio/dummy).
+Both the original driver and this modification can provide emulated
+industrial I/O devices for testing vhost-device-scmi.
+
+## Modifications in this module
+
+If the stock industrial I/O dummy driver is enough for you, use it
+(but you may still want to read the instructions below).
+
+Otherwise, this alternative is provided with the following changes:
+
+- Simplified Makefile for out of tree compilation.
+- The accelerometer has three axes instead of just one.
+
+Of course, you can modified it further for your liking if needed.
+
+## How to create emulated industrial I/O devices
+
+Make sure your kernel supports software industrial I/O devices and
+industrial I/O with configfs.  You can check this by running `modprobe
+industrialio_sw_device && modprobe industrialio_configfs`.  If any of
+the modules is not present, follow the [instructions for recompiling
+kernel](#recompiling-kernel-with-industrial-io) below.
+
+Make sure you have the right kernel version.  Since Linux 5.19, the
+dummy industrial I/O driver is broken.  This will be probably fixed in
+Linux 6.6.
+
+If you have a broken kernel version, apply the
+[fix](./iio-dummy-fix.patch) and compile and install the modified
+kernel.
+
+If you want to use the modified module from here, compile it.  In
+order to do this, you must have kernel development environment
+installed, for example:
+
+- Fedora or derivatives: `dnf install kernel-devel kernel-modules make`
+- Debian or derivatives: `apt install linux-headers-$(uname -r) make`
+- NixOS: `nix-shell '<nixpkgs>' -A linux.dev`
+
+Then you can compile the module, simply running `make` should work on
+most distributions.
+
+Insert a dummy industrial I/O kernel module.  Either the stock one:
+
+```
+# modprobe iio-dummy
+```
+
+or the modified one from here:
+
+```
+# modprobe industrialio
+# modprobe industrialio_configfs
+# modprobe industrialio_sw_device
+# insmod ./iio-dummy-modified.ko
+```
+
+Find out where configfs is mounted: `mount | grep configfs`.  It's
+typically `/sys/kernel/config`.  If configfs is not mounted, mount it
+somewhere: `mount -t configfs none MOUNTPOINT`.
+
+Now you can create emulated industrial I/O devices with the stock driver:
+
+```
+# mkdir /sys/kernel/config/iio/devices/dummy/my-device
+```
+
+And/or with the modified driver from here:
+
+```
+# mkdir /sys/kernel/config/iio/devices/dummy-modified/my-device
+```
+
+If everything is OK then you can find the device in
+`/sys/bus/iio/devices/`.
+
+## Recompiling kernel with industrial I/O
+
+Making a custom kernel is different on each GNU/Linux distribution.
+The corresponding documentation can be found for example here:
+
+- Fedora: [https://fedoraproject.org/wiki/Building_a_custom_kernel](https://fedoraproject.org/wiki/Building_a_custom_kernel)
+- CentOS Stream: [https://wiki.centos.org/HowTos/BuildingKernelModules](https://wiki.centos.org/HowTos/BuildingKernelModules)
+  (looks more useful for Fedora builds than CentOS)
+- Debian: [https://kernel-team.pages.debian.net/kernel-handbook/ch-common-tasks.html#s-common-official](https://kernel-team.pages.debian.net/kernel-handbook/ch-common-tasks.html#s-common-official)
+- NixOS: [https://nixos.wiki/wiki/Linux_kernel](https://nixos.wiki/wiki/Linux_kernel)
+
+Here are instructions for Fedora, similar steps can be used for other
+distributions, with distribution specifics as described in the links
+above.  This is not necessarily the most official or the best way to
+do it but it's a way that *actually works* for me.
+
+Note on CentOS Stream 9: The kernel there doesn't contain the needed
+modules.  Recompiling the kernel on CentOS Stream may be challenging
+due to missing build dependencies.  If it doesn't work for you, you
+can try to use Fedora kernel and modules on CentOS Stream, including
+the dummy module compiled on Fedora.
+
+### Install kernel sources
+
+```
+# dnf install 'dnf-command(download)'
+$ dnf download --source kernel
+$ rpm -i kernel-*.src.rpm
+# dnf builddep ~/rpmbuild/SPECS/kernel.spec
+```
+
+### Change kernel configuration
+
+Not needed for current Fedora but may be needed for e.g. CentOS Stream.
+
+```
+# dnf install kernel-devel kernel-modules make rpm-build python3-devel ncurses-devel
+$ rpmbuild -bp ~/rpmbuild/SPECS/kernel.spec
+$ cd ~/rpmbuild/BUILD/kernel-*/linux-*/
+$ cp configs/kernel-VERSION-YOURARCH.config .config
+$ make nconfig
+```
+
+Configuration options that must be enabled:
+
+- Device Drivers -> Industrial I/O Support -> Enable IIO configuration via configfs
+- Device Drivers -> Industrial I/O Support -> Enable software IIO device support
+
+Optionally (you can use the alternative driver from here instead):
+
+- Device Drivers -> Industrial I/O Support -> IIO dummy drive -> An example driver with no hardware requirements
+
+Then copy `.config` back to its original file and don't forget to add
+the original architecture specification line there.
+
+### Apply the kernel fix
+
+If the kernel fix from here is needed, copy it to the sources:
+
+```
+cp .../iio-dummy-fix.patch ~/rpmbuild/SOURCES/
+```
+
+Edit `~/rpmbuild/SPECS/kernel.spec`:
+
+- Uncomment: `%define buildid .local`.
+
+- Add the patch file before: `Patch999999: linux-kernel-test.patch`.
+
+- Add the patch file before: `ApplyOptionalPatch linux-kernel-test.patch`.
+
+### Build the kernel
+
+You can use different options, if you don't need anything extra then
+the following builds the most important rpm's:
+
+```
+$ rpmbuild -bb --with baseonly --without debug --without debuginfo ~/rpmbuild/SPECS/kernel.spec
+```
+
+## Adding industrial I/O dummy module to your kernel
+
+If all you need is to add a missing stock I/O dummy module, you can
+try to compile just the module.  Switch to kernel sources and run:
+
+```
+$ make oldconfig
+$ make prepare
+$ make modules_prepare
+$ make M=drivers/iio/dummy
+```
+
+And insert the module:
+
+```
+# modprobe industrialio
+# modprobe industrialio_configfs
+# modprobe industrialio_sw_device
+# insmod ./drivers/iio/dummy/iio-dummy.ko
+```
+
+If this fails, inspect `dmesg` output and try to figure out what's
+wrong.  If this fails too, rebuild the whole kernel with the given
+module enabled.

--- a/crates/scmi/kernel/iio-dummy/README.md
+++ b/crates/scmi/kernel/iio-dummy/README.md
@@ -14,6 +14,7 @@ Otherwise, this alternative is provided with the following changes:
 
 - Simplified Makefile for out of tree compilation.
 - The accelerometer has three axes instead of just one.
+- The Y axis of the accelerometer has offset and scale.
 
 Of course, you can modified it further for your liking if needed.
 

--- a/crates/scmi/kernel/iio-dummy/iio-dummy-fix.patch
+++ b/crates/scmi/kernel/iio-dummy/iio-dummy-fix.patch
@@ -1,0 +1,55 @@
+Commit 813665564b3d ("iio: core: Convert to use firmware node handle
+instead of OF node") switched the kind of nodes to use for label
+retrieval in device registration.  Probably an unwanted change in that
+commit was that if the device has no parent then NULL pointer is
+accessed.  This is what happens in the stock IIO dummy driver when a
+new entry is created in configfs:
+
+  # mkdir /sys/kernel/config/iio/devices/dummy/foo
+  BUG: kernel NULL pointer dereference, address: ...
+  ...
+  Call Trace:
+  __iio_device_register
+  iio_dummy_probe
+
+Since there seems to be no reason to make a parent device of an IIO
+dummy device mandatory, let’s prevent the invalid memory access in
+__iio_device_register when the parent device is NULL.  With this
+change, the IIO dummy driver works fine with configfs.
+
+Fixes: 813665564b3d ("iio: core: Convert to use firmware node handle instead of OF node")
+Reviewed-by: Andy Shevchenko <andriy.shevchenko-VuQAYsv1563Yd54FQh9/CA@public.gmane.org>
+Signed-off-by: Milan Zamazal <mzamazal-H+wXaHxf7aLQT0dZR+AlfA@public.gmane.org>
+---
+ drivers/iio/industrialio-core.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/iio/industrialio-core.c b/drivers/iio/industrialio-core.c
+index c117f50d0cf3..adcba832e6fa 100644
+--- a/drivers/iio/industrialio-core.c
++++ b/drivers/iio/industrialio-core.c
+@@ -1888,7 +1888,7 @@ static const struct iio_buffer_setup_ops noop_ring_setup_ops;
+ int __iio_device_register(struct iio_dev *indio_dev, struct module *this_mod)
+ {
+ 	struct iio_dev_opaque *iio_dev_opaque = to_iio_dev_opaque(indio_dev);
+-	struct fwnode_handle *fwnode;
++	struct fwnode_handle *fwnode = NULL;
+ 	int ret;
+ 
+ 	if (!indio_dev->info)
+@@ -1899,7 +1899,8 @@ int __iio_device_register(struct iio_dev *indio_dev, struct module *this_mod)
+ 	/* If the calling driver did not initialize firmware node, do it here */
+ 	if (dev_fwnode(&indio_dev->dev))
+ 		fwnode = dev_fwnode(&indio_dev->dev);
+-	else
++	/* The default dummy IIO device has no parent */
++	else if (indio_dev->dev.parent)
+ 		fwnode = dev_fwnode(indio_dev->dev.parent);
+ 	device_set_node(&indio_dev->dev, fwnode);
+ 
+-- 
+
+2.40.1
+
+
+

--- a/crates/scmi/kernel/iio-dummy/iio_modified_dummy.c
+++ b/crates/scmi/kernel/iio-dummy/iio_modified_dummy.c
@@ -16,6 +16,7 @@
  *
  * - Dropped conditional parts.
  * - Use 3 axes in the accelerometer device.
+ * - Define offset and scale for some of the accelerometer axes.
  */
 #include <linux/kernel.h>
 #include <linux/slab.h>
@@ -184,6 +185,9 @@ static const struct iio_chan_spec iio_dummy_channels[] = {
 		/* Channel 2 is use for modifiers */
 		.channel2 = IIO_MOD_Y,
 		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+		BIT(IIO_CHAN_INFO_RAW) |
+		BIT(IIO_CHAN_INFO_OFFSET) |
+		BIT(IIO_CHAN_INFO_SCALE) |
 		BIT(IIO_CHAN_INFO_CALIBSCALE) |
 		BIT(IIO_CHAN_INFO_CALIBBIAS),
 		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
@@ -352,6 +356,15 @@ static int iio_dummy_read_raw(struct iio_dev *indio_dev,
 				*val2 = 1344;
 				ret = IIO_VAL_INT_PLUS_NANO;
 			}
+                        break;
+		case IIO_ACCEL:
+			switch(chan->scan_index) {
+			case DUMMY_INDEX_ACCEL_Y:
+                        	*val = 0;
+				*val2 = 1344;
+				break;
+			}
+			ret = IIO_VAL_INT_PLUS_MICRO;
 			break;
 		default:
 			break;

--- a/crates/scmi/kernel/iio-dummy/iio_modified_dummy.c
+++ b/crates/scmi/kernel/iio-dummy/iio_modified_dummy.c
@@ -1,0 +1,693 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2011 Jonathan Cameron
+ *
+ * A reference industrial I/O driver to illustrate the functionality available.
+ *
+ * There are numerous real drivers to illustrate the finer points.
+ * The purpose of this driver is to provide a driver with far more comments
+ * and explanatory notes than any 'real' driver would have.
+ * Anyone starting out writing an IIO driver should first make sure they
+ * understand all of this driver except those bits specifically marked
+ * as being present to allow us to 'fake' the presence of hardware.
+ *
+ * Changes by Milan Zamazal <mzamazal@redhat.com> 2023, for testing
+ * with vhost-device-scmi:
+ *
+ * - Dropped conditional parts.
+ * - Use 3 axes in the accelerometer device.
+ */
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/module.h>
+#include <linux/string.h>
+
+#include <linux/iio/iio.h>
+#include <linux/iio/sysfs.h>
+#include <linux/iio/events.h>
+#include <linux/iio/buffer.h>
+#include <linux/iio/sw_device.h>
+#include "iio_modified_dummy.h"
+
+static const struct config_item_type iio_dummy_type = {
+	.ct_owner = THIS_MODULE,
+};
+
+/**
+ * struct iio_dummy_accel_calibscale - realworld to register mapping
+ * @val: first value in read_raw - here integer part.
+ * @val2: second value in read_raw etc - here micro part.
+ * @regval: register value - magic device specific numbers.
+ */
+struct iio_dummy_accel_calibscale {
+	int val;
+	int val2;
+	int regval; /* what would be written to hardware */
+};
+
+static const struct iio_dummy_accel_calibscale dummy_scales[] = {
+	{ 0, 100, 0x8 }, /* 0.000100 */
+	{ 0, 133, 0x7 }, /* 0.000133 */
+	{ 733, 13, 0x9 }, /* 733.000013 */
+};
+
+/*
+ * iio_dummy_channels - Description of available channels
+ *
+ * This array of structures tells the IIO core about what the device
+ * actually provides for a given channel.
+ */
+static const struct iio_chan_spec iio_dummy_channels[] = {
+	/* indexed ADC channel in_voltage0_raw etc */
+	{
+		.type = IIO_VOLTAGE,
+		/* Channel has a numeric index of 0 */
+		.indexed = 1,
+		.channel = 0,
+		/* What other information is available? */
+		.info_mask_separate =
+		/*
+		 * in_voltage0_raw
+		 * Raw (unscaled no bias removal etc) measurement
+		 * from the device.
+		 */
+		BIT(IIO_CHAN_INFO_RAW) |
+		/*
+		 * in_voltage0_offset
+		 * Offset for userspace to apply prior to scale
+		 * when converting to standard units (microvolts)
+		 */
+		BIT(IIO_CHAN_INFO_OFFSET) |
+		/*
+		 * in_voltage0_scale
+		 * Multipler for userspace to apply post offset
+		 * when converting to standard units (microvolts)
+		 */
+		BIT(IIO_CHAN_INFO_SCALE),
+		/*
+		 * sampling_frequency
+		 * The frequency in Hz at which the channels are sampled
+		 */
+		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
+		/* The ordering of elements in the buffer via an enum */
+		.scan_index = DUMMY_INDEX_VOLTAGE_0,
+		.scan_type = { /* Description of storage in buffer */
+			.sign = 'u', /* unsigned */
+			.realbits = 13, /* 13 bits */
+			.storagebits = 16, /* 16 bits used for storage */
+			.shift = 0, /* zero shift */
+		},
+	},
+	/* Differential ADC channel in_voltage1-voltage2_raw etc*/
+	{
+		.type = IIO_VOLTAGE,
+		.differential = 1,
+		/*
+		 * Indexing for differential channels uses channel
+		 * for the positive part, channel2 for the negative.
+		 */
+		.indexed = 1,
+		.channel = 1,
+		.channel2 = 2,
+		/*
+		 * in_voltage1-voltage2_raw
+		 * Raw (unscaled no bias removal etc) measurement
+		 * from the device.
+		 */
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		/*
+		 * in_voltage-voltage_scale
+		 * Shared version of scale - shared by differential
+		 * input channels of type IIO_VOLTAGE.
+		 */
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),
+		/*
+		 * sampling_frequency
+		 * The frequency in Hz at which the channels are sampled
+		 */
+		.scan_index = DUMMY_INDEX_DIFFVOLTAGE_1M2,
+		.scan_type = { /* Description of storage in buffer */
+			.sign = 's', /* signed */
+			.realbits = 12, /* 12 bits */
+			.storagebits = 16, /* 16 bits used for storage */
+			.shift = 0, /* zero shift */
+		},
+	},
+	/* Differential ADC channel in_voltage3-voltage4_raw etc*/
+	{
+		.type = IIO_VOLTAGE,
+		.differential = 1,
+		.indexed = 1,
+		.channel = 3,
+		.channel2 = 4,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_SCALE),
+		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
+		.scan_index = DUMMY_INDEX_DIFFVOLTAGE_3M4,
+		.scan_type = {
+			.sign = 's',
+			.realbits = 11,
+			.storagebits = 16,
+			.shift = 0,
+		},
+	},
+	/*
+	 * 'modified' (i.e. axis specified) acceleration channel
+	 * in_accel_[xyz]_raw
+	 */
+	{
+		.type = IIO_ACCEL,
+		.modified = 1,
+		/* Channel 2 is use for modifiers */
+		.channel2 = IIO_MOD_X,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+		/*
+		 * Internal bias and gain correction values. Applied
+		 * by the hardware or driver prior to userspace
+		 * seeing the readings. Typically part of hardware
+		 * calibration.
+		 */
+		BIT(IIO_CHAN_INFO_CALIBSCALE) |
+		BIT(IIO_CHAN_INFO_CALIBBIAS),
+		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
+		.scan_index = DUMMY_INDEX_ACCEL_X,
+		.scan_type = { /* Description of storage in buffer */
+			.sign = 's', /* signed */
+			.realbits = 16, /* 16 bits */
+			.storagebits = 16, /* 16 bits used for storage */
+			.shift = 0, /* zero shift */
+		},
+	},
+	{
+		.type = IIO_ACCEL,
+		.modified = 1,
+		/* Channel 2 is use for modifiers */
+		.channel2 = IIO_MOD_Y,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+		BIT(IIO_CHAN_INFO_CALIBSCALE) |
+		BIT(IIO_CHAN_INFO_CALIBBIAS),
+		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
+		.scan_index = DUMMY_INDEX_ACCEL_Y,
+		.scan_type = { /* Description of storage in buffer */
+			.sign = 's', /* signed */
+			.realbits = 16, /* 16 bits */
+			.storagebits = 16, /* 16 bits used for storage */
+			.shift = 0, /* zero shift */
+		},
+	},
+	{
+		.type = IIO_ACCEL,
+		.modified = 1,
+		/* Channel 2 is use for modifiers */
+		.channel2 = IIO_MOD_Z,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW) |
+		BIT(IIO_CHAN_INFO_CALIBSCALE) |
+		BIT(IIO_CHAN_INFO_CALIBBIAS),
+		.info_mask_shared_by_dir = BIT(IIO_CHAN_INFO_SAMP_FREQ),
+		.scan_index = DUMMY_INDEX_ACCEL_Z,
+		.scan_type = { /* Description of storage in buffer */
+			.sign = 's', /* signed */
+			.realbits = 16, /* 16 bits */
+			.storagebits = 16, /* 16 bits used for storage */
+			.shift = 0, /* zero shift */
+		},
+	},
+	/*
+	 * Convenience macro for timestamps. 4 is the index in
+	 * the buffer.
+	 */
+	IIO_CHAN_SOFT_TIMESTAMP(4),
+	/* DAC channel out_voltage0_raw */
+	{
+		.type = IIO_VOLTAGE,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_RAW),
+		.scan_index = -1, /* No buffer support */
+		.output = 1,
+		.indexed = 1,
+		.channel = 0,
+	},
+	{
+		.type = IIO_STEPS,
+		.info_mask_shared_by_type = BIT(IIO_CHAN_INFO_ENABLE) |
+			BIT(IIO_CHAN_INFO_CALIBHEIGHT),
+		.info_mask_separate = BIT(IIO_CHAN_INFO_PROCESSED),
+		.scan_index = -1, /* No buffer support */
+	},
+	{
+		.type = IIO_ACTIVITY,
+		.modified = 1,
+		.channel2 = IIO_MOD_RUNNING,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_PROCESSED),
+		.scan_index = -1, /* No buffer support */
+	},
+	{
+		.type = IIO_ACTIVITY,
+		.modified = 1,
+		.channel2 = IIO_MOD_WALKING,
+		.info_mask_separate = BIT(IIO_CHAN_INFO_PROCESSED),
+		.scan_index = -1, /* No buffer support */
+	},
+};
+
+/**
+ * iio_dummy_read_raw() - data read function.
+ * @indio_dev:	the struct iio_dev associated with this device instance
+ * @chan:	the channel whose data is to be read
+ * @val:	first element of returned value (typically INT)
+ * @val2:	second element of returned value (typically MICRO)
+ * @mask:	what we actually want to read as per the info_mask_*
+ *		in iio_chan_spec.
+ */
+static int iio_dummy_read_raw(struct iio_dev *indio_dev,
+			      struct iio_chan_spec const *chan,
+			      int *val,
+			      int *val2,
+			      long mask)
+{
+	struct iio_dummy_state *st = iio_priv(indio_dev);
+	int ret = -EINVAL;
+
+	mutex_lock(&st->lock);
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW: /* magic value - channel value read */
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			if (chan->output) {
+				/* Set integer part to cached value */
+				*val = st->dac_val;
+				ret = IIO_VAL_INT;
+			} else if (chan->differential) {
+				if (chan->channel == 1)
+					*val = st->differential_adc_val[0];
+				else
+					*val = st->differential_adc_val[1];
+				ret = IIO_VAL_INT;
+			} else {
+				*val = st->single_ended_adc_val;
+				ret = IIO_VAL_INT;
+			}
+			break;
+		case IIO_ACCEL:
+			switch(chan->scan_index) {
+			case DUMMY_INDEX_ACCEL_X:
+				*val = st->accel_val[0];
+				break;
+			case DUMMY_INDEX_ACCEL_Y:
+				*val = st->accel_val[1];
+				break;
+			case DUMMY_INDEX_ACCEL_Z:
+				*val = st->accel_val[2];
+				break;
+			default:
+				*val = 0;
+			}
+			ret = IIO_VAL_INT;
+			break;
+		default:
+			break;
+		}
+		break;
+	case IIO_CHAN_INFO_PROCESSED:
+		switch (chan->type) {
+		case IIO_STEPS:
+			*val = st->steps;
+			ret = IIO_VAL_INT;
+			break;
+		case IIO_ACTIVITY:
+			switch (chan->channel2) {
+			case IIO_MOD_RUNNING:
+				*val = st->activity_running;
+				ret = IIO_VAL_INT;
+				break;
+			case IIO_MOD_WALKING:
+				*val = st->activity_walking;
+				ret = IIO_VAL_INT;
+				break;
+			default:
+				break;
+			}
+			break;
+		default:
+			break;
+		}
+		break;
+	case IIO_CHAN_INFO_OFFSET:
+		/* only single ended adc -> 7 */
+		*val = 7;
+		ret = IIO_VAL_INT;
+		break;
+	case IIO_CHAN_INFO_SCALE:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			switch (chan->differential) {
+			case 0:
+				/* only single ended adc -> 0.001333 */
+				*val = 0;
+				*val2 = 1333;
+				ret = IIO_VAL_INT_PLUS_MICRO;
+				break;
+			case 1:
+				/* all differential adc -> 0.000001344 */
+				*val = 0;
+				*val2 = 1344;
+				ret = IIO_VAL_INT_PLUS_NANO;
+			}
+			break;
+		default:
+			break;
+		}
+		break;
+	case IIO_CHAN_INFO_CALIBBIAS:
+		/* only the acceleration axis - read from cache */
+		*val = st->accel_calibbias;
+		ret = IIO_VAL_INT;
+		break;
+	case IIO_CHAN_INFO_CALIBSCALE:
+		*val = st->accel_calibscale->val;
+		*val2 = st->accel_calibscale->val2;
+		ret = IIO_VAL_INT_PLUS_MICRO;
+		break;
+	case IIO_CHAN_INFO_SAMP_FREQ:
+		*val = 3;
+		*val2 = 33;
+		ret = IIO_VAL_INT_PLUS_NANO;
+		break;
+	case IIO_CHAN_INFO_ENABLE:
+		switch (chan->type) {
+		case IIO_STEPS:
+			*val = st->steps_enabled;
+			ret = IIO_VAL_INT;
+			break;
+		default:
+			break;
+		}
+		break;
+	case IIO_CHAN_INFO_CALIBHEIGHT:
+		switch (chan->type) {
+		case IIO_STEPS:
+			*val = st->height;
+			ret = IIO_VAL_INT;
+			break;
+		default:
+			break;
+		}
+		break;
+
+	default:
+		break;
+	}
+	mutex_unlock(&st->lock);
+	return ret;
+}
+
+/**
+ * iio_dummy_write_raw() - data write function.
+ * @indio_dev:	the struct iio_dev associated with this device instance
+ * @chan:	the channel whose data is to be written
+ * @val:	first element of value to set (typically INT)
+ * @val2:	second element of value to set (typically MICRO)
+ * @mask:	what we actually want to write as per the info_mask_*
+ *		in iio_chan_spec.
+ *
+ * Note that all raw writes are assumed IIO_VAL_INT and info mask elements
+ * are assumed to be IIO_INT_PLUS_MICRO unless the callback write_raw_get_fmt
+ * in struct iio_info is provided by the driver.
+ */
+static int iio_dummy_write_raw(struct iio_dev *indio_dev,
+			       struct iio_chan_spec const *chan,
+			       int val,
+			       int val2,
+			       long mask)
+{
+	int i;
+	int ret = 0;
+	struct iio_dummy_state *st = iio_priv(indio_dev);
+
+	switch (mask) {
+	case IIO_CHAN_INFO_RAW:
+		switch (chan->type) {
+		case IIO_VOLTAGE:
+			if (chan->output == 0)
+				return -EINVAL;
+
+			/* Locking not required as writing single value */
+			mutex_lock(&st->lock);
+			st->dac_val = val;
+			mutex_unlock(&st->lock);
+			return 0;
+		default:
+			return -EINVAL;
+		}
+	case IIO_CHAN_INFO_PROCESSED:
+		switch (chan->type) {
+		case IIO_STEPS:
+			mutex_lock(&st->lock);
+			st->steps = val;
+			mutex_unlock(&st->lock);
+			return 0;
+		case IIO_ACTIVITY:
+			if (val < 0)
+				val = 0;
+			if (val > 100)
+				val = 100;
+			switch (chan->channel2) {
+			case IIO_MOD_RUNNING:
+				st->activity_running = val;
+				return 0;
+			case IIO_MOD_WALKING:
+				st->activity_walking = val;
+				return 0;
+			default:
+				return -EINVAL;
+			}
+			break;
+		default:
+			return -EINVAL;
+		}
+	case IIO_CHAN_INFO_CALIBSCALE:
+		mutex_lock(&st->lock);
+		/* Compare against table - hard matching here */
+		for (i = 0; i < ARRAY_SIZE(dummy_scales); i++)
+			if (val == dummy_scales[i].val &&
+			    val2 == dummy_scales[i].val2)
+				break;
+		if (i == ARRAY_SIZE(dummy_scales))
+			ret = -EINVAL;
+		else
+			st->accel_calibscale = &dummy_scales[i];
+		mutex_unlock(&st->lock);
+		return ret;
+	case IIO_CHAN_INFO_CALIBBIAS:
+		mutex_lock(&st->lock);
+		st->accel_calibbias = val;
+		mutex_unlock(&st->lock);
+		return 0;
+	case IIO_CHAN_INFO_ENABLE:
+		switch (chan->type) {
+		case IIO_STEPS:
+			mutex_lock(&st->lock);
+			st->steps_enabled = val;
+			mutex_unlock(&st->lock);
+			return 0;
+		default:
+			return -EINVAL;
+		}
+	case IIO_CHAN_INFO_CALIBHEIGHT:
+		switch (chan->type) {
+		case IIO_STEPS:
+			st->height = val;
+			return 0;
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/*
+ * Device type specific information.
+ */
+static const struct iio_info iio_dummy_info = {
+	.read_raw = &iio_dummy_read_raw,
+	.write_raw = &iio_dummy_write_raw,
+};
+
+/**
+ * iio_dummy_init_device() - device instance specific init
+ * @indio_dev: the iio device structure
+ *
+ * Most drivers have one of these to set up default values,
+ * reset the device to known state etc.
+ */
+static int iio_dummy_init_device(struct iio_dev *indio_dev)
+{
+	struct iio_dummy_state *st = iio_priv(indio_dev);
+
+	st->dac_val = 0;
+	st->single_ended_adc_val = 73;
+	st->differential_adc_val[0] = 33;
+	st->differential_adc_val[1] = -34;
+	st->accel_val[0] = 34;
+	st->accel_val[1] = 37;
+	st->accel_val[2] = 40;
+	st->accel_calibbias = -7;
+	st->accel_calibscale = &dummy_scales[0];
+	st->steps = 47;
+	st->activity_running = 98;
+	st->activity_walking = 4;
+
+	return 0;
+}
+
+/**
+ * iio_dummy_probe() - device instance probe
+ * @name: name of this instance.
+ *
+ * Arguments are bus type specific.
+ * I2C: iio_dummy_probe(struct i2c_client *client,
+ *                      const struct i2c_device_id *id)
+ * SPI: iio_dummy_probe(struct spi_device *spi)
+ */
+static struct iio_sw_device *iio_dummy_probe(const char *name)
+{
+	int ret;
+	struct iio_dev *indio_dev;
+	struct iio_dummy_state *st;
+	struct iio_sw_device *swd;
+	struct device *parent;
+
+	/*
+	 * With hardware: Set the parent device.
+	 * parent = &spi->dev;
+	 * parent = &client->dev;
+	 */
+
+	swd = kzalloc(sizeof(*swd), GFP_KERNEL);
+	if (!swd)
+		return ERR_PTR(-ENOMEM);
+
+	/*
+	 * Allocate an IIO device.
+	 *
+	 * This structure contains all generic state
+	 * information about the device instance.
+	 * It also has a region (accessed by iio_priv()
+	 * for chip specific state information.
+	 */
+	indio_dev = iio_device_alloc(parent, sizeof(*st));
+	if (!indio_dev) {
+		ret = -ENOMEM;
+		goto error_free_swd;
+	}
+
+	st = iio_priv(indio_dev);
+	mutex_init(&st->lock);
+
+	iio_dummy_init_device(indio_dev);
+
+	 /*
+	 * Make the iio_dev struct available to remove function.
+	 * Bus equivalents
+	 * i2c_set_clientdata(client, indio_dev);
+	 * spi_set_drvdata(spi, indio_dev);
+	 */
+	swd->device = indio_dev;
+
+	/*
+	 * Set the device name.
+	 *
+	 * This is typically a part number and obtained from the module
+	 * id table.
+	 * e.g. for i2c and spi:
+	 *    indio_dev->name = id->name;
+	 *    indio_dev->name = spi_get_device_id(spi)->name;
+	 */
+	indio_dev->name = kstrdup(name, GFP_KERNEL);
+	if (!indio_dev->name) {
+		ret = -ENOMEM;
+		goto error_free_device;
+	}
+
+	/* Provide description of available channels */
+	indio_dev->channels = iio_dummy_channels;
+	indio_dev->num_channels = ARRAY_SIZE(iio_dummy_channels);
+
+	/*
+	 * Provide device type specific interface functions and
+	 * constant data.
+	 */
+	indio_dev->info = &iio_dummy_info;
+
+	/* Specify that device provides sysfs type interfaces */
+	indio_dev->modes = INDIO_DIRECT_MODE;
+
+	ret = iio_device_register(indio_dev);
+	if (ret < 0)
+		goto error_free_name;
+
+	iio_swd_group_init_type_name(swd, name, &iio_dummy_type);
+
+	return swd;
+error_free_name:
+	kfree(indio_dev->name);
+error_free_device:
+	iio_device_free(indio_dev);
+error_free_swd:
+	kfree(swd);
+	return ERR_PTR(ret);
+}
+
+/**
+ * iio_dummy_remove() - device instance removal function
+ * @swd: pointer to software IIO device abstraction
+ *
+ * Parameters follow those of iio_dummy_probe for buses.
+ */
+static int iio_dummy_remove(struct iio_sw_device *swd)
+{
+	/*
+	 * Get a pointer to the device instance iio_dev structure
+	 * from the bus subsystem. E.g.
+	 * struct iio_dev *indio_dev = i2c_get_clientdata(client);
+	 * struct iio_dev *indio_dev = spi_get_drvdata(spi);
+	 */
+	struct iio_dev *indio_dev = swd->device;
+
+	/* Unregister the device */
+	iio_device_unregister(indio_dev);
+
+	/* Free all structures */
+	kfree(indio_dev->name);
+	iio_device_free(indio_dev);
+
+	return 0;
+}
+
+/*
+ * module_iio_sw_device_driver() -  device driver registration
+ *
+ * Varies depending on bus type of the device. As there is no device
+ * here, call probe directly. For information on device registration
+ * i2c:
+ * Documentation/i2c/writing-clients.rst
+ * spi:
+ * Documentation/spi/spi-summary.rst
+ */
+static const struct iio_sw_device_ops iio_dummy_device_ops = {
+	.probe = iio_dummy_probe,
+	.remove = iio_dummy_remove,
+};
+
+static struct iio_sw_device_type iio_dummy_device = {
+	.name = "dummy-modified",
+	.owner = THIS_MODULE,
+	.ops = &iio_dummy_device_ops,
+};
+
+module_iio_sw_device_driver(iio_dummy_device);
+
+MODULE_AUTHOR("Jonathan Cameron <jic23@kernel.org>");
+MODULE_DESCRIPTION("IIO dummy driver");
+MODULE_LICENSE("GPL v2");

--- a/crates/scmi/kernel/iio-dummy/iio_modified_dummy.h
+++ b/crates/scmi/kernel/iio-dummy/iio_modified_dummy.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/**
+ * Copyright (c) 2011 Jonathan Cameron
+ *
+ * Join together the various functionality of iio_modified_dummy driver
+ *
+ * Changes by Milan Zamazal <mzamazal@redhat.com> 2023, for testing
+ * with vhost-device-scmi:
+ *
+ * - Dropped conditional parts.
+ * - Use 3 axes in the accelerometer device.
+ */
+
+#ifndef _IIO_MODIFIED_DUMMY_H_
+#define _IIO_MODIFIED_DUMMY_H_
+#include <linux/kernel.h>
+
+struct iio_dummy_accel_calibscale;
+struct iio_dummy_regs;
+
+/**
+ * struct iio_dummy_state - device instance specific state.
+ * @dac_val:			cache for dac value
+ * @single_ended_adc_val:	cache for single ended adc value
+ * @differential_adc_val:	cache for differential adc value
+ * @accel_val:			cache for acceleration value
+ * @accel_calibbias:		cache for acceleration calibbias
+ * @accel_calibscale:		cache for acceleration calibscale
+ * @lock:			lock to ensure state is consistent
+ * @event_irq:			irq number for event line (faked)
+ * @event_val:			cache for event threshold value
+ * @event_en:			cache of whether event is enabled
+ */
+struct iio_dummy_state {
+	int dac_val;
+	int single_ended_adc_val;
+	int differential_adc_val[2];
+	int accel_val[3];
+	int accel_calibbias;
+	int activity_running;
+	int activity_walking;
+	const struct iio_dummy_accel_calibscale *accel_calibscale;
+	struct mutex lock;
+	struct iio_dummy_regs *regs;
+	int steps_enabled;
+	int steps;
+	int height;
+};
+
+/**
+ * enum iio_modified_dummy_scan_elements - scan index enum
+ * @DUMMY_INDEX_VOLTAGE_0:         the single ended voltage channel
+ * @DUMMY_INDEX_DIFFVOLTAGE_1M2:   first differential channel
+ * @DUMMY_INDEX_DIFFVOLTAGE_3M4:   second differential channel
+ * @DUMMY_INDEX_ACCELX:            acceleration channel
+ *
+ * Enum provides convenient numbering for the scan index.
+ */
+enum iio_modified_dummy_scan_elements {
+	DUMMY_INDEX_VOLTAGE_0,
+	DUMMY_INDEX_DIFFVOLTAGE_1M2,
+	DUMMY_INDEX_DIFFVOLTAGE_3M4,
+	DUMMY_INDEX_ACCEL_X,
+	DUMMY_INDEX_ACCEL_Y,
+	DUMMY_INDEX_ACCEL_Z,
+};
+
+#endif /* _IIO_MODIFIED_DUMMY_H_ */

--- a/crates/scmi/src/devices.rs
+++ b/crates/scmi/src/devices.rs
@@ -20,107 +20,141 @@ type NameDeviceMapping = HashMap<String, DeviceSpecification>;
 
 pub fn available_devices() -> NameDeviceMapping {
     let mut devices: NameDeviceMapping = HashMap::new();
-    devices.insert(String::from("fake"), FakeSensor::new);
+    devices.insert("fake".to_owned(), FakeSensor::new);
     devices
 }
 
-pub struct FakeSensor {
-    enabled: bool,
-    value: u8,
+// Common sensor infrastructure
+
+pub struct Sensor {
     name: String,
+    enabled: bool,
 }
 
-impl FakeSensor {
-    const NUMBER_OF_AXES: u32 = 3;
-
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new() -> Box<dyn ScmiDevice> {
-        let name = String::from("fake");
-        let sensor = Self {
+impl Sensor {
+    const fn new(default_name: String) -> Self {
+        Self {
+            name: default_name,
             enabled: false,
-            value: 0,
-            name,
-        };
-        Box::new(sensor)
+        }
     }
 }
 
-impl ScmiDevice for FakeSensor {
-    fn configure(&mut self, properties: &DeviceProperties) -> Result<(), String> {
-        for (k, v) in properties {
-            if k == "name" {
-                // TODO: Check for duplicate names
-                self.name = String::from(v);
-            } else {
-                return Result::Err(format!("Invalid device option: {k}"));
-            }
-        }
-        Ok(())
-    }
+trait SensorT: Send {
+    fn sensor(&self) -> &Sensor;
+    fn sensor_mut(&mut self) -> &mut Sensor;
 
     fn protocol(&self) -> ProtocolId {
         SENSOR_PROTOCOL_ID
     }
 
+    fn invalid_property(&self, name: &String) -> Result<(), String> {
+        Result::Err(format!("Invalid device option: {name}"))
+    }
+
+    fn process_property(&mut self, name: &String, _value: &str) -> Result<(), String> {
+        self.invalid_property(name)
+    }
+
+    fn configure(&mut self, properties: &DeviceProperties) -> Result<(), String> {
+        for (name, value) in properties {
+            if name == "name" {
+                // TODO: Check for duplicate names
+                self.sensor_mut().name = String::from(value);
+            } else {
+                self.process_property(name, value)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn number_of_axes(&self) -> u32 {
+        1
+    }
+
+    fn description_get(&self) -> DeviceResult {
+        // Continuous update required by Linux SCMI IIO driver
+        let low = 1 << 30;
+        let high = self.number_of_axes() << 16 | 1 << 8;
+        let name = self.sensor().name.clone();
+        let values: MessageValues = vec![
+            // attributes low
+            MessageValue::Unsigned(low),
+            // attributes high
+            MessageValue::Unsigned(high),
+            // name, up to 16 bytes with final NULL (non-extended version)
+            MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+        ];
+        Ok(values)
+    }
+
+    fn axis_unit(&self) -> u32;
+
+    fn axis_name_prefix(&self) -> String {
+        "axis".to_owned()
+    }
+
+    fn axis_name_suffix(&self, axis: u32) -> char {
+        match axis {
+            0 => 'X',
+            1 => 'Y',
+            2 => 'Z',
+            _ => 'N', // shouldn't be reached currently
+        }
+    }
+
+    fn axis_description(&self, axis: u32) -> Vec<MessageValue> {
+        let mut values = vec![];
+        values.push(MessageValue::Unsigned(axis)); // axis id
+        values.push(MessageValue::Unsigned(0)); // attributes low
+        values.push(MessageValue::Unsigned(self.axis_unit())); // attributes high
+
+        // Name in the recommended format, 16 bytes:
+        let prefix = self.axis_name_prefix();
+        let suffix = self.axis_name_suffix(axis);
+        values.push(MessageValue::String(
+            format!("{prefix}_{suffix}"),
+            MAX_SIMPLE_STRING_LENGTH,
+        ));
+        values
+    }
+
+    fn config_get(&self) -> DeviceResult {
+        let config = u32::from(self.sensor().enabled);
+        Ok(vec![MessageValue::Unsigned(config)])
+    }
+
+    fn config_set(&mut self, config: u32) -> DeviceResult {
+        if config & 0xFFFFFFFE != 0 {
+            return Result::Err(ScmiDeviceError::UnsupportedRequest);
+        }
+        self.sensor_mut().enabled = config != 0;
+        debug!("Sensor enabled: {}", self.sensor().enabled);
+        Ok(vec![])
+    }
+
+    fn reading_get(&mut self) -> DeviceResult;
+
     fn handle(&mut self, message_id: MessageId, parameters: &[MessageValue]) -> DeviceResult {
         match message_id {
-            SENSOR_DESCRIPTION_GET => {
-                // Continuous update required by Linux SCMI IIO driver
-                let low = 1 << 30;
-                let high = Self::NUMBER_OF_AXES << 16 | 1 << 8;
-                let name = self.name.clone();
-                let values: MessageValues = vec![
-                    // attributes low
-                    MessageValue::Unsigned(low),
-                    // attributes high
-                    MessageValue::Unsigned(high),
-                    // name, up to 16 bytes with final NULL (non-extended version)
-                    MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
-                ];
-                Ok(values)
-            }
+            SENSOR_DESCRIPTION_GET => self.description_get(),
             SENSOR_AXIS_DESCRIPTION_GET => {
+                let n_sensor_axes = self.number_of_axes();
                 let axis_desc_index = parameters[0].get_unsigned();
-                if axis_desc_index >= Self::NUMBER_OF_AXES {
+                if axis_desc_index >= n_sensor_axes {
                     return Result::Err(ScmiDeviceError::InvalidParameters);
                 }
-                let mut values = vec![MessageValue::Unsigned(
-                    Self::NUMBER_OF_AXES - axis_desc_index,
-                )];
-                for i in axis_desc_index..Self::NUMBER_OF_AXES {
-                    values.push(MessageValue::Unsigned(i)); // axis id
-                    values.push(MessageValue::Unsigned(0)); // attributes low
-
-                    // The sensor type is "Meters per second squared", since this is the
-                    // only, together with "Radians per second", what Google Linux IIO
-                    // supports (accelerometers and gyroscopes only).
-                    values.push(MessageValue::Unsigned(
-                        SENSOR_UNIT_METERS_PER_SECOND_SQUARED,
-                    )); // attributes high
-
-                    // Name in the recommended format, 16 bytes:
-                    let axis = match i {
-                        0 => 'X',
-                        1 => 'Y',
-                        2 => 'Z',
-                        _ => 'N', // shouldn't be reached currently
-                    };
-                    values.push(MessageValue::String(format!("acc_{axis}").to_string(), 16));
+                let mut values = vec![MessageValue::Unsigned(n_sensor_axes - axis_desc_index)];
+                for i in axis_desc_index..n_sensor_axes {
+                    let mut description = self.axis_description(i);
+                    values.append(&mut description);
                 }
                 Ok(values)
             }
-            SENSOR_CONFIG_GET => {
-                let config = u32::from(self.enabled);
-                Ok(vec![MessageValue::Unsigned(config)])
-            }
+            SENSOR_CONFIG_GET => self.config_get(),
             SENSOR_CONFIG_SET => {
                 let config = parameters[0].get_unsigned();
-                if config & 0xFFFFFFFE != 0 {
-                    return Result::Err(ScmiDeviceError::UnsupportedRequest);
-                }
-                self.enabled = config != 0;
-                debug!("Sensor enabled: {}", self.enabled);
-                Ok(vec![])
+                self.config_set(config)
             }
             SENSOR_CONTINUOUS_UPDATE_NOTIFY => {
                 // Linux VIRTIO SCMI insists on this.
@@ -128,21 +162,86 @@ impl ScmiDevice for FakeSensor {
                 Ok(vec![])
             }
             SENSOR_READING_GET => {
-                if !self.enabled {
+                if !self.sensor().enabled {
                     return Result::Err(ScmiDeviceError::NotEnabled);
                 }
-                let value = self.value;
-                self.value = self.value.overflowing_add(1).0;
-                let mut result = vec![];
-                for i in 0..3 {
-                    result.push(MessageValue::Unsigned(u32::from(value) + 100 * i));
-                    result.push(MessageValue::Unsigned(0));
-                    result.push(MessageValue::Unsigned(0));
-                    result.push(MessageValue::Unsigned(0));
-                }
-                Ok(result)
+                self.reading_get()
             }
             _ => Result::Err(ScmiDeviceError::UnsupportedRequest),
         }
+    }
+}
+
+// It's possible to impl ScmiDevice for SensorT but it is not very useful
+// because it doesn't allow to pass SensorT as ScmiDevice directly.
+// Hence this wrapper.
+struct SensorDevice(Box<dyn SensorT>);
+
+impl ScmiDevice for SensorDevice {
+    fn configure(&mut self, properties: &DeviceProperties) -> Result<(), String> {
+        self.0.configure(properties)
+    }
+
+    fn protocol(&self) -> ProtocolId {
+        self.0.protocol()
+    }
+
+    fn handle(&mut self, message_id: MessageId, parameters: &[MessageValue]) -> DeviceResult {
+        self.0.handle(message_id, parameters)
+    }
+}
+
+// Particular sensor implementations
+
+pub struct FakeSensor {
+    sensor: Sensor,
+    value: u8,
+}
+
+impl SensorT for FakeSensor {
+    // TODO: Define a macro for this boilerplate?
+    fn sensor(&self) -> &Sensor {
+        &self.sensor
+    }
+    fn sensor_mut(&mut self) -> &mut Sensor {
+        &mut self.sensor
+    }
+
+    fn number_of_axes(&self) -> u32 {
+        3
+    }
+
+    fn axis_unit(&self) -> u32 {
+        // The sensor type is "Meters per second squared", since this is the
+        // only, together with "Radians per second", what Google Linux IIO
+        // supports (accelerometers and gyroscopes only).
+        SENSOR_UNIT_METERS_PER_SECOND_SQUARED
+    }
+
+    fn axis_name_prefix(&self) -> String {
+        "acc".to_owned()
+    }
+
+    fn reading_get(&mut self) -> DeviceResult {
+        let value = self.value;
+        self.value = self.value.overflowing_add(1).0;
+        let mut result = vec![];
+        for i in 0..3 {
+            result.push(MessageValue::Unsigned(u32::from(value) + 100 * i));
+            result.push(MessageValue::Unsigned(0));
+            result.push(MessageValue::Unsigned(0));
+            result.push(MessageValue::Unsigned(0));
+        }
+        Ok(result)
+    }
+}
+
+impl FakeSensor {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new() -> Box<dyn ScmiDevice> {
+        let sensor = Sensor::new("fake".to_owned());
+        let fake_sensor = Self { sensor, value: 0 };
+        let sensor_device = SensorDevice(Box::new(fake_sensor));
+        Box::new(sensor_device)
     }
 }

--- a/crates/scmi/src/devices.rs
+++ b/crates/scmi/src/devices.rs
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use log::debug;
+
+use crate::scmi::{
+    DeviceResult, MessageId, MessageValue, MessageValues, ProtocolId, ScmiDevice, ScmiDeviceError,
+    MAX_SIMPLE_STRING_LENGTH, SENSOR_AXIS_DESCRIPTION_GET, SENSOR_CONFIG_GET, SENSOR_CONFIG_SET,
+    SENSOR_CONTINUOUS_UPDATE_NOTIFY, SENSOR_DESCRIPTION_GET, SENSOR_PROTOCOL_ID,
+    SENSOR_READING_GET, SENSOR_UNIT_METERS_PER_SECOND_SQUARED,
+};
+
+pub struct FakeSensor {
+    enabled: bool,
+    value: u8,
+    name: String,
+}
+
+impl FakeSensor {
+    const NUMBER_OF_AXES: u32 = 3;
+
+    pub const fn new(name: String) -> Self {
+        Self {
+            enabled: false,
+            value: 0,
+            name,
+        }
+    }
+}
+
+impl ScmiDevice for FakeSensor {
+    fn protocol(&self) -> ProtocolId {
+        SENSOR_PROTOCOL_ID
+    }
+
+    fn handle(&mut self, message_id: MessageId, parameters: &[MessageValue]) -> DeviceResult {
+        match message_id {
+            SENSOR_DESCRIPTION_GET => {
+                // Continuous update required by Linux SCMI IIO driver
+                let low = 1 << 30;
+                let high = Self::NUMBER_OF_AXES << 16 | 1 << 8;
+                let name = self.name.clone();
+                let values: MessageValues = vec![
+                    // attributes low
+                    MessageValue::Unsigned(low),
+                    // attributes high
+                    MessageValue::Unsigned(high),
+                    // name, up to 16 bytes with final NULL (non-extended version)
+                    MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+                ];
+                Ok(values)
+            }
+            SENSOR_AXIS_DESCRIPTION_GET => {
+                let axis_desc_index = parameters[0].get_unsigned();
+                if axis_desc_index >= Self::NUMBER_OF_AXES {
+                    return Result::Err(ScmiDeviceError::InvalidParameters);
+                }
+                let mut values = vec![MessageValue::Unsigned(
+                    Self::NUMBER_OF_AXES - axis_desc_index,
+                )];
+                for i in axis_desc_index..Self::NUMBER_OF_AXES {
+                    values.push(MessageValue::Unsigned(i)); // axis id
+                    values.push(MessageValue::Unsigned(0)); // attributes low
+
+                    // The sensor type is "Meters per second squared", since this is the
+                    // only, together with "Radians per second", what Google Linux IIO
+                    // supports (accelerometers and gyroscopes only).
+                    values.push(MessageValue::Unsigned(
+                        SENSOR_UNIT_METERS_PER_SECOND_SQUARED,
+                    )); // attributes high
+
+                    // Name in the recommended format, 16 bytes:
+                    let axis = match i {
+                        0 => 'X',
+                        1 => 'Y',
+                        2 => 'Z',
+                        _ => 'N', // shouldn't be reached currently
+                    };
+                    values.push(MessageValue::String(format!("acc_{axis}").to_string(), 16));
+                }
+                Ok(values)
+            }
+            SENSOR_CONFIG_GET => {
+                let config = u32::from(self.enabled);
+                Ok(vec![MessageValue::Unsigned(config)])
+            }
+            SENSOR_CONFIG_SET => {
+                let config = parameters[0].get_unsigned();
+                if config & 0xFFFFFFFE != 0 {
+                    return Result::Err(ScmiDeviceError::UnsupportedRequest);
+                }
+                self.enabled = config != 0;
+                debug!("Sensor enabled: {}", self.enabled);
+                Ok(vec![])
+            }
+            SENSOR_CONTINUOUS_UPDATE_NOTIFY => {
+                // Linux VIRTIO SCMI insists on this.
+                // We can accept it and ignore it, the sensor will be still working.
+                Ok(vec![])
+            }
+            SENSOR_READING_GET => {
+                if !self.enabled {
+                    return Result::Err(ScmiDeviceError::NotEnabled);
+                }
+                let value = self.value;
+                self.value = self.value.overflowing_add(1).0;
+                let mut result = vec![];
+                for i in 0..3 {
+                    result.push(MessageValue::Unsigned(u32::from(value) + 100 * i));
+                    result.push(MessageValue::Unsigned(0));
+                    result.push(MessageValue::Unsigned(0));
+                    result.push(MessageValue::Unsigned(0));
+                }
+                Ok(result)
+            }
+            _ => Result::Err(ScmiDeviceError::UnsupportedRequest),
+        }
+    }
+}

--- a/crates/scmi/src/devices/common.rs
+++ b/crates/scmi/src/devices/common.rs
@@ -191,6 +191,10 @@ pub trait SensorT: Send {
     fn sensor(&self) -> &Sensor;
     fn sensor_mut(&mut self) -> &mut Sensor;
 
+    fn initialize(&mut self) -> Result<(), DeviceError> {
+        Ok(())
+    }
+
     fn protocol(&self) -> ProtocolId {
         SENSOR_PROTOCOL_ID
     }
@@ -328,6 +332,10 @@ pub trait SensorT: Send {
 pub struct SensorDevice(pub(crate) Box<dyn SensorT>);
 
 impl ScmiDevice for SensorDevice {
+    fn initialize(&mut self) -> Result<(), DeviceError> {
+        self.0.initialize()
+    }
+
     fn protocol(&self) -> ProtocolId {
         self.0.protocol()
     }

--- a/crates/scmi/src/devices/common.rs
+++ b/crates/scmi/src/devices/common.rs
@@ -128,7 +128,7 @@ pub fn available_devices() -> NameDeviceMapping {
     devices.insert(
         "fake",
         DeviceSpecification::new(
-            fake::FakeSensor::new,
+            fake::FakeSensor::new_device,
             "fake accelerometer",
             "A simple 3-axes sensor providing fake pre-defined values.",
             &["name: an optional name of the sensor, max. 15 characters"],

--- a/crates/scmi/src/devices/common.rs
+++ b/crates/scmi/src/devices/common.rs
@@ -12,7 +12,6 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::fmt::Write;
-use std::process::exit;
 
 use itertools::Itertools;
 use log::debug;
@@ -27,12 +26,7 @@ use crate::scmi::{
 
 use super::{fake, iio};
 
-/// Enumeration of vhost-device-scmi exit codes.
-// TODO: It should be better placed elsewhere but it's currently used only here.
-enum ExitCodes {
-    Help = 1,
-}
-
+/// Non-SCMI related device errors.
 #[derive(Debug, ThisError)]
 pub enum DeviceError {
     #[error("{0}")]
@@ -225,7 +219,6 @@ fn devices_help() -> String {
 pub fn print_devices_help() {
     let help = devices_help();
     println!("{}", help);
-    exit(ExitCodes::Help as i32);
 }
 
 // Common sensor infrastructure

--- a/crates/scmi/src/devices/fake.rs
+++ b/crates/scmi/src/devices/fake.rs
@@ -51,8 +51,7 @@ impl SensorT for FakeSensor {
 }
 
 impl FakeSensor {
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(properties: &DeviceProperties) -> MaybeDevice {
+    pub fn new_device(properties: &DeviceProperties) -> MaybeDevice {
         properties.check(&[], &["name"])?;
         let sensor = Sensor::new(properties, "fake");
         let fake_sensor = Self { sensor, value: 0 };

--- a/crates/scmi/src/devices/fake.rs
+++ b/crates/scmi/src/devices/fake.rs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Fake sensor
+
+use crate::scmi::{DeviceResult, MessageValue, SENSOR_UNIT_METERS_PER_SECOND_SQUARED};
+
+use super::common::{DeviceProperties, MaybeDevice, Sensor, SensorDevice, SensorT};
+
+pub struct FakeSensor {
+    sensor: Sensor,
+    value: u8,
+}
+
+impl SensorT for FakeSensor {
+    // TODO: Define a macro for this boilerplate?
+    fn sensor(&self) -> &Sensor {
+        &self.sensor
+    }
+    fn sensor_mut(&mut self) -> &mut Sensor {
+        &mut self.sensor
+    }
+
+    fn number_of_axes(&self) -> u32 {
+        3
+    }
+
+    fn axis_unit(&self) -> u32 {
+        // The sensor type is "Meters per second squared", since this is the
+        // only, together with "Radians per second", what Google Linux IIO
+        // supports (accelerometers and gyroscopes only).
+        SENSOR_UNIT_METERS_PER_SECOND_SQUARED
+    }
+
+    fn axis_name_prefix(&self) -> String {
+        "acc".to_owned()
+    }
+
+    fn reading_get(&mut self) -> DeviceResult {
+        let value = self.value;
+        self.value = self.value.overflowing_add(1).0;
+        let mut result = vec![];
+        for i in 0..3 {
+            result.push(MessageValue::Unsigned(u32::from(value) + 100 * i));
+            result.push(MessageValue::Unsigned(0));
+            result.push(MessageValue::Unsigned(0));
+            result.push(MessageValue::Unsigned(0));
+        }
+        Ok(result)
+    }
+}
+
+impl FakeSensor {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(properties: &DeviceProperties) -> MaybeDevice {
+        properties.check(&[], &["name"])?;
+        let sensor = Sensor::new(properties, "fake");
+        let fake_sensor = Self { sensor, value: 0 };
+        let sensor_device = SensorDevice(Box::new(fake_sensor));
+        Ok(Box::new(sensor_device))
+    }
+}

--- a/crates/scmi/src/devices/fake.rs
+++ b/crates/scmi/src/devices/fake.rs
@@ -3,7 +3,7 @@
 
 // Fake sensor
 
-use crate::scmi::{DeviceResult, MessageValue, SENSOR_UNIT_METERS_PER_SECOND_SQUARED};
+use crate::scmi::{self, DeviceResult, MessageValue};
 
 use super::common::{DeviceProperties, MaybeDevice, Sensor, SensorDevice, SensorT};
 
@@ -25,11 +25,11 @@ impl SensorT for FakeSensor {
         3
     }
 
-    fn axis_unit(&self) -> u32 {
+    fn unit(&self) -> u8 {
         // The sensor type is "Meters per second squared", since this is the
         // only, together with "Radians per second", what Google Linux IIO
         // supports (accelerometers and gyroscopes only).
-        SENSOR_UNIT_METERS_PER_SECOND_SQUARED
+        scmi::SENSOR_UNIT_METERS_PER_SECOND_SQUARED
     }
 
     fn axis_name_prefix(&self) -> String {

--- a/crates/scmi/src/devices/fake.rs
+++ b/crates/scmi/src/devices/fake.rs
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-// Fake sensor
+//! Fake sensor implementation.
+//!
+//! The fake sensor is completely implemented here rather than bound to a host
+//! device.  It emulates a dummy accelerometer device that increments an axis
+//! reading value on each its retrieval.  Useful for initial testing and
+//! arranging SCMI virtualization setup without the need to bind real host
+//! devices.
 
 use crate::scmi::{self, DeviceResult, MessageValue};
 

--- a/crates/scmi/src/devices/iio.rs
+++ b/crates/scmi/src/devices/iio.rs
@@ -1,0 +1,782 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Industrial I/O sensors
+
+use std::cmp::{max, min};
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use log::{debug, error, warn};
+
+use crate::scmi::{self, DeviceResult, MessageValue, ScmiDeviceError, MAX_SIMPLE_STRING_LENGTH};
+
+use super::common::{DeviceError, DeviceProperties, MaybeDevice, Sensor, SensorDevice, SensorT};
+
+struct UnitMapping<'a> {
+    channel: &'a str,
+    unit: u8,
+    unit_exponent: i8, // max. 5 bits actually
+}
+
+// Incomplete, just a sample.
+// TODO: Make some macro(s) for this.
+const UNIT_MAPPING: &[UnitMapping] = &[
+    UnitMapping {
+        channel: "in_accel",
+        unit: scmi::SENSOR_UNIT_METERS_PER_SECOND_SQUARED,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_angle",
+        unit: scmi::SENSOR_UNIT_RADIANS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_anglevel",
+        unit: scmi::SENSOR_UNIT_RADIANS_PER_SECOND,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_concentration",
+        unit: scmi::SENSOR_UNIT_PERCENTAGE,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_current",
+        unit: scmi::SENSOR_UNIT_AMPS,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_capacitance",
+        unit: scmi::SENSOR_UNIT_FARADS,
+        unit_exponent: -9,
+    },
+    UnitMapping {
+        channel: "in_distance",
+        unit: scmi::SENSOR_UNIT_METERS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_electricalconductivity",
+        unit: scmi::SENSOR_UNIT_SIEMENS, // per meter
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_energy",
+        unit: scmi::SENSOR_UNIT_JOULS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_gravity",
+        unit: scmi::SENSOR_UNIT_METERS_PER_SECOND_SQUARED,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_humidityrelative",
+        unit: scmi::SENSOR_UNIT_PERCENTAGE,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_illuminance",
+        unit: scmi::SENSOR_UNIT_LUX,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_magn",
+        unit: scmi::SENSOR_UNIT_GAUSS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_ph",
+        unit: scmi::SENSOR_UNIT_UNSPECIFIED, // SCMI doesn't define pH
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_positionrelative",
+        unit: scmi::SENSOR_UNIT_PERCENTAGE,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_power",
+        unit: scmi::SENSOR_UNIT_WATTS,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_pressure",
+        unit: scmi::SENSOR_UNIT_PASCALS,
+        unit_exponent: 3,
+    },
+    UnitMapping {
+        channel: "in_proximity",
+        unit: scmi::SENSOR_UNIT_METERS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_resistance",
+        unit: scmi::SENSOR_UNIT_OHMS,
+        unit_exponent: 0,
+    },
+    UnitMapping {
+        channel: "in_temp",
+        unit: scmi::SENSOR_UNIT_DEGREES_C,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_velocity_sqrt(x^2+y^2+z^2)",
+        unit: scmi::SENSOR_UNIT_METERS_PER_SECOND,
+        unit_exponent: -3,
+    },
+    UnitMapping {
+        channel: "in_voltage",
+        unit: scmi::SENSOR_UNIT_VOLTS,
+        unit_exponent: -3,
+    },
+];
+
+#[derive(PartialEq, Debug)]
+struct Axis {
+    path: OsString, // without "_raw" suffix
+    unit_exponent: i8,
+    custom_exponent: i8,
+}
+
+#[derive(Debug)]
+pub(crate) struct IIOSensor {
+    sensor: Sensor,
+    // Full /sys path to the device directory
+    path: OsString,
+    // Prefix of the device type in the device directory, e.g. "in_accel"
+    channel: OsString,
+    // Whether the sensor is scalar or has one or more axes
+    scalar: bool,
+    // Paths to "_raw" files
+    axes: Vec<Axis>,
+}
+
+impl SensorT for IIOSensor {
+    // TODO: Define a macro for this boilerplate?
+    fn sensor(&self) -> &Sensor {
+        &self.sensor
+    }
+    fn sensor_mut(&mut self) -> &mut Sensor {
+        &mut self.sensor
+    }
+
+    fn initialize(&mut self) -> Result<(), DeviceError> {
+        let mut axes: Vec<Axis> = vec![];
+        match fs::read_dir(&self.path) {
+            Ok(iter) => {
+                for dir_entry in iter {
+                    match dir_entry {
+                        Ok(entry) => self.register_iio_file(entry, &mut axes),
+                        Err(error) => return Err(DeviceError::IOError(self.path.clone(), error)),
+                    }
+                }
+            }
+            Err(error) => return Err(DeviceError::IOError(self.path.clone(), error)),
+        }
+        if axes.is_empty() {
+            return Err(DeviceError::GenericError(format!(
+                "No {:?} channel found in {:?}",
+                &self.channel, &self.path
+            )));
+        }
+        axes.sort_by(|a1, a2| a1.path.cmp(&a2.path));
+        self.axes = axes;
+        Ok(())
+    }
+
+    fn unit(&self) -> u8 {
+        UNIT_MAPPING
+            .iter()
+            .find(|mapping| mapping.channel == self.channel)
+            .map_or(scmi::SENSOR_UNIT_UNSPECIFIED, |mapping| mapping.unit)
+    }
+
+    fn unit_exponent(&self, axis_index: u32) -> i8 {
+        let axis: &Axis = self.axes.get(axis_index as usize).unwrap();
+        axis.unit_exponent + axis.custom_exponent
+    }
+
+    fn number_of_axes(&self) -> u32 {
+        if self.scalar {
+            0
+        } else {
+            self.axes.len() as u32
+        }
+    }
+
+    fn axis_name_prefix(&self) -> String {
+        let channel = self.channel.to_str().unwrap();
+        let in_prefix = "in_";
+        let out_prefix = "out_";
+        let name: &str = if channel.starts_with(in_prefix) {
+            channel.strip_prefix(in_prefix).unwrap()
+        } else if channel.starts_with(out_prefix) {
+            channel.strip_prefix(out_prefix).unwrap()
+        } else {
+            channel
+        };
+        let len = min(name.len(), MAX_SIMPLE_STRING_LENGTH - 1);
+        String::from(&name[..len])
+    }
+
+    fn reading_get(&mut self) -> DeviceResult {
+        let mut result = vec![];
+        for axis in &self.axes {
+            let value = self.read_axis(axis)?;
+            result.push(MessageValue::Unsigned((value & 0xFFFFFFFF) as u32));
+            result.push(MessageValue::Unsigned((value >> 32) as u32));
+            result.push(MessageValue::Unsigned(0));
+            result.push(MessageValue::Unsigned(0));
+        }
+        Ok(result)
+    }
+}
+
+fn read_number_from_file<F: FromStr>(path: &Path) -> Result<Option<F>, ScmiDeviceError> {
+    match fs::read_to_string(path) {
+        Ok(string) => match string.trim().parse() {
+            Ok(value) => Ok(Some(value)),
+            _ => {
+                error!(
+                    "Failed to parse IIO numeric value from {}: {string}",
+                    path.display()
+                );
+                Err(ScmiDeviceError::GenericError)
+            }
+        },
+        Err(error) => match error.kind() {
+            ErrorKind::NotFound => {
+                let raw = path.ends_with("_raw");
+                let format = || {
+                    format!(
+                        "IIO {} file {} not found",
+                        if raw { "value" } else { "data" },
+                        path.display()
+                    )
+                };
+                if raw {
+                    error!("{}", format());
+                    Err(ScmiDeviceError::GenericError)
+                } else {
+                    debug!("{}", format());
+                    Ok(None)
+                }
+            }
+            other_error => {
+                error!(
+                    "Failed to read IIO data from {}: {}",
+                    path.display(),
+                    other_error
+                );
+                Err(ScmiDeviceError::GenericError)
+            }
+        },
+    }
+}
+
+impl IIOSensor {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(properties: &DeviceProperties) -> Result<IIOSensor, DeviceError> {
+        properties.check(&["path", "channel"], &["name"])?;
+        let sensor = Sensor::new(properties, "iio");
+        Ok(IIOSensor {
+            sensor,
+            path: OsString::from(properties.get("path").unwrap()),
+            channel: OsString::from(properties.get("channel").unwrap()),
+            scalar: true,
+            axes: vec![],
+        })
+    }
+
+    pub fn new_device(properties: &DeviceProperties) -> MaybeDevice {
+        let iio_sensor = IIOSensor::new(properties)?;
+        let sensor_device = SensorDevice(Box::new(iio_sensor));
+        Ok(Box::new(sensor_device))
+    }
+
+    fn set_sensor_name_from_file(&mut self, path: &PathBuf) {
+        match fs::read_to_string(path) {
+            Ok(name) => self.sensor_mut().name = name,
+            Err(error) => warn!(
+                "Error reading IIO device name from {}: {}",
+                path.display(),
+                error
+            ),
+        }
+    }
+
+    fn custom_exponent(&self, path: &OsStr, unit_exponent: i8) -> i8 {
+        let mut custom_exponent: i8 = 0;
+        if let Ok(Some(scale)) = self.read_axis_scale(path) {
+            // Crash completely OK if *this* doesn't fit:
+            custom_exponent = scale.log10() as i8;
+            if scale < 1.0 {
+                // The logarithm is truncated towards zero, we need floor
+                custom_exponent -= 1;
+            }
+            // The SCMI exponent (unit_exponent + custom_exponent) can have max. 5 bits:
+            custom_exponent = min(15 - unit_exponent, custom_exponent);
+            custom_exponent = max(-16 - unit_exponent, custom_exponent);
+            debug!(
+                "Setting custom scaling coefficient for {:?}: {}",
+                &path, custom_exponent
+            );
+        }
+        custom_exponent
+    }
+
+    fn add_axis(&mut self, axes: &mut Vec<Axis>, path: &OsStr) {
+        let unit_exponent = UNIT_MAPPING
+            .iter()
+            .find(|mapping| mapping.channel == self.channel)
+            .map_or(0, |mapping| mapping.unit_exponent);
+        // To get meaningful integer values, we must adjust exponent to
+        // the provided scale if any.
+        let custom_exponent = self.custom_exponent(path, unit_exponent);
+        axes.push(Axis {
+            path: OsString::from(path),
+            unit_exponent,
+            custom_exponent,
+        });
+    }
+
+    fn register_iio_file(&mut self, file: fs::DirEntry, axes: &mut Vec<Axis>) {
+        let channel = self.channel.to_str().unwrap();
+        let os_file_name = file.file_name();
+        let file_name = os_file_name.to_str().unwrap_or_default();
+        let raw_suffix = "_raw";
+        if file_name == "name" {
+            self.set_sensor_name_from_file(&file.path());
+        } else if file_name.starts_with(channel) && file_name.ends_with(raw_suffix) {
+            let infix = &file_name[channel.len()..file_name.len() - raw_suffix.len()];
+            let infix_len = infix.len();
+            if infix_len == 0 || (infix_len == 2 && infix.starts_with('_')) {
+                let raw_axis_path = Path::new(&self.path)
+                    .join(Path::new(&file_name))
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+                let axis_path = raw_axis_path.strip_suffix(raw_suffix).unwrap();
+                self.add_axis(axes, &OsString::from(axis_path));
+                if infix_len > 0 {
+                    self.scalar = false;
+                }
+            }
+        }
+    }
+
+    fn read_axis_file<T: FromStr>(
+        &self,
+        path: &OsStr,
+        name: &str,
+    ) -> Result<Option<T>, ScmiDeviceError> {
+        for value_path in [
+            Path::new(&(String::from(path.to_str().unwrap()) + "_" + name)),
+            &Path::new(&path).parent().unwrap().join(name),
+        ]
+        .iter()
+        {
+            let value: Option<T> = read_number_from_file(value_path)?;
+            if value.is_some() {
+                return Ok(value);
+            }
+        }
+        Ok(None)
+    }
+
+    fn read_axis_offset(&self, path: &OsStr) -> Result<Option<i64>, ScmiDeviceError> {
+        self.read_axis_file(path, "offset")
+    }
+
+    fn read_axis_scale(&self, path: &OsStr) -> Result<Option<f64>, ScmiDeviceError> {
+        self.read_axis_file(path, "scale")
+    }
+
+    fn read_axis(&self, axis: &Axis) -> Result<i64, ScmiDeviceError> {
+        let path_result = axis.path.clone().into_string();
+        let mut value: i64 =
+            read_number_from_file(Path::new(&(path_result.unwrap() + "_raw")))?.unwrap();
+        let offset: Option<i64> = self.read_axis_offset(&axis.path)?;
+        if let Some(offset_value) = offset {
+            match value.checked_add(offset_value) {
+                Some(new_value) => value = new_value,
+                None => {
+                    error!(
+                        "IIO offset overflow in {:?}: {} + {}",
+                        &axis.path,
+                        value,
+                        offset.unwrap()
+                    );
+                    return Err(ScmiDeviceError::GenericError);
+                }
+            }
+        }
+        let scale: Option<f64> = self.read_axis_scale(&axis.path)?;
+        if let Some(scale_value) = scale {
+            let exponent_scale = 10.0_f64.powi(i32::from(axis.custom_exponent));
+            value = (value as f64 * (scale_value / exponent_scale)).round() as i64;
+        }
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::scmi::ScmiDevice;
+
+    use super::*;
+    use std::{
+        assert_eq, fs,
+        path::{Path, PathBuf},
+    };
+
+    fn make_directory(prefix: &str) -> PathBuf {
+        for i in 1..100 {
+            let path = Path::new(".").join(format!("{prefix}{i}"));
+            if fs::create_dir(&path).is_ok() {
+                return path;
+            }
+        }
+        panic!("Couldn't create test directory");
+    }
+
+    struct IIODirectory {
+        path: PathBuf,
+    }
+
+    impl IIODirectory {
+        fn new(files: &[(&str, &str)]) -> IIODirectory {
+            let path = make_directory("_test");
+            let directory = IIODirectory { path };
+            for (file, content) in files.iter() {
+                fs::write(&directory.path.join(file), content).unwrap();
+            }
+            directory
+        }
+    }
+
+    impl Drop for IIODirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn directory_path(directory: &IIODirectory) -> String {
+        directory
+            .path
+            .clone()
+            .into_os_string()
+            .into_string()
+            .unwrap()
+    }
+
+    fn device_properties(path: String, channel: String, name: Option<String>) -> DeviceProperties {
+        let mut pairs = vec![("path".to_owned(), path), ("channel".to_owned(), channel)];
+        if let Some(name) = name {
+            pairs.push(("name".to_owned(), name));
+        }
+        DeviceProperties::new(pairs)
+    }
+
+    fn make_iio_sensor_from_path(path: String, channel: String, name: Option<String>) -> IIOSensor {
+        let properties = device_properties(path, channel, name);
+        IIOSensor::new(&properties).unwrap()
+    }
+
+    fn make_iio_sensor(
+        directory: &IIODirectory,
+        channel: String,
+        name: Option<String>,
+    ) -> IIOSensor {
+        let path = directory_path(directory);
+        make_iio_sensor_from_path(path, channel, name)
+    }
+
+    fn make_scmi_sensor_from_path(
+        path: String,
+        channel: String,
+        name: Option<String>,
+    ) -> MaybeDevice {
+        let properties = device_properties(path, channel, name);
+        IIOSensor::new_device(&properties)
+    }
+
+    fn make_scmi_sensor(
+        directory: &IIODirectory,
+        channel: String,
+        name: Option<String>,
+    ) -> Box<dyn ScmiDevice> {
+        let path = directory_path(directory);
+        make_scmi_sensor_from_path(path, channel, name).unwrap()
+    }
+
+    #[test]
+    fn test_missing_property() {
+        let properties = DeviceProperties::new(vec![("path".to_owned(), ".".to_owned())]);
+        let result = IIOSensor::new(&properties);
+        match result {
+            Ok(_) => panic!("Should fail on a missing property"),
+            Err(DeviceError::MissingDeviceProperties(missing)) => {
+                assert_eq!(missing, vec!["channel".to_owned()])
+            }
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extra_property() {
+        let properties = DeviceProperties::new(vec![
+            ("path".to_owned(), ".".to_owned()),
+            ("name".to_owned(), "test".to_owned()),
+            ("channel".to_owned(), "in_accel".to_owned()),
+            ("foo".to_owned(), "something".to_owned()),
+            ("bar".to_owned(), "baz".to_owned()),
+        ]);
+        let result = IIOSensor::new(&properties);
+        match result {
+            Ok(_) => panic!("Should fail on an extra property"),
+            Err(DeviceError::UnexpectedDeviceProperties(extra)) => {
+                assert_eq!(extra, ["bar".to_owned(), "foo".to_owned()])
+            }
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_iio_init() {
+        let directory = IIODirectory::new(&[("foo", "bar"), ("in_accel_raw", "123")]);
+        let mut sensor =
+            make_scmi_sensor(&directory, "in_accel".to_owned(), Some("accel".to_owned()));
+        sensor.initialize().unwrap();
+    }
+
+    #[test]
+    fn test_iio_init_no_directory() {
+        let mut sensor =
+            make_scmi_sensor_from_path("non-existent".to_owned(), "".to_owned(), None).unwrap();
+        match sensor.initialize() {
+            Ok(_) => panic!("Should fail on an inaccessible path"),
+            Err(DeviceError::IOError(path, std::io::Error { .. })) => {
+                assert_eq!(path, "non-existent")
+            }
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_iio_init_no_channel() {
+        let directory = IIODirectory::new(&[("foo", "bar")]);
+        let mut sensor = make_scmi_sensor(&directory, "in_accel".to_owned(), None);
+        match sensor.initialize() {
+            Ok(_) => panic!("Should fail on an inaccessible channel"),
+            Err(DeviceError::GenericError(message)) => {
+                assert!(
+                    message.starts_with("No \"in_accel\" channel found in \"./_test"),
+                    "Unexpected error: {}",
+                    message
+                )
+            }
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_sensor_name_from_fs() {
+        let directory = IIODirectory::new(&[("in_accel_raw", "123"), ("name", "foo")]);
+        let mut sensor =
+            make_iio_sensor(&directory, "in_accel".to_owned(), Some("accel".to_owned()));
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.sensor.name, "foo");
+    }
+
+    #[test]
+    fn test_sensor_name_from_params() {
+        let directory = IIODirectory::new(&[("in_accel_raw", "123")]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), Some("foo".to_owned()));
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.sensor.name, "foo");
+    }
+
+    #[test]
+    fn test_default_sensor_name() {
+        let directory = IIODirectory::new(&[("in_accel_raw", "123")]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.sensor.name, "iio");
+    }
+
+    #[test]
+    fn test_units() {
+        let directory = IIODirectory::new(&[
+            ("in_foo_raw", "123"),
+            ("in_accel_raw", "123"),
+            ("in_voltage_raw", "123"),
+        ]);
+        for (name, unit) in [
+            ("foo", scmi::SENSOR_UNIT_UNSPECIFIED),
+            ("accel", scmi::SENSOR_UNIT_METERS_PER_SECOND_SQUARED),
+            ("voltage", scmi::SENSOR_UNIT_VOLTS),
+        ]
+        .iter()
+        {
+            let sensor =
+                make_iio_sensor(&directory, "in_".to_owned() + name, Some(name.to_string()));
+            assert_eq!(sensor.unit(), *unit);
+        }
+    }
+
+    #[test]
+    fn test_unit_exponent() {
+        for (channel, scale, exponent) in [
+            ("in_accel", 1.23, 0),
+            ("in_accel", 0.000123, -4),
+            ("in_accel", 123.0, 2),
+            ("in_voltage", 123.0, -1),
+        ]
+        .iter()
+        {
+            let raw_file = format!("{channel}_raw");
+            let scale_file = format!("{channel}_scale");
+            let directory =
+                IIODirectory::new(&[(&raw_file, "123"), (&scale_file, &scale.to_string())]);
+            let mut sensor = make_iio_sensor(&directory, channel.to_string(), None);
+            sensor.initialize().unwrap();
+            assert_eq!(sensor.unit_exponent(0), *exponent);
+        }
+    }
+
+    #[test]
+    fn test_unit_exponent_multiple_axes() {
+        let directory = IIODirectory::new(&[
+            ("in_accel_x_raw", "123"),
+            ("in_accel_x_scale", "0.123"),
+            ("in_accel_y_raw", "123"),
+            ("in_accel_y_scale", "12.3"),
+        ]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.unit_exponent(0), -1);
+        assert_eq!(sensor.unit_exponent(1), 1);
+    }
+
+    #[test]
+    fn test_unit_exponent_single_scale() {
+        let directory = IIODirectory::new(&[("in_accel_raw", "123"), ("scale", "0.123")]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.unit_exponent(0), -1);
+    }
+
+    #[test]
+    fn test_number_of_axes_scalar() {
+        let directory = IIODirectory::new(&[("in_accel_raw", "123"), ("in_accel_scale", "123")]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.number_of_axes(), 0);
+    }
+
+    #[test]
+    fn test_number_of_axes_1() {
+        let directory = IIODirectory::new(&[("in_accel_x_raw", "123"), ("in_accel_scale", "123")]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.number_of_axes(), 1);
+    }
+
+    #[test]
+    fn test_number_of_axes_3() {
+        let directory = IIODirectory::new(&[
+            ("in_accel_x_raw", "123"),
+            ("in_accel_y_raw", "123"),
+            ("in_accel_z_raw", "123"),
+            ("in_accel_x_scale", "123"),
+        ]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        assert_eq!(sensor.number_of_axes(), 3);
+    }
+
+    #[test]
+    fn test_axis_name_prefix() {
+        for (channel, prefix) in [
+            ("in_accel", "accel"),
+            ("out_voltage", "voltage"),
+            ("foo", "foo"),
+            ("name-longer-than-fifteen-characters", "name-longer-tha"),
+        ]
+        .iter()
+        {
+            let sensor = make_iio_sensor_from_path("".to_owned(), channel.to_string(), None);
+            assert_eq!(&sensor.axis_name_prefix(), prefix);
+        }
+    }
+
+    #[test]
+    fn test_iio_reading_scalar() {
+        let directory = IIODirectory::new(&[
+            ("in_voltage_raw", "9876543210"),
+            ("in_voltage_offset", "123"),
+            ("in_voltage_scale", "456"),
+        ]);
+        let mut sensor = make_iio_sensor(&directory, "in_voltage".to_owned(), None);
+        sensor.initialize().unwrap();
+        let result = sensor.reading_get().unwrap();
+        // (9876543210 + 123) * 456 = 4503703759848
+        // custom exponent = 2
+        // applied and rounded: 45037037598 = 0xA7C6AA81E
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0).unwrap(), &MessageValue::Unsigned(0x7C6AA81E));
+        assert_eq!(result.get(1).unwrap(), &MessageValue::Unsigned(0xA));
+        assert_eq!(result.get(2).unwrap(), &MessageValue::Unsigned(0));
+        assert_eq!(result.get(3).unwrap(), &MessageValue::Unsigned(0));
+    }
+
+    #[test]
+    fn test_iio_reading_scalar_whitespace() {
+        let directory = IIODirectory::new(&[
+            ("in_accel_raw", "10\n"),
+            ("in_accel_offset", "20\n"),
+            ("in_accel_scale", "0.3\n"),
+        ]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        let result = sensor.reading_get().unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0).unwrap(), &MessageValue::Unsigned(0x5A));
+        assert_eq!(result.get(1).unwrap(), &MessageValue::Unsigned(0));
+        assert_eq!(result.get(2).unwrap(), &MessageValue::Unsigned(0));
+        assert_eq!(result.get(3).unwrap(), &MessageValue::Unsigned(0));
+    }
+
+    #[test]
+    fn test_iio_reading_axes() {
+        let directory = IIODirectory::new(&[
+            ("in_accel_x_raw", "10"),
+            ("in_accel_x_offset", "1"),
+            ("in_accel_y_raw", "20"),
+            ("in_accel_y_offset", "10"),
+            ("in_accel_z_raw", "30"),
+            ("in_accel_z_offset", "20"),
+            ("in_accel_z_scale", "0.3"),
+            ("scale", "0.02"),
+        ]);
+        let mut sensor = make_iio_sensor(&directory, "in_accel".to_owned(), None);
+        sensor.initialize().unwrap();
+        let result = sensor.reading_get().unwrap();
+        assert_eq!(result.len(), 12);
+        assert_eq!(result.get(0).unwrap(), &MessageValue::Unsigned(22));
+        assert_eq!(result.get(4).unwrap(), &MessageValue::Unsigned(60));
+        assert_eq!(result.get(8).unwrap(), &MessageValue::Unsigned(150));
+        for i in 0..12 {
+            if i % 4 != 0 {
+                assert_eq!(result.get(i).unwrap(), &MessageValue::Unsigned(0));
+            }
+        }
+    }
+}

--- a/crates/scmi/src/devices/mod.rs
+++ b/crates/scmi/src/devices/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod common;
 pub mod fake;
+pub mod iio;

--- a/crates/scmi/src/devices/mod.rs
+++ b/crates/scmi/src/devices/mod.rs
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: Red Hat, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Implementation of SCMI bindings to host devices.
+//!
+//! The general infrastructure is implemented in [crate::devices::common] module.
+//! Access to particular kinds of devices is implemented in the other modules:
+//! - [crate::devices::fake] provides a fake sensor.
+//! - [crate::devices::iio] implements access to industrial I/O (IIO) devices.
+
 pub mod common;
 pub mod fake;
 pub mod iio;

--- a/crates/scmi/src/devices/mod.rs
+++ b/crates/scmi/src/devices/mod.rs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod common;
+pub mod fake;

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -29,7 +29,11 @@ struct ScmiArgs {
     #[clap(short, long, help = "vhost-user socket to use")]
     socket_path: String,
     // Specification of SCMI devices to create.
-    #[clap(short, long)]
+    #[clap(
+        short,
+        long,
+        help = "Devices to expose (use `help' device for more info)"
+    )]
     #[arg(num_args(1..))]
     device: Vec<String>,
 }

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -4,6 +4,7 @@
 
 mod scmi;
 mod vhu_scmi;
+mod devices;
 
 use std::process::exit;
 use std::sync::{Arc, RwLock};

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -6,7 +6,7 @@ mod devices;
 mod scmi;
 mod vhu_scmi;
 
-use devices::{DeviceDescription, DeviceProperties};
+use devices::common::{DeviceDescription, DeviceProperties};
 
 use std::{
     process::exit,

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -2,48 +2,79 @@
 // SPDX-License-Identifier: Apache-2.0
 // Based on implementation of other devices here, Copyright by Linaro Ltd.
 
+mod devices;
 mod scmi;
 mod vhu_scmi;
-mod devices;
 
-use std::process::exit;
-use std::sync::{Arc, RwLock};
+use std::{
+    process::exit,
+    sync::{Arc, RwLock},
+};
 
 use clap::Parser;
+use itertools::Itertools;
 use log::{debug, error, info, warn};
 
 use vhost::vhost_user;
 use vhost::vhost_user::Listener;
 use vhost_user_backend::VhostUserDaemon;
-use vhu_scmi::{VuScmiBackend, VuScmiError};
+use vhu_scmi::VuScmiBackend;
 use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
-type Result<T> = std::result::Result<T, VuScmiError>;
+type Result<T> = std::result::Result<T, String>;
 
 #[derive(Parser)]
 struct ScmiArgs {
     // Location of vhost-user Unix domain socket.
     #[clap(short, long, help = "vhost-user socket to use")]
     socket_path: String,
+    // Specification of SCMI devices to create.
+    #[clap(short, long)]
+    #[arg(num_args(1..))]
+    device: Vec<String>,
 }
 
-struct VuScmiConfig {
+// [(NAME, [(PROPERTY, VALUE), ...]), ...]
+type DeviceDescription = Vec<(String, DeviceProperties)>;
+type DeviceProperties = Vec<(String, String)>;
+
+pub struct VuScmiConfig {
     socket_path: String,
+    devices: DeviceDescription,
 }
 
 impl TryFrom<ScmiArgs> for VuScmiConfig {
-    type Error = VuScmiError;
+    type Error = String;
 
     fn try_from(cmd_args: ScmiArgs) -> Result<Self> {
         let socket_path = cmd_args.socket_path.trim().to_string();
-        Ok(Self { socket_path })
+        let device_iterator = cmd_args.device.iter();
+        let mut devices: DeviceDescription = vec![];
+        for d in device_iterator {
+            let mut split = d.split(',');
+            let name = split.next().unwrap().to_owned();
+            let mut properties: DeviceProperties = vec![];
+            for s in split {
+                if let Some((key, value)) = s.split('=').collect_tuple() {
+                    properties.push((key.to_owned(), value.to_owned()));
+                } else {
+                    return Result::Err(format!("Invalid device {name} property format: {s}"));
+                }
+            }
+            devices.push((name, properties));
+        }
+        Ok(Self {
+            socket_path,
+            devices,
+        })
     }
 }
 
 fn start_backend(config: VuScmiConfig) -> Result<()> {
     loop {
         debug!("Starting backend");
-        let backend = Arc::new(RwLock::new(VuScmiBackend::new().unwrap()));
+        // TODO: Print a nice error message on backend configuration failure.
+        let backend = Arc::new(RwLock::new(VuScmiBackend::new(&config).unwrap()));
         let listener = Listener::new(config.socket_path.clone(), true).unwrap();
         let mut daemon = VhostUserDaemon::new(
             "vhost-device-scmi".to_owned(),
@@ -78,9 +109,17 @@ fn start_backend(config: VuScmiConfig) -> Result<()> {
 
 fn main() {
     env_logger::init();
-    if let Err(error) = start_backend(VuScmiConfig::try_from(ScmiArgs::parse()).unwrap()) {
-        error!("{error}");
-        exit(1);
+    match VuScmiConfig::try_from(ScmiArgs::parse()) {
+        Ok(config) => {
+            if let Err(error) = start_backend(config) {
+                error!("{error}");
+                exit(1);
+            }
+        }
+        Err(message) => {
+            println!("{message}");
+            // TODO: print help
+        }
     }
 }
 
@@ -91,9 +130,31 @@ mod tests {
     #[test]
     fn test_command_line() {
         let path = "/foo/scmi.sock".to_owned();
-        let command_line = format!("-s {path}");
-        let args: ScmiArgs = Parser::parse_from(["", &command_line]);
-        let config: VuScmiConfig = args.try_into().unwrap();
+        let params_string = format!(
+            "binary \
+                     --device dummy \
+                     -s {path} \
+                     --device fake,name=foo,prop=value \
+                     -d fake,name=bar"
+        );
+        let params: Vec<&str> = params_string.split_whitespace().collect();
+        let args: ScmiArgs = Parser::parse_from(params);
+        let config = VuScmiConfig::try_from(args).unwrap();
         assert_eq!(config.socket_path, path);
+        let devices = vec![
+            ("dummy".to_owned(), vec![]),
+            (
+                "fake".to_owned(),
+                vec![
+                    ("name".to_owned(), "foo".to_owned()),
+                    ("prop".to_owned(), "value".to_owned()),
+                ],
+            ),
+            (
+                "fake".to_owned(),
+                vec![("name".to_owned(), "bar".to_owned())],
+            ),
+        ];
+        assert_eq!(config.devices, devices);
     }
 }

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+// Based on implementation of other devices here, Copyright by Linaro Ltd.
+
+mod scmi;
+mod vhu_scmi;
+
+use std::process::exit;
+use std::sync::{Arc, RwLock};
+
+use clap::Parser;
+use log::{debug, error, info, warn};
+
+use vhost::vhost_user;
+use vhost::vhost_user::Listener;
+use vhost_user_backend::VhostUserDaemon;
+use vhu_scmi::{VuScmiBackend, VuScmiError};
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+
+type Result<T> = std::result::Result<T, VuScmiError>;
+
+#[derive(Parser)]
+struct ScmiArgs {
+    // Location of vhost-user Unix domain socket.
+    #[clap(short, long, help = "vhost-user socket to use")]
+    socket_path: String,
+}
+
+struct VuScmiConfig {
+    socket_path: String,
+}
+
+impl TryFrom<ScmiArgs> for VuScmiConfig {
+    type Error = VuScmiError;
+
+    fn try_from(cmd_args: ScmiArgs) -> Result<Self> {
+        let socket_path = cmd_args.socket_path.trim().to_string();
+        Ok(Self { socket_path })
+    }
+}
+
+fn start_backend(config: VuScmiConfig) -> Result<()> {
+    loop {
+        debug!("Starting backend");
+        let backend = Arc::new(RwLock::new(VuScmiBackend::new().unwrap()));
+        let listener = Listener::new(config.socket_path.clone(), true).unwrap();
+        let mut daemon = VhostUserDaemon::new(
+            "vhost-device-scmi".to_owned(),
+            backend.clone(),
+            GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+        )
+        .unwrap();
+
+        daemon.start(listener).unwrap();
+
+        match daemon.wait() {
+            Ok(()) => {
+                info!("Stopping cleanly");
+            }
+            Err(vhost_user_backend::Error::HandleRequest(vhost_user::Error::PartialMessage)) => {
+                info!(
+                    "vhost-user connection closed with partial message.
+                       If the VM is shutting down, this is expected behavior;
+                       otherwise, it might be a bug."
+                );
+            }
+            Err(e) => {
+                warn!("Error running daemon: {:?}", e);
+            }
+        }
+
+        // No matter the result, we need to shut down the worker thread.
+        backend.read().unwrap().exit_event.write(1).unwrap();
+        debug!("Finishing backend");
+    }
+}
+
+fn main() {
+    env_logger::init();
+    if let Err(error) = start_backend(VuScmiConfig::try_from(ScmiArgs::parse()).unwrap()) {
+        error!("{error}");
+        exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_line() {
+        let path = "/foo/scmi.sock".to_owned();
+        let command_line = format!("-s {path}");
+        let args: ScmiArgs = Parser::parse_from(["", &command_line]);
+        let config: VuScmiConfig = args.try_into().unwrap();
+        assert_eq!(config.socket_path, path);
+    }
+}

--- a/crates/scmi/src/main.rs
+++ b/crates/scmi/src/main.rs
@@ -2,6 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // Based on implementation of other devices here, Copyright by Linaro Ltd.
 
+//! vhost-user daemon implementation for
+//! [System Control and Management Interface](https://developer.arm.com/Architectures/System%20Control%20and%20Management%20Interface)
+//! (SCMI).
+//!
+//! Currently, the mandatory parts of the following SCMI protocols are implemented:
+//!
+//! - base
+//! - sensor management
+//!
+//! As for sensor management, support for industrial I/O (IIO) Linux devices
+//! and a fake sensor device is implemented.
+//!
+//! The daemon listens on a socket that is specified using `--socket-path`
+//! command line option.  Usually at least one exposed device is specified,
+//! which is done using `--device` command line option.  It can be used more
+//! than once, for different devices.  `--device help` lists the available
+//! devices and their options.
+//!
+//! The daemon normally logs info and higher messages to the standard error
+//! output.  To log more messages, you can set `RUST_LOG` environment variable,
+//! e.g. to `debug`.
+//!
+//! Here is an example command line invocation of the daemon:
+//!
+//! ```sh
+//! RUST_LOG=debug vhost-device-scmi \
+//!   --socket ~/tmp/scmi.sock \
+//!   --device iio,path=/sys/bus/iio/devices/iio:device0,channel=in_accel
+//! ```
+
 mod devices;
 mod scmi;
 mod vhu_scmi;

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -216,7 +216,8 @@ pub const SENSOR_CONFIG_GET: MessageId = 0x9;
 pub const SENSOR_CONFIG_SET: MessageId = 0xA;
 pub const SENSOR_CONTINUOUS_UPDATE_NOTIFY: MessageId = 0xB;
 
-pub const SENSOR_UNIT_METERS_PER_SECOND_SQUARED: u32 = 89;
+pub const SENSOR_UNIT_UNSPECIFIED: u8 = 1;
+pub const SENSOR_UNIT_METERS_PER_SECOND_SQUARED: u8 = 89;
 
 enum ParameterType {
     _SignedInt32,
@@ -309,7 +310,12 @@ impl HandlerMap {
             BASE_DISCOVER_VENDOR,
             "base/discover_vendor",
             vec![],
-            |_, _| -> Response { Response::from(MessageValue::String("rust-vmm".to_string(), 16)) },
+            |_, _| -> Response {
+                Response::from(MessageValue::String(
+                    "rust-vmm".to_string(),
+                    MAX_SIMPLE_STRING_LENGTH,
+                ))
+            },
         );
         self.bind(
             BASE_PROTOCOL_ID,
@@ -1144,7 +1150,7 @@ mod tests {
             let mut description = vec![
                 MessageValue::Unsigned(i),
                 MessageValue::Unsigned(0),
-                MessageValue::Unsigned(SENSOR_UNIT_METERS_PER_SECOND_SQUARED),
+                MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
                 MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
             ];
             result.append(&mut description);

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -11,6 +11,8 @@ use itertools::Itertools;
 use log::{debug, error, info};
 use thiserror::Error as ThisError;
 
+use crate::devices::common::DeviceError;
+
 pub type MessageHeader = u32;
 
 pub const MAX_SIMPLE_STRING_LENGTH: usize = 16; // incl. NULL terminator
@@ -484,6 +486,7 @@ pub enum ScmiDeviceError {
 }
 
 pub trait ScmiDevice: Send {
+    fn initialize(&mut self) -> Result<(), DeviceError>;
     fn protocol(&self) -> ProtocolId;
     fn handle(
         &mut self,

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -716,7 +716,7 @@ impl ScmiHandler {
 
 #[cfg(test)]
 mod tests {
-    use crate::devices::{DeviceProperties, FakeSensor};
+    use crate::devices::{common::DeviceProperties, fake::FakeSensor};
 
     use super::*;
 

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use thiserror::Error as ThisError;
 
 use crate::devices::common::DeviceError;
@@ -218,7 +218,25 @@ pub const SENSOR_CONFIG_GET: MessageId = 0x9;
 pub const SENSOR_CONFIG_SET: MessageId = 0xA;
 pub const SENSOR_CONTINUOUS_UPDATE_NOTIFY: MessageId = 0xB;
 
+#[allow(dead_code)]
+pub const SENSOR_UNIT_NONE: u8 = 0;
 pub const SENSOR_UNIT_UNSPECIFIED: u8 = 1;
+pub const SENSOR_UNIT_DEGREES_C: u8 = 2;
+pub const SENSOR_UNIT_VOLTS: u8 = 5;
+pub const SENSOR_UNIT_AMPS: u8 = 6;
+pub const SENSOR_UNIT_WATTS: u8 = 7;
+pub const SENSOR_UNIT_JOULS: u8 = 8;
+pub const SENSOR_UNIT_LUX: u8 = 13;
+pub const SENSOR_UNIT_METERS: u8 = 31;
+pub const SENSOR_UNIT_RADIANS: u8 = 36;
+pub const SENSOR_UNIT_GAUSS: u8 = 45;
+pub const SENSOR_UNIT_FARADS: u8 = 48;
+pub const SENSOR_UNIT_OHMS: u8 = 49;
+pub const SENSOR_UNIT_SIEMENS: u8 = 50;
+pub const SENSOR_UNIT_PERCENTAGE: u8 = 65;
+pub const SENSOR_UNIT_PASCALS: u8 = 66;
+pub const SENSOR_UNIT_RADIANS_PER_SECOND: u8 = 87;
+pub const SENSOR_UNIT_METERS_PER_SECOND: u8 = 90;
 pub const SENSOR_UNIT_METERS_PER_SECOND_SQUARED: u8 = 89;
 
 enum ParameterType {
@@ -475,6 +493,8 @@ impl HandlerMap {
 
 #[derive(Debug, PartialEq, Eq, ThisError)]
 pub enum ScmiDeviceError {
+    #[error("Generic error")]
+    GenericError,
     #[error("Invalid parameters")]
     InvalidParameters,
     #[error("No such device")]
@@ -658,6 +678,10 @@ impl ScmiHandler {
                 ScmiDeviceError::UnsupportedRequest => {
                     info!("Unsupported request for {}", device_index);
                     Response::from(ReturnStatus::NotSupported)
+                }
+                ScmiDeviceError::GenericError => {
+                    warn!("Device error in {}", device_index);
+                    Response::from(ReturnStatus::GenericError)
                 }
             },
         }

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -480,6 +480,9 @@ pub enum ScmiDeviceError {
 }
 
 pub trait ScmiDevice: Send {
+    fn short_help(&self) -> String;
+    fn long_help(&self) -> String;
+    fn parameters_help(&self) -> Vec<String>;
     fn configure(&mut self, properties: &DeviceProperties) -> Result<(), String>;
     fn protocol(&self) -> ProtocolId;
     fn handle(

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -870,7 +870,7 @@ mod tests {
         let mut handler = ScmiHandler::new();
         for i in 0..2 {
             let properties = DeviceProperties::new(vec![("name".to_owned(), format!("fake{i}"))]);
-            let fake_sensor = FakeSensor::new(&properties).unwrap();
+            let fake_sensor = FakeSensor::new_device(&properties).unwrap();
             handler.register_device(fake_sensor);
         }
         handler

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use log::debug;
+
+pub type MessageHeader = u32;
+// SCMI specification talks about Le32 parameter and return values.
+// VirtIO SCMI specification talks about u8 SCMI values.
+// Let's stick with SCMI specification for implementation simplicity.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(dead_code)]
+enum MessageValue {
+    Signed(i32),
+    Unsigned(u32),
+    String(String, usize), // string, expected characters
+}
+type MessageValues = Vec<MessageValue>;
+
+#[derive(Debug, PartialEq)]
+enum MessageType {
+    // 4-bit unsigned integer
+    Command,     // 0
+    Unsupported, // anything else
+}
+type MessageId = u8;
+type ProtocolId = u8;
+type NParameters = u8;
+
+#[derive(Clone, Copy)]
+// Not all the codes are currently used but let's have a complete return status
+// enumeration from the SCMI specification here.
+#[allow(dead_code)]
+enum ReturnStatus {
+    // 32-bit signed integer
+    Success = 0,
+    NotSupported = -1,
+    InvalidParameters = -2,
+    Denied = -3,
+    NotFound = -4,
+    OutOfRange = -5,
+    Busy = -6,
+    CommsError = -7,
+    GenericError = -8,
+    HardwareError = -9,
+    ProtocolError = -10,
+    // -11..-127: reserved
+    // <-127: vendor specific
+}
+
+impl ReturnStatus {
+    const fn as_value(&self) -> MessageValue {
+        MessageValue::Signed(*self as i32)
+    }
+}
+
+struct Response {
+    values: MessageValues,
+}
+
+impl From<ReturnStatus> for Response {
+    fn from(value: ReturnStatus) -> Self {
+        Self {
+            values: vec![value.as_value()],
+        }
+    }
+}
+
+impl From<&MessageValues> for Response {
+    #[allow(dead_code)]
+    fn from(value: &MessageValues) -> Self {
+        let mut response_values = vec![ReturnStatus::Success.as_value()];
+        response_values.extend_from_slice(value.as_slice());
+        Self {
+            values: response_values,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ScmiResponse {
+    header: MessageHeader,
+    ret_bytes: Vec<u8>,
+}
+
+impl ScmiResponse {
+    fn from(header: MessageHeader, response: Response) -> Self {
+        debug!("response arguments: {:?}", response.values);
+        let mut ret_bytes: Vec<u8> = vec![];
+        ret_bytes.extend_from_slice(&header.to_le_bytes());
+        for v in response.values {
+            let mut bytes = match v {
+                MessageValue::Signed(n) => n.to_le_bytes().to_vec(),
+                MessageValue::Unsigned(n) => n.to_le_bytes().to_vec(),
+                // Strings can be UTF-8 or ASCII and they must be
+                // null-terminated in either case.  Let's put the
+                // null-terminator here rather than having to put it
+                // to all the strings anywhere.
+                MessageValue::String(s, size) => {
+                    let mut v = s.as_bytes().to_vec();
+                    let v_len = v.len();
+                    // The string must be NULL terminated, at least one NULL must be present.
+                    assert!(
+                        v_len < size,
+                        "String longer than specified: {v_len} >= {size}"
+                    );
+                    v.resize(size, b'\0');
+                    v
+                }
+            };
+            ret_bytes.append(&mut bytes)
+        }
+        debug!("ret bytes: {:?}", ret_bytes);
+        Self { header, ret_bytes }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.ret_bytes.as_slice()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.ret_bytes.len()
+    }
+
+    pub(crate) fn communication_error(&self) -> Self {
+        Self::from(self.header, Response::from(ReturnStatus::CommsError))
+    }
+}
+
+pub struct ScmiHandler {}
+
+impl ScmiHandler {
+    pub const fn new() -> Self {
+        Self {}
+    }
+
+    pub fn handle(&mut self, request: ScmiRequest) -> ScmiResponse {
+        let response = match request.message_type {
+            // TODO: Implement a mechanism to invoke the proper protocol &
+            // message handling on command requests.
+            MessageType::Command => Response::from(ReturnStatus::NotSupported),
+            MessageType::Unsupported => Response::from(ReturnStatus::NotSupported),
+        };
+        ScmiResponse::from(request.header, response)
+    }
+
+    pub fn number_of_parameters(&self, _request: &ScmiRequest) -> Option<NParameters> {
+        // TODO: Implement.
+        Some(0)
+    }
+
+    pub fn store_parameters(&self, _request: &mut ScmiRequest, _buffer: &[u8]) {
+        // TODO: Implement (depends on knowledge of the number of parameters).
+    }
+}
+
+#[allow(dead_code)]
+pub struct ScmiRequest {
+    header: MessageHeader,     // 32-bit unsigned integer, split below:
+    message_id: MessageId,     // bits 7:0
+    message_type: MessageType, // bits 9:8
+    protocol_id: ProtocolId,   // bits 17:10
+    // token: u16,             // bits 27:18
+    // bits 31:28 are reserved, must be 0
+    _parameters: Option<MessageValues>, // set later based on the number of parameters
+}
+
+impl ScmiRequest {
+    pub(crate) fn new(header: MessageHeader) -> Self {
+        let protocol_id: u8 = ((header >> 10) & 0xFF).try_into().unwrap();
+        let message_id: u8 = (header & 0xFF).try_into().unwrap();
+        // Token is an arbitrary info, the Linux SCMI driver uses it as a sequence number.
+        // No actual meaning for vhost except copying the unchanged header in the response
+        // as required by SCMI specification. We extract it here only for debugging purposes.
+        let token: u16 = ((header >> 18) & 0x3FF).try_into().unwrap();
+        let message_type = match (header >> 8) & 0x3 {
+            0 => MessageType::Command,
+            _ => MessageType::Unsupported,
+        };
+        debug!(
+            "SCMI request: protocol id={}, message id={}, message_type={:?}, token={}",
+            protocol_id, message_id, message_type, token
+        );
+        Self {
+            header,
+            message_id,
+            message_type,
+            protocol_id,
+            _parameters: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_response_from_status() {
+        let status = ReturnStatus::Busy;
+        let response = Response::from(status);
+        assert_eq!(response.values.len(), 1);
+        assert_eq!(response.values[0], MessageValue::Signed(status as i32));
+    }
+
+    #[test]
+    fn test_response_from_values() {
+        let status = ReturnStatus::Success;
+        let values = vec![
+            MessageValue::Signed(-2),
+            MessageValue::Unsigned(8),
+            MessageValue::String("foo".to_owned(), 16),
+        ];
+        let len = values.len() + 1;
+        let response = Response::from(&values);
+        assert_eq!(response.values.len(), len);
+        assert_eq!(response.values[0], MessageValue::Signed(status as i32));
+        for i in 1..len {
+            assert_eq!(response.values[i], values[i - 1]);
+        }
+    }
+
+    fn make_response(header: MessageHeader) -> ScmiResponse {
+        let values = vec![
+            MessageValue::Signed(-2),
+            MessageValue::Unsigned(800_000_000),
+            MessageValue::String("foo".to_owned(), 16),
+        ];
+        let response = Response::from(&values);
+        ScmiResponse::from(header, response)
+    }
+
+    #[test]
+    fn test_response() {
+        let header: MessageHeader = 1_000_000;
+        let scmi_response = make_response(header);
+        assert_eq!(scmi_response.header, header);
+        let bytes: Vec<u8> = vec![
+            0x40, 0x42, 0x0F, 0x00, // header
+            0x00, 0x00, 0x00, 0x00, // SUCCESS
+            0xFE, 0xFF, 0xFF, 0xFF, // -2
+            0x00, 0x08, 0xAF, 0x2F, // 800 000 000
+            0x66, 0x6F, 0x6F, 0x00, // "foo" + NULLs
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        assert_eq!(scmi_response.ret_bytes, bytes);
+        assert_eq!(scmi_response.len(), bytes.len());
+        assert_eq!(scmi_response.as_slice(), bytes.as_slice());
+    }
+
+    #[test]
+    fn test_communication_error_response() {
+        let header: MessageHeader = 1_000_000;
+        let scmi_response = make_response(header).communication_error();
+        assert_eq!(scmi_response.header, header);
+        let bytes: Vec<u8> = vec![
+            0x40, 0x42, 0x0F, 0x00, // header
+            0xF9, 0xFF, 0xFF, 0xFF, // ComsError
+        ];
+        assert_eq!(scmi_response.ret_bytes, bytes);
+    }
+
+    #[test]
+    fn test_request() {
+        let header: MessageHeader = 0x000304AB;
+        let request = ScmiRequest::new(header);
+        assert_eq!(request.header, header);
+        assert_eq!(request.message_id, 0xAB);
+        assert_eq!(request.message_type, MessageType::Command);
+        assert_eq!(request.protocol_id, 0xC1);
+    }
+
+    #[test]
+    fn test_request_unsupported() {
+        let header: MessageHeader = 0x000102AB;
+        let request = ScmiRequest::new(header);
+        assert_eq!(request.header, header);
+        assert_eq!(request.message_id, 0xAB);
+        assert_eq!(request.message_type, MessageType::Unsupported);
+        assert_eq!(request.protocol_id, 0x40);
+    }
+}

--- a/crates/scmi/src/scmi.rs
+++ b/crates/scmi/src/scmi.rs
@@ -11,8 +11,6 @@ use itertools::Itertools;
 use log::{debug, error, info};
 use thiserror::Error as ThisError;
 
-use crate::DeviceProperties;
-
 pub type MessageHeader = u32;
 
 pub const MAX_SIMPLE_STRING_LENGTH: usize = 16; // incl. NULL terminator
@@ -480,10 +478,6 @@ pub enum ScmiDeviceError {
 }
 
 pub trait ScmiDevice: Send {
-    fn short_help(&self) -> String;
-    fn long_help(&self) -> String;
-    fn parameters_help(&self) -> Vec<String>;
-    fn configure(&mut self, properties: &DeviceProperties) -> Result<(), String>;
     fn protocol(&self) -> ProtocolId;
     fn handle(
         &mut self,
@@ -722,7 +716,7 @@ impl ScmiHandler {
 
 #[cfg(test)]
 mod tests {
-    use crate::devices::FakeSensor;
+    use crate::devices::{DeviceProperties, FakeSensor};
 
     use super::*;
 
@@ -866,9 +860,8 @@ mod tests {
     fn make_handler() -> ScmiHandler {
         let mut handler = ScmiHandler::new();
         for i in 0..2 {
-            let properties = vec![("name".to_owned(), format!("fake{i}"))];
-            let mut fake_sensor = FakeSensor::new();
-            fake_sensor.configure(&properties).unwrap();
+            let properties = DeviceProperties::new(vec![("name".to_owned(), format!("fake{i}"))]);
+            let fake_sensor = FakeSensor::new(&properties).unwrap();
             handler.register_device(fake_sensor);
         }
         handler

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -103,7 +103,15 @@ impl VuScmiBackend {
             }
             match device_mapping.get(name.as_str()) {
                 Some(specification) => match (specification.constructor)(properties) {
-                    Ok(device) => handler.register_device(device),
+                    Ok(mut device) => {
+                        if let Err(error) = device.initialize() {
+                            return Result::Err(VuScmiError::DeviceConfigurationError(
+                                name.clone(),
+                                error,
+                            ));
+                        }
+                        handler.register_device(device);
+                    }
                     Err(error) => {
                         return Result::Err(VuScmiError::DeviceConfigurationError(
                             name.clone(),

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -23,7 +23,7 @@ use vm_memory::{
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
-use crate::devices::common::{available_devices, print_devices_help, DeviceError};
+use crate::devices::common::{available_devices, DeviceError};
 use crate::scmi::{MessageHeader, ScmiHandler, ScmiRequest};
 use crate::VuScmiConfig;
 
@@ -101,9 +101,6 @@ impl VuScmiBackend {
         let mut handler = ScmiHandler::new();
         let device_mapping = available_devices();
         for (name, properties) in config.devices.iter() {
-            if name == "help" {
-                print_devices_help();
-            }
             match device_mapping.get(name.as_str()) {
                 Some(specification) => match (specification.constructor)(properties) {
                     Ok(mut device) => {

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -20,7 +20,7 @@ use vm_memory::{
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
-use crate::devices::{available_devices, print_devices_help, DeviceError};
+use crate::devices::common::{available_devices, print_devices_help, DeviceError};
 use crate::scmi::{MessageHeader, ScmiHandler, ScmiRequest};
 use crate::VuScmiConfig;
 
@@ -108,7 +108,7 @@ impl VuScmiBackend {
                         return Result::Err(VuScmiError::DeviceConfigurationError(
                             name.clone(),
                             error,
-                        ))
+                        ));
                     }
                 },
                 None => return Result::Err(VuScmiError::UnknownDeviceRequested(name.clone())),

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Based on https://github.com/rust-vmm/vhost-device, Copyright by Linaro Ltd.
 
+//! General part of the vhost-user SCMI backend.  Nothing very different from
+//! the other rust-vmm backends.
+
 use log::{debug, error, warn};
 use std::io;
 use std::io::Result as IoResult;
@@ -82,14 +85,14 @@ pub struct VuScmiBackend {
     event_idx: bool,
     pub exit_event: EventFd,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
-    // Event vring and descriptors serve for asynchronous responses and notifications.
-    // They are obtained from the driver and we store them here for later use.
-    // (We currently don't implement asynchronous responses or notifications but we support
-    // the event queue because the Linux VIRTIO SCMI driver seems to be unhappy if it is not
-    // present. And it doesn't harm to be ready for possible event queue use in future.)
+    /// Event vring and descriptors serve for asynchronous responses and notifications.
+    /// They are obtained from the driver and we store them here for later use.
+    /// (We currently don't implement asynchronous responses or notifications but we support
+    /// the event queue because the Linux VIRTIO SCMI driver seems to be unhappy if it is not
+    /// present. And it doesn't harm to be ready for possible event queue use in future.)
     event_vring: Option<VringRwLock>,
     event_descriptors: Vec<DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>>,
-    // The abstraction of request handling, with all the needed information stored inside.
+    /// The abstraction of request handling, with all the needed information stored inside.
     scmi_handler: ScmiHandler,
 }
 

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -21,6 +21,7 @@ use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
 use crate::devices::available_devices;
+use crate::devices::print_devices_help;
 use crate::scmi::ScmiDevice;
 use crate::scmi::{MessageHeader, ScmiHandler, ScmiRequest};
 use crate::VuScmiConfig;
@@ -99,6 +100,9 @@ impl VuScmiBackend {
         let mut handler = ScmiHandler::new();
         let device_mapping = available_devices();
         for (name, properties) in config.devices.iter() {
+            if name == "help" {
+                print_devices_help();
+            }
             match device_mapping.get(name) {
                 Some(constructor) => {
                     let mut device: Box<dyn ScmiDevice> = constructor();

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -34,7 +34,7 @@ const EVENT_QUEUE: u16 = 1;
 
 const VIRTIO_SCMI_F_P2A_CHANNELS: u16 = 0;
 
-#[derive(Debug, PartialEq, Eq, ThisError)]
+#[derive(Debug, ThisError)]
 pub enum VuScmiError {
     #[error("Descriptor not found")]
     DescriptorNotFound,
@@ -638,22 +638,24 @@ mod tests {
         // Have only one descriptor, expected two.
         let parameters = vec![&default];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedDescriptorCount(1)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedDescriptorCount(1) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Have three descriptors, expected two.
         let parameters = vec![&default, &default, &default];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedDescriptorCount(3)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedDescriptorCount(3) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Write only descriptors.
         let p = DescParameters {
@@ -663,12 +665,13 @@ mod tests {
         };
         let parameters = vec![&p, &p];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedWriteOnlyDescriptor(0)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedWriteOnlyDescriptor(0) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid request address.
         let parameters = vec![
@@ -684,12 +687,13 @@ mod tests {
             },
         ];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::DescriptorReadFailed
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::DescriptorReadFailed => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid request length (very small).
         let parameters = vec![
@@ -705,30 +709,33 @@ mod tests {
             },
         ];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedMinimumDescriptorSize(4, 2)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedMinimumDescriptorSize(4, 2) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid request length (too small).
         let desc_chain = build_cmd_desc_chain(0x10, 0x2, vec![]);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedDescriptorSize(8, 4)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedDescriptorSize(8, 4) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid request length (too large).
         let desc_chain = build_cmd_desc_chain(0x10, 0x0, vec![0]);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedDescriptorSize(4, 8)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedDescriptorSize(4, 8) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Read only descriptors.
         let p = DescParameters {
@@ -738,12 +745,13 @@ mod tests {
         };
         let parameters = vec![&p, &p];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedReadableDescriptor(1)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedReadableDescriptor(1) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid response address.
         let parameters = vec![
@@ -759,12 +767,13 @@ mod tests {
             },
         ];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::DescriptorWriteFailed
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::DescriptorWriteFailed => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Invalid response length.
         let parameters = vec![
@@ -780,12 +789,13 @@ mod tests {
             },
         ];
         let desc_chain = build_dummy_desc_chain(parameters);
-        assert_eq!(
-            backend
-                .process_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::InsufficientDescriptorSize(8, 6)
-        );
+        match backend
+            .process_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::InsufficientDescriptorSize(8, 6) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
     }
 
     #[test]
@@ -832,12 +842,13 @@ mod tests {
             len: 0,
         };
         let desc_chain = build_dummy_desc_chain(vec![&p, &p]);
-        assert_eq!(
-            backend
-                .process_event_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedDescriptorCount(2)
-        );
+        match backend
+            .process_event_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedDescriptorCount(2) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
 
         // Read only descriptor
         let p = DescParameters {
@@ -846,12 +857,13 @@ mod tests {
             len: 0,
         };
         let desc_chain = build_dummy_desc_chain(vec![&p]);
-        assert_eq!(
-            backend
-                .process_event_requests(vec![desc_chain], &vring)
-                .unwrap_err(),
-            VuScmiError::UnexpectedReadableDescriptor(0)
-        );
+        match backend
+            .process_event_requests(vec![desc_chain], &vring)
+            .unwrap_err()
+        {
+            VuScmiError::UnexpectedReadableDescriptor(0) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/scmi/src/vhu_scmi.rs
+++ b/crates/scmi/src/vhu_scmi.rs
@@ -1,0 +1,787 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+// Based on https://github.com/rust-vmm/vhost-device, Copyright by Linaro Ltd.
+
+use log::{debug, error, warn};
+use std::io;
+use std::io::Result as IoResult;
+use std::mem::size_of;
+use thiserror::Error as ThisError;
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_ring::{
+    VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
+};
+use virtio_queue::{DescriptorChain, QueueOwnedT};
+use vm_memory::{
+    Bytes, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap,
+};
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+
+use crate::scmi::{MessageHeader, ScmiHandler, ScmiRequest};
+
+// QUEUE_SIZE must be apparently at least 1024 for MMIO.
+// There is probably a maximum size per descriptor defined in the kernel.
+const QUEUE_SIZE: usize = 1024;
+const NUM_QUEUES: usize = 2;
+
+const COMMAND_QUEUE: u16 = 0;
+const EVENT_QUEUE: u16 = 1;
+
+const VIRTIO_SCMI_F_P2A_CHANNELS: u16 = 0;
+
+#[derive(Debug, PartialEq, Eq, ThisError)]
+pub enum VuScmiError {
+    #[error("Descriptor not found")]
+    DescriptorNotFound,
+    #[error("Descriptor read failed")]
+    DescriptorReadFailed,
+    #[error("Descriptor write failed")]
+    DescriptorWriteFailed,
+    #[error("Failed to create new EventFd")]
+    EventFdFailed,
+    #[error("Failed to handle event, didn't match EPOLLIN")]
+    HandleEventNotEpollIn,
+    #[error("Failed to handle unknown event")]
+    HandleEventUnknownEvent,
+    #[error("Isufficient descriptor size, required: {0}, found: {1}")]
+    InsufficientDescriptorSize(usize, usize),
+    #[error("Failed to send notification")]
+    SendNotificationFailed,
+    #[error("Invalid descriptor count {0}")]
+    UnexpectedDescriptorCount(usize),
+    #[error("Invalid descriptor size, expected: {0}, found: {1}")]
+    UnexpectedDescriptorSize(usize, usize),
+    #[error("Invalid descriptor size, expected at least: {0}, found: {1}")]
+    UnexpectedMinimumDescriptorSize(usize, usize),
+    #[error("Received unexpected readable descriptor at index {0}")]
+    UnexpectedReadableDescriptor(usize),
+    #[error("Received unexpected write only descriptor at index {0}")]
+    UnexpectedWriteOnlyDescriptor(usize),
+}
+
+impl From<VuScmiError> for io::Error {
+    fn from(e: VuScmiError) -> Self {
+        Self::new(io::ErrorKind::Other, e)
+    }
+}
+
+type Result<T> = std::result::Result<T, VuScmiError>;
+
+type ScmiDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
+
+pub struct VuScmiBackend {
+    event_idx: bool,
+    pub exit_event: EventFd,
+    mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    // Event vring and descriptors serve for asynchronous responses and notifications.
+    // They are obtained from the driver and we store them here for later use.
+    // (We currently don't implement asynchronous responses or notifications but we support
+    // the event queue because the Linux VIRTIO SCMI driver seems to be unhappy if it is not
+    // present. And it doesn't harm to be ready for possible event queue use in future.)
+    event_vring: Option<VringRwLock>,
+    event_descriptors: Vec<DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>>,
+    // The abstraction of request handling, with all the needed information stored inside.
+    scmi_handler: ScmiHandler,
+}
+
+impl VuScmiBackend {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            event_idx: false,
+            exit_event: EventFd::new(EFD_NONBLOCK).map_err(|_| VuScmiError::EventFdFailed)?,
+            mem: None,
+            event_vring: None,
+            event_descriptors: vec![],
+            scmi_handler: ScmiHandler::new(),
+        })
+    }
+
+    pub fn process_requests(
+        &mut self,
+        requests: Vec<ScmiDescriptorChain>,
+        vring: &VringRwLock,
+    ) -> Result<bool> {
+        if requests.is_empty() {
+            return Ok(true);
+        }
+
+        for desc_chain in requests {
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+            if descriptors.len() != 2 {
+                return Err(VuScmiError::UnexpectedDescriptorCount(descriptors.len()));
+            }
+
+            let desc_request = descriptors[0];
+            if desc_request.is_write_only() {
+                return Err(VuScmiError::UnexpectedWriteOnlyDescriptor(0));
+            }
+
+            let read_desc_len: usize = desc_request.len() as usize;
+            let header_size = size_of::<MessageHeader>();
+            if read_desc_len < header_size {
+                return Err(VuScmiError::UnexpectedMinimumDescriptorSize(
+                    header_size,
+                    read_desc_len,
+                ));
+            }
+
+            let header = desc_chain
+                .memory()
+                .read_obj::<MessageHeader>(desc_request.addr())
+                .map_err(|_| VuScmiError::DescriptorReadFailed)?;
+            let mut scmi_request = ScmiRequest::new(header);
+            let n_parameters = self.scmi_handler.number_of_parameters(&scmi_request);
+            debug!("SCMI request with n parameters: {:?}", n_parameters);
+            let value_size = 4;
+            if let Some(expected_parameters) = n_parameters {
+                if expected_parameters > 0 {
+                    let param_bytes = (expected_parameters as usize) * value_size;
+                    let total_size = value_size + param_bytes;
+                    if read_desc_len != total_size {
+                        return Err(VuScmiError::UnexpectedDescriptorSize(
+                            total_size,
+                            read_desc_len,
+                        ));
+                    }
+                    let mut buffer: Vec<u8> = vec![0; header_size + param_bytes];
+                    desc_chain
+                        .memory()
+                        .read_slice(&mut buffer, desc_request.addr())
+                        .map_err(|_| VuScmiError::DescriptorReadFailed)?;
+                    self.scmi_handler
+                        .store_parameters(&mut scmi_request, &buffer[header_size..]);
+                } else if read_desc_len != value_size {
+                    return Err(VuScmiError::UnexpectedDescriptorSize(
+                        value_size,
+                        read_desc_len,
+                    ));
+                }
+            }
+
+            debug!("Calling SCMI request handler");
+            let mut response = self.scmi_handler.handle(scmi_request);
+            debug!("SCMI response: {:?}", response);
+
+            let desc_response = descriptors[1];
+            if !desc_response.is_write_only() {
+                return Err(VuScmiError::UnexpectedReadableDescriptor(1));
+            }
+
+            let write_desc_len: usize = desc_response.len() as usize;
+            if response.len() > write_desc_len {
+                error!(
+                    "Response of length {} cannot fit into the descriptor size {}",
+                    response.len(),
+                    write_desc_len
+                );
+                response = response.communication_error();
+                if response.len() > write_desc_len {
+                    return Err(VuScmiError::InsufficientDescriptorSize(
+                        response.len(),
+                        write_desc_len,
+                    ));
+                }
+            }
+            desc_chain
+                .memory()
+                .write_slice(response.as_slice(), desc_response.addr())
+                .map_err(|_| VuScmiError::DescriptorWriteFailed)?;
+
+            if vring
+                .add_used(desc_chain.head_index(), response.len() as u32)
+                .is_err()
+            {
+                error!("Couldn't return used descriptors to the ring");
+            }
+        }
+        Ok(true)
+    }
+
+    fn process_command_queue(&mut self, vring: &VringRwLock) -> Result<()> {
+        debug!("Processing command queue");
+        let requests: Vec<_> = vring
+            .get_mut()
+            .get_queue_mut()
+            .iter(self.mem.as_ref().unwrap().memory())
+            .map_err(|_| VuScmiError::DescriptorNotFound)?
+            .collect();
+
+        debug!("Requests to process: {}", requests.len());
+        match self.process_requests(requests, vring) {
+            Ok(_) => {
+                // Send notification once all the requests are processed
+                debug!("Sending processed request notification");
+                vring
+                    .signal_used_queue()
+                    .map_err(|_| VuScmiError::SendNotificationFailed)?;
+                debug!("Notification sent");
+            }
+            Err(err) => {
+                warn!("Failed SCMI request: {}", err);
+                return Err(err);
+            }
+        }
+        debug!("Processing command queue finished");
+        Ok(())
+    }
+
+    fn start_event_queue(&mut self, vring: &VringRwLock) {
+        if self.event_vring.is_none() {
+            self.event_vring = Some(vring.clone());
+        }
+    }
+
+    pub fn process_event_requests(
+        &mut self,
+        requests: Vec<ScmiDescriptorChain>,
+        _vring: &VringRwLock,
+    ) -> Result<bool> {
+        // The requests here are notifications from the guest about adding
+        // fresh buffers for the used ring. The Linux driver allocates 256
+        // buffers for the event queue initially (arriving here in several
+        // batches) and then adds a free buffer after each message delivered
+        // through the event queue.
+        for desc_chain in requests {
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+            debug!(
+                "SCMI event request with n descriptors: {}",
+                descriptors.len()
+            );
+            if descriptors.len() != 1 {
+                return Err(VuScmiError::UnexpectedDescriptorCount(descriptors.len()));
+            }
+
+            let desc = descriptors[0];
+            if !desc.is_write_only() {
+                return Err(VuScmiError::UnexpectedReadableDescriptor(0));
+            }
+            debug!("SCMI event request avail descriptor length: {}", desc.len());
+
+            self.event_descriptors.push(desc_chain);
+        }
+        Ok(true)
+    }
+
+    fn process_event_queue(&mut self, vring: &VringRwLock) -> Result<()> {
+        debug!("Processing event queue");
+
+        let requests: Vec<_> = vring
+            .get_mut()
+            .get_queue_mut()
+            .iter(self.mem.as_ref().unwrap().memory())
+            .map_err(|_| VuScmiError::DescriptorNotFound)?
+            .collect();
+        debug!("Requests to process: {}", requests.len());
+        match self.process_event_requests(requests, vring) {
+            Ok(_) => {
+                // Send notification once all the requests are processed
+                debug!("Sending processed request notification");
+                vring
+                    .signal_used_queue()
+                    .map_err(|_| VuScmiError::SendNotificationFailed)?;
+                debug!("Notification sent");
+            }
+            Err(err) => {
+                warn!("Failed SCMI request: {}", err);
+                return Err(err);
+            }
+        }
+        self.start_event_queue(vring);
+        debug!("Processing event queue finished");
+        Ok(())
+    }
+}
+
+/// VhostUserBackend trait methods
+impl VhostUserBackendMut<VringRwLock, ()> for VuScmiBackend {
+    fn num_queues(&self) -> usize {
+        debug!("Num queues called");
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        debug!("Max queue size called");
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        debug!("Features called");
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | 1 << VIRTIO_SCMI_F_P2A_CHANNELS
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        debug!("Protocol features called");
+        VhostUserProtocolFeatures::MQ
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        self.event_idx = enabled;
+        debug!("Event idx set to: {}", enabled);
+    }
+
+    fn update_memory(&mut self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {
+        debug!("Update memory called");
+        self.mem = Some(mem);
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: EventSet,
+        vrings: &[VringRwLock],
+        _thread_id: usize,
+    ) -> IoResult<bool> {
+        debug!("Handle event called");
+        if evset != EventSet::IN {
+            warn!("Non-input event");
+            return Err(VuScmiError::HandleEventNotEpollIn.into());
+        }
+
+        match device_event {
+            COMMAND_QUEUE => {
+                let vring = &vrings[COMMAND_QUEUE as usize];
+
+                if self.event_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        vring.disable_notification().unwrap();
+                        self.process_command_queue(vring)?;
+                        if !vring.enable_notification().unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    self.process_command_queue(vring)?;
+                }
+            }
+
+            EVENT_QUEUE => {
+                let vring = &vrings[EVENT_QUEUE as usize];
+
+                if self.event_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        vring.disable_notification().unwrap();
+                        self.process_event_queue(vring)?;
+                        if !vring.enable_notification().unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    self.process_event_queue(vring)?;
+                }
+            }
+
+            _ => {
+                warn!("unhandled device_event: {}", device_event);
+                return Err(VuScmiError::HandleEventUnknownEvent.into());
+            }
+        }
+        debug!("Handle event finished");
+        Ok(false)
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+        debug!("Exit event called");
+        self.exit_event.try_clone().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
+    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+
+    use super::*;
+
+    fn build_event_desc_chain() -> ScmiDescriptorChain {
+        let mem = &GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let vq = MockSplitQueue::new(mem, 16);
+        let next_addr = vq.desc_table().total_size() + 0x100;
+
+        // Descriptor for the SCMI event
+        let desc_response = Descriptor::new(next_addr, 0x100, VRING_DESC_F_WRITE as u16, 0);
+        vq.desc_table().store(0, desc_response).unwrap();
+
+        // Put the descriptor index 0 in the first available ring position.
+        mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
+            .unwrap();
+        // Set `avail_idx` to 1.
+        mem.write_obj(1u16, vq.avail_addr().unchecked_add(2))
+            .unwrap();
+        // Create descriptor chain from pre-filled memory.
+        vq.create_queue::<Queue>()
+            .unwrap()
+            .iter(GuestMemoryAtomic::new(mem.clone()).memory())
+            .unwrap()
+            .next()
+            .unwrap()
+    }
+
+    // Build just empty descriptors
+    struct DescParameters {
+        addr: Option<u64>,
+        flags: u16,
+        len: u32,
+    }
+    fn build_dummy_desc_chain(parameters: Vec<&DescParameters>) -> ScmiDescriptorChain {
+        let mem = &GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+        let vq = MockSplitQueue::new(mem, 16);
+
+        for (i, p) in parameters.iter().enumerate() {
+            let mut f: u16 = if i == parameters.len() - 1 {
+                0
+            } else {
+                VRING_DESC_F_NEXT as u16
+            };
+            f |= p.flags;
+            let offset = match p.addr {
+                Some(addr) => addr,
+                _ => 0x100,
+            };
+            let desc = Descriptor::new(offset, p.len, f, (i + 1) as u16);
+            vq.desc_table().store(i as u16, desc).unwrap();
+        }
+
+        // Put the descriptor index 0 in the first available ring position.
+        mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
+            .unwrap();
+        // Set `avail_idx` to 1.
+        mem.write_obj(1u16, vq.avail_addr().unchecked_add(2))
+            .unwrap();
+        // Create descriptor chain from pre-filled memory
+        vq.create_queue::<Queue>()
+            .unwrap()
+            .iter(GuestMemoryAtomic::new(mem.clone()).memory())
+            .unwrap()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_process_requests_failure() {
+        let mut backend = VuScmiBackend::new().unwrap();
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        let vring = VringRwLock::new(mem, 0x1000).unwrap();
+        let default = DescParameters {
+            addr: None,
+            flags: 0,
+            len: 0,
+        };
+
+        // Have only one descriptor, expected two.
+        let parameters = vec![&default];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedDescriptorCount(1)
+        );
+
+        // Have three descriptors, expected two.
+        let parameters = vec![&default, &default, &default];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedDescriptorCount(3)
+        );
+
+        // Write only descriptors.
+        let p = DescParameters {
+            addr: None,
+            flags: VRING_DESC_F_WRITE as u16,
+            len: 0,
+        };
+        let parameters = vec![&p, &p];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedWriteOnlyDescriptor(0)
+        );
+
+        // Invalid request address.
+        let parameters = vec![
+            &DescParameters {
+                addr: Some(0x10000),
+                flags: 0,
+                len: 4,
+            },
+            &DescParameters {
+                addr: None,
+                flags: VRING_DESC_F_WRITE as u16,
+                len: 4,
+            },
+        ];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::DescriptorReadFailed
+        );
+
+        // Invalid request length (very small).
+        let parameters = vec![
+            &DescParameters {
+                addr: None,
+                flags: 0,
+                len: 2,
+            },
+            &DescParameters {
+                addr: None,
+                flags: VRING_DESC_F_WRITE as u16,
+                len: 4,
+            },
+        ];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedMinimumDescriptorSize(4, 2)
+        );
+
+        // Read only descriptors.
+        let p = DescParameters {
+            addr: None,
+            flags: 0,
+            len: 4,
+        };
+        let parameters = vec![&p, &p];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedReadableDescriptor(1)
+        );
+
+        // Invalid response address.
+        let parameters = vec![
+            &DescParameters {
+                addr: None,
+                flags: 0,
+                len: 4,
+            },
+            &DescParameters {
+                addr: Some(0x10000),
+                flags: VRING_DESC_F_WRITE as u16,
+                len: 8,
+            },
+        ];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::DescriptorWriteFailed
+        );
+
+        // Invalid response length.
+        let parameters = vec![
+            &DescParameters {
+                addr: None,
+                flags: 0,
+                len: 4,
+            },
+            &DescParameters {
+                addr: None,
+                flags: VRING_DESC_F_WRITE as u16,
+                len: 6,
+            },
+        ];
+        let desc_chain = build_dummy_desc_chain(parameters);
+        assert_eq!(
+            backend
+                .process_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::InsufficientDescriptorSize(8, 6)
+        );
+    }
+
+    #[test]
+    fn test_event_requests() {
+        let mut backend = VuScmiBackend::new().unwrap();
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        let vring = VringRwLock::new(mem, 0x1000).unwrap();
+
+        // Descriptor chain size zero, shouldn't fail and should be no-op
+        backend
+            .process_event_requests(Vec::<ScmiDescriptorChain>::new(), &vring)
+            .unwrap();
+        assert_eq!(backend.event_descriptors.len(), 0);
+
+        // Valid event descriptors, should get stored
+        let desc_chains = vec![build_event_desc_chain(), build_event_desc_chain()];
+        backend.process_event_requests(desc_chains, &vring).unwrap();
+        assert_eq!(backend.event_descriptors.len(), 2);
+
+        // Some more event descriptors
+        let desc_chains = vec![
+            build_event_desc_chain(),
+            build_event_desc_chain(),
+            build_event_desc_chain(),
+        ];
+        backend.process_event_requests(desc_chains, &vring).unwrap();
+        assert_eq!(backend.event_descriptors.len(), 5);
+    }
+
+    #[test]
+    fn test_event_requests_failure() {
+        let mut backend = VuScmiBackend::new().unwrap();
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        let vring = VringRwLock::new(mem, 0x1000).unwrap();
+
+        // Invalid number of desc chains
+        let p = DescParameters {
+            addr: None,
+            flags: 0,
+            len: 0,
+        };
+        let desc_chain = build_dummy_desc_chain(vec![&p, &p]);
+        assert_eq!(
+            backend
+                .process_event_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedDescriptorCount(2)
+        );
+
+        // Read only descriptor
+        let p = DescParameters {
+            addr: None,
+            flags: 0,
+            len: 0,
+        };
+        let desc_chain = build_dummy_desc_chain(vec![&p]);
+        assert_eq!(
+            backend
+                .process_event_requests(vec![desc_chain], &vring)
+                .unwrap_err(),
+            VuScmiError::UnexpectedReadableDescriptor(0)
+        );
+    }
+
+    #[test]
+    fn test_backend() {
+        let mut backend = VuScmiBackend::new().unwrap();
+
+        assert_eq!(backend.num_queues(), NUM_QUEUES);
+        assert_eq!(backend.max_queue_size(), QUEUE_SIZE);
+        assert_eq!(backend.features(), 0x171000001);
+        assert_eq!(backend.protocol_features(), VhostUserProtocolFeatures::MQ);
+
+        assert_eq!(backend.queues_per_thread(), vec![0xffff_ffff]);
+
+        backend.set_event_idx(true);
+        assert!(backend.event_idx);
+
+        assert!(backend.exit_event(0).is_some());
+
+        let mem = GuestMemoryAtomic::new(
+            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap(),
+        );
+        backend.update_memory(mem.clone()).unwrap();
+
+        let vring_request = VringRwLock::new(mem.clone(), 0x1000).unwrap();
+        vring_request.set_queue_info(0x100, 0x200, 0x300).unwrap();
+        vring_request.set_queue_ready(true);
+
+        let vring_event = VringRwLock::new(mem, 0x1000).unwrap();
+        vring_event.set_queue_info(0x100, 0x200, 0x300).unwrap();
+        vring_event.set_queue_ready(true);
+
+        assert_eq!(
+            backend
+                .handle_event(
+                    0,
+                    EventSet::OUT,
+                    &[vring_request.clone(), vring_event.clone()],
+                    0,
+                )
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Other
+        );
+
+        assert_eq!(
+            backend
+                .handle_event(
+                    2,
+                    EventSet::IN,
+                    &[vring_request.clone(), vring_event.clone()],
+                    0,
+                )
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::Other
+        );
+
+        // Hit the loop part
+        backend.set_event_idx(true);
+        backend
+            .handle_event(
+                0,
+                EventSet::IN,
+                &[vring_request.clone(), vring_event.clone()],
+                0,
+            )
+            .unwrap();
+
+        // Hit the non-loop part
+        backend.set_event_idx(false);
+        backend
+            .handle_event(
+                0,
+                EventSet::IN,
+                &[vring_request.clone(), vring_event.clone()],
+                0,
+            )
+            .unwrap();
+
+        // Hit the loop part
+        backend.set_event_idx(true);
+        backend
+            .handle_event(
+                1,
+                EventSet::IN,
+                &[vring_request.clone(), vring_event.clone()],
+                0,
+            )
+            .unwrap();
+
+        // Hit the non-loop part
+        backend.set_event_idx(false);
+        backend
+            .handle_event(1, EventSet::IN, &[vring_request, vring_event], 0)
+            .unwrap();
+    }
+}


### PR DESCRIPTION
### Summary of the PR

This PR proposes to add an SCMI (System Control and Management Interface) vhost-user daemon.

### Commentary

SCMI vhost-user device support was added to QEMU and will be available in QEMU 8.1. This patch provides a corresponding vhost-user daemon. It implements the mandatory parts of the Base and Sensor management SCMI protocols. For the Sensor management protocol, SCMI bindings to selected parts of Linux industrial I/O (IIO) sysfs interface are implemented; a fake sensor device for testing is additionally implemented in vhost-user-scmi directly. Additionally, some instructions and patches regarding Linux kernel and its IIO dummy driver are provided in `kernel` subdirectory; these are not part of the functionality but can be useful as a related documentation and for testing.

I understand the PR is quite large but this is hard to avoid in an initial submission of a new device daemon. I assume SCMI support makes sense to be part of rust-vmm/vhost-device; in case you think otherwise, please tell me.