### PR TITLE
vsock: Don't allow duplicate CIDs

### DIFF
--- a/crates/vsock/src/vhu_vsock.rs
+++ b/crates/vsock/src/vhu_vsock.rs
@@ -135,6 +135,8 @@ pub(crate) enum Error {
     EventFdCreate(std::io::Error),
     #[error("Raw vsock packets queue is empty")]
     EmptyRawPktsQueue,
+    #[error("CID already in use by another vsock device")]
+    CidAlreadyInUse,
 }
 
 impl std::convert::From<Error> for std::io::Error {


### PR DESCRIPTION
Currently, while updating the `cid_map`, it is not checked if the map already contained a key with the same CID before. So, fail to create the vsock thread if the CID is already in use.

Fixes #432.