### PR TITLE
deps: bump rust-vmm-ci + silence new clippy warning

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 71.0,
+  "coverage_score": 73.42,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
We cannot fix the clippy warning before bumping since the old tools do not know the warning. Thus this first picks the submodule bumping commit from the now obsolete #435 PR.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
