### PR TITLE
Update vhost-user-backend package dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ea9d5e8ec847cde4df1c04e586698a479706fd6beca37323f9d425b24b4c2f"
+checksum = "ab069cdedaf18a0673766eb0a07a0f4ee3ed1b8e17fbfe4aafe5b988e2de1d01"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
vhost-user-backend v0.10.0 introduced an issue that affects all vhost-user backends. I easily reproduced the problem with vhost-device-vsock: just restart the guest kernel and the device no longer works.

vhost-user-backend v0.10.1 includes the fix [1] for that issue.

[1] https://github.com/rust-vmm/vhost/pull/180
