### PR TITLE
build(deps): bump vm-memory to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3750e9b70da7f2ce2f7bf942c886d45f9bae064135c398f05635bf77e926a2ef"
+checksum = "9dc276f0d00c17b9aeb584da0f1e1c673df0d183cc2539e3636ec8cbc5eae99b"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",


### PR DESCRIPTION
This should hopefully stop cargo audit complaining about our old version.
