### PR TITLE
Add experimental vhost-user-video backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ More information may be found in its [README file](./staging/README.md).
 Here is the list of device backends in **staging**:
 
 - [Sound](https://github.com/rust-vmm/vhost-device/blob/main/staging/vhost-device-sound/README.md)
+- [Video](https://github.com/rust-vmm/vhost-device/blob/main/staging/vhost-device-video/README.md)
 
 <!--
 Template:

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +242,17 @@ name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "enumn"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ad8cef1d801a4686bfd8919f0b30eac4c8e48968c437a6405ded4fb5272d2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -538,6 +555,17 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -964,6 +992,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "v4l2r"
+version = "0.0.1"
+source = "git+https://github.com/Gnurou/v4l2r?rev=110fd77#110fd773d15c787cbc6c2ded1bf8459c8df89f72"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "enumn",
+ "log",
+ "nix 0.27.1",
+ "thiserror",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1046,7 @@ dependencies = [
 name = "vhost-device-video"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "bitflags 2.4.1",
  "clap",
  "env_logger",
@@ -1013,7 +1055,10 @@ dependencies = [
  "libc",
  "log",
  "num_enum",
+ "rstest",
+ "tempfile",
  "thiserror",
+ "v4l2r",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -251,6 +251,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "epoll"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +322,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -540,6 +551,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +636,16 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -857,7 +909,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -867,6 +919,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -929,6 +992,27 @@ dependencies = [
  "pipewire",
  "rstest",
  "tempfile",
+ "thiserror",
+ "vhost",
+ "vhost-user-backend",
+ "virtio-bindings",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "vhost-device-video"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.1",
+ "clap",
+ "env_logger",
+ "epoll",
+ "futures-executor",
+ "libc",
+ "log",
+ "num_enum",
  "thiserror",
  "vhost",
  "vhost-user-backend",

--- a/staging/Cargo.toml
+++ b/staging/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "2"
 members = [
   "vhost-device-sound",
+  "vhost-device-video",
 ]

--- a/staging/vhost-device-video/CHANGELOG.md
+++ b/staging/vhost-device-video/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+## [0.1.0]
+
+First release
+

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "vhost-device-video"
+version = "0.1.0"
+authors = ["Albert Esteve <aesteve@redhat.com>"]
+description = "A virtio-video device using the vhost-user protocol."
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+keywords = ["vhost", "video", "virt", "backend"]
+license = "Apache-2.0 OR BSD-3-Clause"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
+default = []
+
+[dependencies]
+bitflags = "2.3.3"
+clap = { version = "4.4",  features = ["derive"] }
+env_logger = "0.10"
+epoll = "4.3"
+num_enum = "0.7"
+log = "0.4"
+libc = "0.2.147"
+thiserror = "1.0"
+futures-executor = { version = "0.3", features = ["thread-pool"] }
+vhost = { version = "0.8", features = ["vhost-user-slave"] }
+vhost-user-backend = "0.10"
+virtio-bindings = "0.2.1"
+virtio-queue = "0.9"
+vm-memory = "0.12"
+vmm-sys-util = "0.11"
+
+[dev-dependencies]
+virtio-queue = { version = "0.9", features = ["test-utils"] }
+vm-memory = { version = "0.12", features = ["backend-mmap", "backend-atomic"] }

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2021"
 
 [features]
 xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
-default = []
+default = ["v4l2-decoder"]
+v4l2-decoder = ["v4l2r"]
 
 [dependencies]
 bitflags = "2.3.3"
@@ -31,7 +32,11 @@ virtio-bindings = "0.2.1"
 virtio-queue = "0.9"
 vm-memory = "0.12"
 vmm-sys-util = "0.11"
+v4l2r = { git =  "https://github.com/Gnurou/v4l2r", rev = "110fd77", optional = true }
 
 [dev-dependencies]
+assert_matches = "1.5"
+rstest = "0.18.2"
+tempfile = "3.8.0"
 virtio-queue = { version = "0.9", features = ["test-utils"] }
 vm-memory = { version = "0.12", features = ["backend-mmap", "backend-atomic"] }

--- a/staging/vhost-device-video/LICENSE-APACHE
+++ b/staging/vhost-device-video/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/staging/vhost-device-video/LICENSE-BSD-3-Clause
+++ b/staging/vhost-device-video/LICENSE-BSD-3-Clause
@@ -1,0 +1,1 @@
+../../LICENSE-BSD-3-Clause

--- a/staging/vhost-device-video/README.md
+++ b/staging/vhost-device-video/README.md
@@ -1,0 +1,14 @@
+# vhost-user-video
+
+## Design
+
+## Usage
+
+## Working example
+
+## License
+
+This project is licensed under either of
+
+- [Apache License](http://www.apache.org/licenses/LICENSE-2.0), Version 2.0
+- [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)

--- a/staging/vhost-device-video/README.md
+++ b/staging/vhost-device-video/README.md
@@ -1,10 +1,151 @@
 # vhost-user-video
 
-## Design
+## Synopsis
+    vhost-user-video --socket-path <SOCKET_PATH> --backend <BACKEND>
 
-## Usage
+## Description
+    A virtio-video device using the vhost-user protocol.
+
+## Arguments
+
+```text
+    <BACKEND>
+        Video backend to be used [possible values: null, v4l2-decoder]
+```
+
+## Options
+
+```text
+    -s, --socket-path <SOCKET_PATH>
+        Unix socket to which a hypervisor connects to and sets up the control path with the device
+
+    -d, --v4l2-device <V4L2_DEVICE>
+        Path to the video device file [default: /dev/video0]
+
+    -b, --backend <BACKEND>
+        Video backend to be used [possible values: null, v4l2-decoder]
+
+    -h, --help
+        Print help
+
+    -V, --version
+        Print version
+```
+
+## Limitations
+
+Currently this crate only supports v4l2 stateful decoder devices, and
+the intention is it will be used with Arm SoCs that implement stateful
+decode/encode devices such as Qcom Venus, RPi, MediaTek etc.
+
+Support for VAAPI or decoding via libavcodec or similar
+libraries is not implemented, but this could be added in the future
+through different video backends.
+
+## Features
+
+This crate is a work-in-progress. Also, the specification for this device is
+still a work-in-progress, so it requires and out-of-tree kernel on the
+guest. Currently, the vmm translates from virtio-video
+[v3](http://archive.lwn.net:8080/linux-media/6557912.4vTCxPXJkl@os-lin-dmo/T/)
+protocol and writes to a 
+[v4l2 mem2mem stateful decoder device](https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/dev-decoder.html).
+The v3 of the specification was chosen as there is a
+virtio-video Linux frontend driver implementation available for testing.
+
+The primary goal so far is to enable development of virtio-video
+frontend driver using purely open source software. Using
+[vicodec](https://lwn.net/Articles/760650/)
+v4l2 stateful decoder on the host for testing allows a pure
+virtual environment for development and testing.
 
 ## Working example
+
+In this section we provide with some example commands to run the daemon
+and decode a video using vicodec.
+
+Guest Linux kernel modules:
+
+```text
+CONFIG_MEDIA_SUPPORT=y
+CONFIG_MEDIA_TEST_SUPPORT=y
+CONFIG_V4L_TEST_DRIVERS=y
+CONFIG_VIRTIO_VIDEO=y
+CONFIG_GDB_SCRIPTS=y
+CONFIG_DRM_VIRTIO_GPU=y
+```
+
+
+Host kernel modules:
+
+```text
+CONFIG_MEDIA_SUPPORT=y
+CONFIG_MEDIA_TEST_SUPPORT=y
+CONFIG_V4L_TEST_DRIVERS=y
+CONFIG_VIDEO_VICODEC=y
+```
+
+The daemon should be started first (video3 typically is the stateful video):
+
+```text
+host# vhost-user-video --socket-path=/tmp/video.sock --v4l2-device=/dev/video3 --backend=v4l2-decoder
+```
+
+The QEMU invocation needs to create a chardev socket the device can
+use to communicate as well as share the guests memory over a memfd.
+
+```text
+host# qemu-system								                            \
+    -device vhost-user-video-pci,chardev=video,id=video                     \
+    -chardev socket,path=/tmp/video.sock,id=video                           \
+    -m 4096 		        					                            \
+    -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on	\
+    -numa node,memdev=mem							                        \
+    ...
+```
+
+After booting, the device should be available at /dev/video0:
+
+```text
+guest# v4l2-ctl -d/dev/video0 --info
+Driver Info:
+        Driver name      : virtio-video
+        Card type        : 
+        Bus info         : virtio:stateful-decoder
+        Driver version   : 6.1.0
+        Capabilities     : 0x84204000
+                Video Memory-to-Memory Multiplanar
+                Streaming
+                Extended Pix Format
+                Device Capabilities
+        Device Caps      : 0x04204000
+                Video Memory-to-Memory Multiplanar
+                Streaming
+                Extended Pix Format
+```
+
+Example v4l2-ctl decode command:
+
+```text
+guest# v4l2-ctl -d0 -x width=640,height=480 -v width=640,height=480,pixelformat=YU12 \
+    --stream-mmap --stream-out-mmap --stream-from test_640_480-420P.fwht            \
+    --stream-to out-test-640-480.YU12
+```
+
+Play the raw decoded video with ffplay or mplayer:
+
+```text
+guest# ffplay -loglevel warning -v info -f rawvideo -pixel_format yuv420p \
+    -video_size "640x480" ./out-test-640-480.YU12
+guest# mplayer -demuxer rawvideo -rawvideo \
+    format=i420:w=640:h=480:fps=25 out-test-640-480.YU12
+```
+
+Enable v4l2 debug in virtio-video driver:
+
+```text
+# echo 0x1f > /sys/class/video4linux/videoX/dev_debug
+```
 
 ## License
 

--- a/staging/vhost-device-video/rustfmt.toml
+++ b/staging/vhost-device-video/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2018"
+format_generated_files = false
+format_code_in_doc_comments = true
+format_strings = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+wrap_comments = true

--- a/staging/vhost-device-video/src/main.rs
+++ b/staging/vhost-device-video/src/main.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+mod stream;
+mod vhu_video;
+mod vhu_video_thread;
+mod video;
+mod video_backends;
+
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
+
+use clap::Parser;
+use log::{info, warn};
+use thiserror::Error as ThisError;
+use vhost::{vhost_user, vhost_user::Listener};
+use vhost_user_backend::VhostUserDaemon;
+use vhu_video::{BackendType, VuVideoBackend};
+use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, ThisError)]
+pub(crate) enum Error {
+    #[error("Could not create backend: {0}")]
+    CouldNotCreateBackend(vhu_video::VuVideoError),
+    #[error("Could not create daemon: {0}")]
+    CouldNotCreateDaemon(vhost_user_backend::Error),
+    #[error("Failed creating listener: {0}")]
+    FailedCreatingListener(vhost_user::Error),
+}
+
+#[derive(Clone, Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct VideoArgs {
+    /// Unix socket to which a hypervisor connects to and sets up the control
+    /// path with the device.
+    #[clap(short, long)]
+    socket_path: PathBuf,
+
+    /// Path to the video device file. Defaults to /dev/video0.
+    #[clap(short = 'd', long, default_value = "/dev/video0")]
+    v4l2_device: PathBuf,
+
+    /// Video backend to be used.
+    #[clap(short, long)]
+    #[clap(value_enum)]
+    backend: BackendType,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct VuVideoConfig {
+    pub socket_path: PathBuf,
+    pub v4l2_device: PathBuf,
+    pub backend: BackendType,
+}
+
+impl From<VideoArgs> for VuVideoConfig {
+    fn from(args: VideoArgs) -> Self {
+        // Divide available bandwidth by the number of threads in order
+        // to avoid overwhelming the HW.
+        Self {
+            socket_path: args.socket_path.to_owned(),
+            v4l2_device: args.v4l2_device.to_owned(),
+            backend: args.backend,
+        }
+    }
+}
+
+pub(crate) fn start_backend(config: VuVideoConfig) -> Result<()> {
+    loop {
+        info!("Starting backend");
+        let vu_video_backend = Arc::new(RwLock::new(
+            VuVideoBackend::new(config.v4l2_device.as_path(), config.backend.to_owned())
+                .map_err(Error::CouldNotCreateBackend)?,
+        ));
+
+        let mut daemon = VhostUserDaemon::new(
+            String::from("vhost-device-video"),
+            vu_video_backend.clone(),
+            GuestMemoryAtomic::new(GuestMemoryMmap::new()),
+        )
+        .map_err(Error::CouldNotCreateDaemon)?;
+
+        let mut vring_workers = daemon.get_epoll_handlers();
+        for thread in vu_video_backend.read().unwrap().threads.iter() {
+            thread
+                .lock()
+                .unwrap()
+                .set_vring_workers(vring_workers.remove(0));
+        }
+
+        daemon
+            .start(Listener::new(&config.socket_path, true).map_err(Error::FailedCreatingListener)?)
+            .expect("Stargin daemon");
+
+        match daemon.wait() {
+            Ok(()) => {
+                info!("Stopping cleanly");
+            }
+            Err(vhost_user_backend::Error::HandleRequest(
+                vhost_user::Error::PartialMessage | vhost_user::Error::Disconnected,
+            )) => {
+                info!(
+                    "vhost-user connection closed with partial message.
+                    If the VM is shutting down, this is expected behavior;
+                    otherwise, it might be a bug."
+                );
+            }
+            Err(e) => {
+                warn!("Error running daemon: {:?} -> {}", e, e.to_string());
+            }
+        }
+
+        vu_video_backend
+            .read()
+            .unwrap()
+            .exit_event
+            .write(1)
+            .expect("Shutting down worker thread");
+    }
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    start_backend(VuVideoConfig::try_from(VideoArgs::parse()).unwrap())
+}

--- a/staging/vhost-device-video/src/stream.rs
+++ b/staging/vhost-device-video/src/stream.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+// Null Backend does not use all stream capabilities
+#![cfg_attr(not(any(feature)), allow(dead_code))]
+
+use std::{
+    collections::HashMap,
+    fs::File,
+    future::Future,
+    os::fd::AsRawFd,
+    path::Path,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, RwLock,
+    },
+    task::{Context, Poll, Waker},
+};
+
+use num_enum::TryFromPrimitive;
+
+use crate::{
+    vhu_video::{Result, VuVideoError},
+    video::{BufferFlags, Format, MemoryType, QueueType},
+};
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct ResourcePlane {
+    pub offset: u32,
+    pub address: u64,
+    pub length: u32,
+}
+
+#[repr(u32)]
+#[derive(Clone, Debug, Default, TryFromPrimitive, Eq, PartialEq)]
+pub enum ResourceState {
+    #[default]
+    Created = 1,
+    Queried,
+    Queued,
+    Ready,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SharedResourceState {
+    value: ResourceState,
+    waker: Option<Waker>,
+}
+
+impl SharedResourceState {
+    pub fn is_ready(&self) -> bool {
+        matches!(self.value, ResourceState::Ready)
+    }
+
+    pub fn set_queried(&mut self) {
+        self.set_state(ResourceState::Queried);
+    }
+
+    pub fn set_queued(&mut self) {
+        self.set_state(ResourceState::Queued);
+    }
+
+    pub fn set_ready(&mut self) {
+        self.set_state(ResourceState::Ready);
+    }
+
+    fn set_state(&mut self, state: ResourceState) {
+        self.value = state;
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BufferData {
+    pub timestamp: u64,
+    pub flags: BufferFlags,
+    pub size: u32,
+}
+
+impl BufferData {
+    pub fn set_data(&mut self, flags: BufferFlags, size: u32) {
+        self.flags = flags;
+        self.size = size;
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct Resource {
+    pub stream_id: u32,
+    pub resource_id: u32,
+    state: Arc<RwLock<SharedResourceState>>,
+    pub index: u32,
+    pub queue_type: QueueType,
+    pub buffer_data: Arc<RwLock<BufferData>>,
+    pub planes_layout: u32,
+    pub planes: Vec<ResourcePlane>,
+}
+
+impl Future for Resource {
+    type Output = BufferData;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.is_ready() {
+            return Poll::Ready(self.buffer_data.read().unwrap().clone());
+        } else {
+            self.state.write().unwrap().waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl Resource {
+    pub fn state(&self) -> ResourceState {
+        self.state.read().unwrap().value.clone()
+    }
+
+    pub fn ready_with(&mut self, flags: BufferFlags, size: u32) {
+        self.buffer_data.write().unwrap().set_data(flags, size);
+        self.set_ready();
+    }
+
+    pub fn set_ready(&mut self) {
+        self.state.write().unwrap().set_ready();
+        if let Some(waker) = self.waker().take() {
+            waker.wake();
+        }
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.state.read().unwrap().is_ready()
+    }
+
+    pub fn set_queried(&mut self) {
+        self.state.write().unwrap().set_queried();
+    }
+
+    pub fn set_queued(&mut self) {
+        self.state.write().unwrap().set_queued();
+    }
+
+    pub fn waker(&self) -> Option<Waker> {
+        self.state.read().unwrap().waker.clone()
+    }
+}
+
+#[repr(u32)]
+#[derive(Clone, Debug, Default, TryFromPrimitive, Eq, PartialEq)]
+pub enum StreamState {
+    #[default]
+    Stopped = 1,
+    Subscribed,
+    Streaming,
+    Draining,
+    Destroying,
+    Destroyed,
+}
+
+#[derive(Clone, Debug)]
+pub struct AtomicStreamState {
+    state: Arc<AtomicUsize>,
+}
+
+impl AtomicStreamState {
+    pub fn new(state: StreamState) -> Self {
+        Self {
+            state: Arc::new(AtomicUsize::new(state as usize)),
+        }
+    }
+
+    pub fn state(&self) -> StreamState {
+        StreamState::try_from_primitive(self.state.load(Ordering::SeqCst) as u32)
+            .expect("Unexpected Stream state")
+    }
+
+    pub fn set_state(&mut self, state: StreamState) {
+        self.state.store(state as usize, Ordering::SeqCst)
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct ResourcesMap {
+    pub map: HashMap<u32, Resource>,
+    pub streaming: bool,
+}
+
+impl ResourcesMap {
+    fn find_mut_by_index(&mut self, v4l2_index: u32) -> Option<&mut Resource> {
+        self.map
+            .iter_mut()
+            .find_map(|(_k, v)| if v.index == v4l2_index { Some(v) } else { None })
+    }
+
+    fn resources(&self) -> Vec<&Resource> {
+        self.map.values().collect()
+    }
+
+    fn resources_mut(&mut self) -> Vec<&mut Resource> {
+        self.map.values_mut().collect()
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Stream {
+    pub stream_id: u32,
+    pub file: Arc<File>,
+    state: AtomicStreamState,
+    pub in_memory_type: MemoryType,
+    pub out_memory_type: MemoryType,
+    pub coded_format: Format,
+    pub inputq_resources: ResourcesMap,
+    pub outputq_resources: ResourcesMap,
+}
+
+impl AsRawFd for Stream {
+    fn as_raw_fd(&self) -> i32 {
+        self.file.as_raw_fd()
+    }
+}
+
+impl Stream {
+    pub(crate) fn new(
+        stream_id: u32,
+        device_path: &Path,
+        in_memory_type: u32,
+        out_memory_type: u32,
+        coded_format: u32,
+    ) -> Result<Self> {
+        Ok(Self {
+            stream_id,
+            file: Arc::new(File::create(device_path).unwrap()),
+            state: AtomicStreamState::new(StreamState::default()),
+            in_memory_type: MemoryType::try_from_primitive(in_memory_type)
+                .map_err(|_| VuVideoError::VideoStreamCreate)?,
+            out_memory_type: MemoryType::try_from_primitive(out_memory_type)
+                .map_err(|_| VuVideoError::VideoStreamCreate)?,
+            coded_format: Format::try_from_primitive(coded_format)
+                .map_err(|_| VuVideoError::VideoStreamCreate)?,
+            inputq_resources: Default::default(),
+            outputq_resources: Default::default(),
+        })
+    }
+
+    pub fn memory(&self, queue_type: QueueType) -> MemoryType {
+        match queue_type {
+            QueueType::InputQueue => self.in_memory_type,
+            QueueType::OutputQueue => self.out_memory_type,
+        }
+    }
+
+    pub fn find_resource(&self, resource_id: u32, queue_type: QueueType) -> Option<&Resource> {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.map.get(&resource_id),
+            QueueType::OutputQueue => self.outputq_resources.map.get(&resource_id),
+        }
+    }
+
+    pub fn find_resource_mut_by_index(
+        &mut self,
+        v4l2_index: u32,
+        queue_type: QueueType,
+    ) -> Option<&mut Resource> {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.find_mut_by_index(v4l2_index),
+            QueueType::OutputQueue => self.outputq_resources.find_mut_by_index(v4l2_index),
+        }
+    }
+
+    pub fn find_resource_mut(
+        &mut self,
+        resource_id: u32,
+        queue_type: QueueType,
+    ) -> Option<&mut Resource> {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.map.get_mut(&resource_id),
+            QueueType::OutputQueue => self.outputq_resources.map.get_mut(&resource_id),
+        }
+    }
+
+    pub fn is_queue_streaming(&self, queue_type: QueueType) -> bool {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.streaming,
+            QueueType::OutputQueue => self.outputq_resources.streaming,
+        }
+    }
+
+    pub fn set_queue_streaming(&mut self, queue_type: QueueType) {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.streaming = true,
+            QueueType::OutputQueue => self.outputq_resources.streaming = true,
+        }
+    }
+
+    pub fn set_state(&mut self, state: StreamState) {
+        self.state.set_state(state);
+    }
+
+    pub fn state(&self) -> StreamState {
+        self.state.state()
+    }
+
+    pub fn all_created(&self, queue_type: QueueType) -> bool {
+        self.all_resources_state(queue_type, ResourceState::Created)
+    }
+
+    fn all_resources_state(&self, queue_type: QueueType, state: ResourceState) -> bool {
+        match queue_type {
+            QueueType::InputQueue => self
+                .inputq_resources
+                .resources()
+                .into_iter()
+                .all(|x| x.state() == state),
+            QueueType::OutputQueue => self
+                .outputq_resources
+                .resources()
+                .into_iter()
+                .all(|x| x.state() == state),
+        }
+    }
+
+    pub fn resources_mut(&mut self, queue_type: QueueType) -> Vec<&mut Resource> {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.resources_mut(),
+            QueueType::OutputQueue => self.outputq_resources.resources_mut(),
+        }
+    }
+
+    pub fn queued_resources_mut(&mut self, queue_type: QueueType) -> Vec<&mut Resource> {
+        self.resources_mut(queue_type)
+            .into_iter()
+            .filter(|x| (*x).state() == ResourceState::Queued)
+            .collect()
+    }
+
+    /// Inserts a new resource into the specific queue map.
+    /// If the map did not have this resource ID present, None is returned.
+    /// If the map did have this resource ID present, the value is updated, and
+    /// the old value is returned. The ID is not updated.
+    pub fn add_resource(
+        &mut self,
+        resource_id: u32,
+        planes_layout: u32,
+        planes: Vec<ResourcePlane>,
+        queue_type: QueueType,
+    ) -> Option<Resource> {
+        let mut resource = Resource {
+            stream_id: self.stream_id,
+            resource_id,
+            queue_type,
+            planes_layout,
+            ..Default::default()
+        };
+        resource.planes = planes;
+        match queue_type {
+            QueueType::InputQueue => {
+                resource.index = self.inputq_resources.map.len() as u32;
+                self.inputq_resources.map.insert(resource_id, resource)
+            }
+            QueueType::OutputQueue => {
+                resource.index = self.outputq_resources.map.len() as u32;
+                self.outputq_resources.map.insert(resource_id, resource)
+            }
+        }
+    }
+
+    pub fn empty_resources(&mut self, queue_type: QueueType) {
+        match queue_type {
+            QueueType::InputQueue => self.inputq_resources.map.clear(),
+            QueueType::OutputQueue => self.outputq_resources.map.clear(),
+        }
+    }
+}

--- a/staging/vhost-device-video/src/vhu_video.rs
+++ b/staging/vhost-device-video/src/vhu_video.rs
@@ -106,6 +106,8 @@ impl convert::From<VuVideoError> for io::Error {
 pub(crate) enum BackendType {
     #[default]
     Null,
+    #[cfg(feature = "v4l2-decoder")]
+    V4L2Decoder,
 }
 
 /// Virtio Video Configuration

--- a/staging/vhost-device-video/src/vhu_video.rs
+++ b/staging/vhost-device-video/src/vhu_video.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{
+    convert,
+    io::{self, Result as IoResult},
+    path::Path,
+    sync::{Arc, Mutex, RwLock},
+};
+
+use clap::ValueEnum;
+use log::{debug, warn};
+use thiserror::Error as ThisError;
+use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
+use vhost_user_backend::{VhostUserBackendMut, VringRwLock, VringT};
+use virtio_bindings::bindings::{
+    virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
+    virtio_ring::{VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC},
+};
+use virtio_queue::DescriptorChain;
+use vm_memory::{ByteValued, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap, Le32};
+use vmm_sys_util::{
+    epoll::EventSet,
+    eventfd::{EventFd, EFD_NONBLOCK},
+};
+
+use crate::{vhu_video_thread::VhostUserVideoThread, video_backends};
+
+/// Virtio Video Feature bits
+const VIRTIO_VIDEO_F_RESOURCE_GUEST_PAGES: u16 = 0;
+/// Unsupported
+/// const VIRTIO_VIDEO_F_RESOURCE_NON_CONTIG: u16 = 1;
+/// const VIRTIO_VIDEO_F_RESOURCE_VIRTIO_OBJECT: u16 = 2;
+
+const COMMAND_Q: u16 = 0;
+const EVENT_Q: u16 = 1;
+const NUM_QUEUES: usize = 2;
+const QUEUE_SIZE: usize = 1024;
+/// Notification coming from the backend.
+/// Event range [0...num_queues] is reserved for queues and exit event.
+/// So NUM_QUEUES + 1 is used.
+pub(crate) const VIDEO_EVENT: u16 = (NUM_QUEUES + 1) as u16;
+
+pub(crate) const VIRTIO_V4L2_CARD_NAME_LEN: usize = 32;
+const MAX_CAPS_LEN: u32 = 4096;
+const MAX_RESP_LEN: u32 = MAX_CAPS_LEN;
+
+pub(crate) type Result<T> = std::result::Result<T, VuVideoError>;
+pub(crate) type VideoDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;
+
+#[derive(Debug, ThisError)]
+/// Errors related to vhost-device-rng daemon.
+pub(crate) enum VuVideoError {
+    #[error("Descriptor not found")]
+    DescriptorNotFound,
+    #[error("Descriptor read failed")]
+    DescriptorReadFailed,
+    #[error("Notification send failed")]
+    SendNotificationFailed,
+    #[error("Can't create eventFd")]
+    EventFdError,
+    #[error("Video device file doesn't exists or can't be accessed")]
+    AccessVideoDeviceFile,
+    #[error("Failed to create stream")]
+    VideoStreamCreate,
+    #[error("Failed to handle event")]
+    HandleEventNotEpollIn,
+    #[error("Unknown device event")]
+    HandleUnknownEvent,
+    #[error("Invalid command type {0}")]
+    InvalidCmdType(u32),
+    #[error("Invalid Resource ID {0}")]
+    InvalidResourceId(u32),
+    #[error("Too many descriptors: {0}")]
+    UnexpectedDescriptorCount(usize),
+    #[error("Invalid descriptor size, expected at least: {0}, found: {1}")]
+    UnexpectedMinimumDescriptorSize(usize, usize),
+    #[error("Invalid descriptor size, expected: {0}, found: {1}")]
+    UnexpectedDescriptorSize(usize, usize),
+    #[error("Received unexpected readable descriptor at index {0}")]
+    UnexpectedReadableDescriptor(usize),
+    #[error("Invalid value for argument: {0}")]
+    UnexpectedArgValue(String),
+    #[error("Failed to create an epoll fd: {0}")]
+    EpollFdCreate(std::io::Error),
+    #[error("Failed to add to epoll: {0}")]
+    EpollAdd(#[from] std::io::Error),
+    #[error("Failed to modify evset associated with epoll: {0}")]
+    EpollModify(std::io::Error),
+    #[error("Failed to consume new epoll event: {0}")]
+    EpollWait(std::io::Error),
+    #[error("Failed to de-register fd from epoll: {0}")]
+    EpollRemove(std::io::Error),
+    #[error("No memory configured")]
+    NoMemoryConfigured,
+    #[error("Unable to create thread pool: {0}")]
+    CreateThreadPool(std::io::Error),
+}
+
+impl convert::From<VuVideoError> for io::Error {
+    fn from(e: VuVideoError) -> Self {
+        io::Error::new(io::ErrorKind::Other, e)
+    }
+}
+
+#[derive(ValueEnum, Debug, Default, Clone, Eq, PartialEq)]
+pub(crate) enum BackendType {
+    #[default]
+    Null,
+}
+
+/// Virtio Video Configuration
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+#[repr(C)]
+pub(crate) struct VirtioVideoConfig {
+    version: Le32,
+    max_caps_length: Le32,
+    max_resp_length: Le32,
+    device_name: [u8; VIRTIO_V4L2_CARD_NAME_LEN],
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for VirtioVideoConfig {}
+
+pub(crate) struct VuVideoBackend {
+    config: VirtioVideoConfig,
+    pub threads: Vec<Mutex<VhostUserVideoThread>>,
+    pub exit_event: EventFd,
+}
+
+impl VuVideoBackend {
+    /// Create a new virtio video device for /dev/video<num>.
+    pub fn new(video_path: &Path, video_backend: BackendType) -> Result<Self> {
+        let backend = Arc::new(RwLock::new(video_backends::alloc_video_backend(
+            video_backend,
+            video_path,
+        )?));
+        Ok(Self {
+            config: VirtioVideoConfig {
+                version: 0.into(),
+                max_caps_length: MAX_CAPS_LEN.into(),
+                max_resp_length: MAX_RESP_LEN.into(),
+                device_name: [0; 32],
+            },
+            threads: vec![Mutex::new(VhostUserVideoThread::new(backend.clone())?)],
+            exit_event: EventFd::new(EFD_NONBLOCK).map_err(|_| VuVideoError::EventFdError)?,
+        })
+    }
+}
+
+/// VhostUserBackend trait methods
+impl VhostUserBackendMut<VringRwLock, ()> for VuVideoBackend {
+    fn num_queues(&self) -> usize {
+        NUM_QUEUES
+    }
+
+    fn max_queue_size(&self) -> usize {
+        QUEUE_SIZE
+    }
+
+    fn features(&self) -> u64 {
+        debug!("Get features");
+        1 << VIRTIO_F_VERSION_1
+            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
+            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+            | 1 << VIRTIO_RING_F_EVENT_IDX
+            | 1 << VIRTIO_VIDEO_F_RESOURCE_GUEST_PAGES
+            | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
+    }
+
+    fn protocol_features(&self) -> VhostUserProtocolFeatures {
+        debug!("Get protocol features");
+        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::CONFIG
+    }
+
+    fn set_event_idx(&mut self, enabled: bool) {
+        for thread in self.threads.iter() {
+            thread.lock().unwrap().event_idx = enabled;
+        }
+    }
+
+    fn update_memory(&mut self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {
+        for thread in self.threads.iter() {
+            thread.lock().unwrap().mem = Some(mem.clone());
+        }
+        Ok(())
+    }
+
+    fn handle_event(
+        &mut self,
+        device_event: u16,
+        evset: EventSet,
+        vrings: &[VringRwLock],
+        thread_id: usize,
+    ) -> IoResult<bool> {
+        if evset != EventSet::IN {
+            return Err(VuVideoError::HandleEventNotEpollIn.into());
+        }
+
+        let mut thread = self.threads[thread_id].lock().unwrap();
+        let commandq = &vrings[COMMAND_Q as usize];
+        let eventq = &vrings[EVENT_Q as usize];
+        let evt_idx = thread.event_idx;
+
+        match device_event {
+            COMMAND_Q => {
+                if evt_idx {
+                    // vm-virtio's Queue implementation only checks avail_index
+                    // once, so to properly support EVENT_IDX we need to keep
+                    // calling process_queue() until it stops finding new
+                    // requests on the queue.
+                    loop {
+                        commandq.disable_notification().unwrap();
+                        thread.process_command_queue(commandq)?;
+                        if !commandq.enable_notification().unwrap() {
+                            break;
+                        }
+                    }
+                } else {
+                    // Without EVENT_IDX, a single call is enough.
+                    thread.process_command_queue(commandq)?;
+                }
+            }
+
+            EVENT_Q => {
+                // This queue is used by the device to asynchronously send
+                // event notifications to the driver. Thus, we do not handle
+                // incoming events.
+                warn!("Unexpected event notification received");
+            }
+
+            VIDEO_EVENT => {
+                thread.process_video_event(eventq)?;
+            }
+
+            _ => {
+                warn!("unhandled device_event: {}", device_event);
+                return Err(VuVideoError::HandleUnknownEvent.into());
+            }
+        }
+        Ok(false)
+    }
+
+    fn get_config(&self, _offset: u32, _size: u32) -> Vec<u8> {
+        let offset = _offset as usize;
+        let size = _size as usize;
+
+        let buf = self.config.as_slice();
+
+        if offset + size > buf.len() {
+            return Vec::new();
+        }
+
+        buf[offset..offset + size].to_vec()
+    }
+
+    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+        self.exit_event.try_clone().ok()
+    }
+}

--- a/staging/vhost-device-video/src/vhu_video_thread.rs
+++ b/staging/vhost-device-video/src/vhu_video_thread.rs
@@ -1,0 +1,573 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{
+    fs::File,
+    mem::size_of,
+    ops::Deref,
+    os::unix::io::{AsRawFd, FromRawFd},
+    sync::{Arc, RwLock},
+};
+
+use futures_executor::{ThreadPool, ThreadPoolBuilder};
+use log::{debug, warn};
+use vhost_user_backend::{VringEpollHandler, VringRwLock, VringT};
+use virtio_queue::{Descriptor, QueueOwnedT};
+use vm_memory::{
+    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
+    GuestMemoryMmap,
+};
+use vmm_sys_util::epoll::EventSet;
+
+use crate::{
+    stream,
+    vhu_video::{self, Result, VideoDescriptorChain, VuVideoBackend, VuVideoError},
+    video::{self, ToBytes},
+    video_backends::VideoBackend,
+};
+
+type ArcVhostBknd = Arc<RwLock<VuVideoBackend>>;
+
+const MAX_BUFFERS: usize = 32;
+
+#[derive(Copy, Clone, Debug)]
+pub struct TriggeredEvent {
+    pub have_read: bool,
+    pub have_write: bool,
+    pub have_event: bool,
+    pub data: u64,
+}
+
+pub enum EventType {
+    None = 0,
+    Read,
+    Write,
+    ReadWrite,
+    Event,
+    EventRead,
+    All,
+}
+
+impl From<EventType> for epoll::Events {
+    fn from(et: EventType) -> epoll::Events {
+        match et {
+            EventType::None => epoll::Events::EPOLLERR,
+            EventType::Read => epoll::Events::EPOLLIN,
+            EventType::Write => epoll::Events::EPOLLOUT,
+            EventType::ReadWrite => epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+            EventType::Event => epoll::Events::EPOLLPRI,
+            EventType::EventRead => epoll::Events::EPOLLPRI | epoll::Events::EPOLLIN,
+            EventType::All => {
+                epoll::Events::EPOLLPRI | epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct PollerEvent {
+    pub event: epoll::Event,
+}
+
+impl PollerEvent {
+    pub fn new(et: EventType, token: u64) -> Self {
+        Self {
+            event: epoll::Event::new(epoll::Events::from(et), token),
+        }
+    }
+}
+
+impl Default for PollerEvent {
+    fn default() -> Self {
+        Self::new(EventType::None, 0)
+    }
+}
+
+struct VideoPoller {
+    /// epoll fd to which new host connections are added.
+    epoll_file: File,
+}
+
+impl VideoPoller {
+    fn new() -> Result<Self> {
+        let poll_fd = epoll::create(true).map_err(VuVideoError::EpollFdCreate)?;
+        Ok(Self {
+            // SAFETY: Safe as the fd is guaranteed to be valid here.
+            epoll_file: unsafe { File::from_raw_fd(poll_fd) },
+        })
+    }
+
+    pub fn add(&self, fd: i32, event: PollerEvent) -> Result<()> {
+        self.epoll_ctl(epoll::ControlOptions::EPOLL_CTL_ADD, fd, &event)
+            .map_err(VuVideoError::EpollAdd)?;
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn modify(&self, fd: i32, event: PollerEvent) -> Result<()> {
+        self.epoll_ctl(epoll::ControlOptions::EPOLL_CTL_MOD, fd, &event)
+            .map_err(VuVideoError::EpollModify)?;
+
+        Ok(())
+    }
+
+    pub fn remove(&self, fd: i32) -> Result<()> {
+        self.epoll_ctl(epoll::ControlOptions::EPOLL_CTL_DEL, fd, None)
+            .map_err(VuVideoError::EpollRemove)?;
+
+        Ok(())
+    }
+
+    pub fn wait(&self, events: &mut [PollerEvent], timeout: i32) -> Result<Vec<TriggeredEvent>> {
+        let mut events: Vec<epoll::Event> = events.iter_mut().map(|e| e.event).collect();
+        match epoll::wait(self.epoll_file.as_raw_fd(), timeout, events.as_mut_slice()) {
+            Ok(count) => {
+                let events = events[0..count]
+                    .iter()
+                    .map(|epoll_event| TriggeredEvent {
+                        have_read: epoll_event.events & epoll::Events::EPOLLIN.bits() != 0,
+                        have_write: epoll_event.events & epoll::Events::EPOLLOUT.bits() != 0,
+                        have_event: epoll_event.events & epoll::Events::EPOLLPRI.bits() != 0,
+                        data: epoll_event.data,
+                    })
+                    .collect();
+                Ok(events)
+            }
+            Err(e) => Err(VuVideoError::EpollWait(e)),
+        }
+    }
+
+    fn epoll_ctl<'a, T>(
+        &self,
+        op: epoll::ControlOptions,
+        fd: i32,
+        event: T,
+    ) -> std::result::Result<(), std::io::Error>
+    where
+        T: Into<Option<&'a PollerEvent>>,
+    {
+        let event: Option<&PollerEvent> = event.into();
+        let ptr = match event.map(|x| x.event as epoll::Event) {
+            Some(ev) => ev,
+            None => epoll::Event::new(epoll::Events::empty(), 0),
+        };
+        epoll::ctl(self.epoll_file.as_raw_fd(), op, fd, ptr)
+    }
+}
+
+pub(crate) trait ReadObj<T: ByteValued> {
+    fn read_body(&self, index: usize, equal: bool) -> Result<T>;
+}
+
+impl<T: ByteValued> ReadObj<T> for VideoDescriptorChain {
+    fn read_body(&self, index: usize, equal: bool) -> Result<T> {
+        let descriptors: Vec<_> = self.clone().collect();
+        let descriptor = descriptors[index];
+        let request_size: usize = size_of::<T>();
+        let to_read = descriptor.len() as usize;
+        if equal {
+            if to_read != request_size {
+                return Err(VuVideoError::UnexpectedDescriptorSize(
+                    request_size,
+                    to_read,
+                ));
+            }
+        } else if to_read < request_size {
+            return Err(VuVideoError::UnexpectedMinimumDescriptorSize(
+                request_size,
+                to_read,
+            ));
+        }
+        self.memory()
+            .read_obj::<T>(descriptor.addr())
+            .map_err(|_| VuVideoError::DescriptorReadFailed)
+    }
+}
+
+pub(crate) struct VhostUserVideoThread {
+    /// Guest memory map.
+    pub mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
+    /// VIRTIO_RING_F_EVENT_IDX.
+    pub event_idx: bool,
+    poller: VideoPoller,
+    vring_worker: Option<Arc<VringEpollHandler<ArcVhostBknd, VringRwLock, ()>>>,
+    backend: Arc<RwLock<Box<dyn VideoBackend + Sync + Send>>>,
+    /// Thread pool to handle async commands.
+    pool: ThreadPool,
+}
+
+fn write_descriptor_data<T: ToBytes>(
+    resp: T,
+    desc_response: &Descriptor,
+    desc_chain: &VideoDescriptorChain,
+    vring: &VringRwLock,
+) {
+    if desc_chain
+        .memory()
+        .write_slice(resp.to_bytes().as_slice(), desc_response.addr())
+        .is_err()
+    {
+        warn!("Descriptor write failed");
+    }
+
+    if vring
+        .add_used(desc_chain.head_index(), desc_response.len())
+        .is_err()
+    {
+        warn!("Couldn't return used descriptors to the ring");
+    }
+}
+
+impl VhostUserVideoThread {
+    pub fn new(backend: Arc<RwLock<Box<dyn VideoBackend + Sync + Send>>>) -> Result<Self> {
+        Ok(Self {
+            mem: None,
+            event_idx: false,
+            poller: VideoPoller::new()?,
+            backend,
+            vring_worker: None,
+            pool: ThreadPoolBuilder::new()
+                .pool_size(MAX_BUFFERS)
+                .create()
+                .map_err(VuVideoError::CreateThreadPool)?,
+        })
+    }
+
+    pub fn set_vring_workers(
+        &mut self,
+        vring_worker: Arc<VringEpollHandler<ArcVhostBknd, VringRwLock, ()>>,
+    ) {
+        self.vring_worker = Some(vring_worker);
+        self.vring_worker
+            .as_ref()
+            .unwrap()
+            .register_listener(
+                self.poller.epoll_file.as_raw_fd(),
+                EventSet::IN,
+                u64::from(vhu_video::VIDEO_EVENT),
+            )
+            .unwrap();
+    }
+
+    pub fn process_requests(
+        &mut self,
+        requests: Vec<VideoDescriptorChain>,
+        vring: &VringRwLock,
+    ) -> Result<bool> {
+        use video::VideoCmd::*;
+        if requests.is_empty() {
+            return Ok(true);
+        }
+        for desc_chain in requests {
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+            debug!("Video request with n descriptors: {}", descriptors.len());
+            let mut desc_len: usize = 2;
+            let response: video::CmdResponseType =
+                match video::VideoCmd::from_descriptor(&desc_chain) {
+                    Err(e) => {
+                        warn!("Reading command failed: {}", e);
+                        video::CmdResponseType::Sync(video::CmdResponse::Error(
+                            video::CmdError::InvalidOperation,
+                        ))
+                    }
+                    Ok(cmd) => {
+                        debug!("Received command: {:?}", cmd);
+                        match cmd {
+                            QueryCapability { queue_type } => {
+                                self.backend.read().unwrap().query_capability(queue_type)
+                            }
+                            QueryControl { control, format: _ } => {
+                                self.backend.read().unwrap().query_control(control)
+                            }
+                            StreamCreate {
+                                stream_id,
+                                in_memory_type,
+                                out_memory_type,
+                                coded_format,
+                            } => self.backend.write().unwrap().create_stream(
+                                stream_id,
+                                in_memory_type as u32,
+                                out_memory_type as u32,
+                                coded_format as u32,
+                            ),
+                            StreamDestroy { stream_id } => {
+                                self.backend.write().unwrap().destroy_stream(stream_id)
+                            }
+                            StreamDrain { stream_id } => {
+                                self.backend.write().unwrap().drain_stream(stream_id)
+                            }
+                            ResourceCreate {
+                                stream_id,
+                                queue_type,
+                                resource_id,
+                                planes_layout,
+                                plane_offsets,
+                            } => {
+                                desc_len = 3;
+                                let planes = self.collect_planes(&desc_chain, plane_offsets)?;
+                                self.backend.write().unwrap().create_resource(
+                                    stream_id,
+                                    resource_id,
+                                    planes_layout,
+                                    planes,
+                                    queue_type,
+                                )
+                            }
+                            ResourceQueue {
+                                stream_id,
+                                queue_type,
+                                resource_id,
+                                timestamp,
+                                data_sizes,
+                            } => {
+                                let mut backend = self.backend.write().unwrap();
+                                if let Some(stream) = backend.stream_mut(&stream_id) {
+                                    self.set_stream_poller(stream, stream_id as u64);
+                                }
+                                backend.queue_resource(
+                                    stream_id,
+                                    queue_type,
+                                    resource_id,
+                                    timestamp,
+                                    data_sizes,
+                                )
+                            }
+                            ResourceDestroyAll {
+                                stream_id,
+                                queue_type,
+                            } => self
+                                .backend
+                                .write()
+                                .unwrap()
+                                .destroy_resources(stream_id, queue_type),
+                            QueueClear {
+                                stream_id,
+                                queue_type,
+                            } => self
+                                .backend
+                                .write()
+                                .unwrap()
+                                .clear_queue(stream_id, queue_type),
+                            GetParams {
+                                stream_id,
+                                queue_type,
+                            } => self
+                                .backend
+                                .write()
+                                .unwrap()
+                                .get_params(stream_id, queue_type),
+                            SetParams {
+                                stream_id,
+                                queue_type: _,
+                                params,
+                            } => self.backend.write().unwrap().set_params(stream_id, params),
+                            GetControl {
+                                stream_id: _,
+                                control: _,
+                            } => {
+                                debug!("GET_CONTROL support is not fully handled yet");
+                                video::CmdResponseType::Sync(video::CmdResponse::Error(
+                                    video::CmdError::UnsupportedControl,
+                                ))
+                            }
+                        }
+                    }
+                };
+            debug!("Response: {:?}", response);
+            if descriptors.len() != desc_len {
+                return Err(VuVideoError::UnexpectedDescriptorCount(descriptors.len()));
+            }
+            let desc_response = &descriptors[desc_len - 1];
+            if !desc_response.is_write_only() {
+                return Err(VuVideoError::UnexpectedReadableDescriptor(desc_len - 1));
+            }
+            match response {
+                video::CmdResponseType::Sync(resp) => {
+                    write_descriptor_data(resp, desc_response, &desc_chain, vring);
+                }
+
+                video::CmdResponseType::AsyncQueue {
+                    stream_id,
+                    queue_type,
+                    resource_id,
+                } => {
+                    let backend = self.backend.read().unwrap();
+                    let stream = backend.stream(&stream_id).unwrap();
+                    let resource = match stream.find_resource(resource_id, queue_type) {
+                        Some(res) => res.clone(),
+                        None => return Err(VuVideoError::InvalidResourceId(resource_id)),
+                    };
+                    let vring = vring.clone();
+                    let desc_response = *desc_response;
+                    self.pool.spawn_ok(async move {
+                        let buf_data = resource.await;
+                        debug!(
+                            "Dequeued resource {} ({:?}) for stream {}",
+                            resource_id, queue_type, stream_id
+                        );
+                        let resp = video::CmdResponse::ResourceQueue {
+                            timestamp: buf_data.timestamp,
+                            flags: buf_data.flags.bits(),
+                            size: buf_data.size,
+                        };
+                        write_descriptor_data(resp, &desc_response, &desc_chain, &vring);
+                        if let Err(e) = vring
+                            .signal_used_queue()
+                            .map_err(|_| VuVideoError::SendNotificationFailed)
+                        {
+                            warn!("{}", e);
+                        }
+                    });
+                    // Avoid signaling the used queue for delayed responses
+                    return Ok(false);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn collect_planes(
+        &self,
+        desc_chain: &VideoDescriptorChain,
+        plane_offsets: Vec<u32>,
+    ) -> Result<Vec<stream::ResourcePlane>> {
+        let mem: video::SingleLayoutBuffer = desc_chain.read_body(1, true)?;
+        // Assumes mplanar with a single plane
+        let virt_addr = self
+            .atomic_mem()?
+            .memory()
+            .deref()
+            .get_host_address(GuestAddress(mem.raw_addr()))
+            .expect("Could not get the host address");
+        let plane_addrs = vec![virt_addr as u64];
+        let plane_lengths = vec![mem.raw_len()];
+        Ok(plane_offsets
+            .into_iter()
+            .zip(plane_addrs)
+            .zip(plane_lengths)
+            .map(|((offset, address), length)| stream::ResourcePlane {
+                offset,
+                address,
+                length,
+            })
+            .collect())
+    }
+
+    fn set_stream_poller(&self, stream: &stream::Stream, data: u64) {
+        if stream.state() != stream::StreamState::Streaming
+            && stream.state() != stream::StreamState::Draining
+        {
+            if let Err(e) = self
+                .poller
+                .add(stream.as_raw_fd(), PollerEvent::new(EventType::All, data))
+            {
+                warn!("Add poller events to stream ID {} failed: {}", data, e);
+            }
+        }
+    }
+
+    fn atomic_mem(&self) -> Result<&GuestMemoryAtomic<GuestMemoryMmap>> {
+        match &self.mem {
+            Some(m) => Ok(m),
+            None => Err(VuVideoError::NoMemoryConfigured),
+        }
+    }
+
+    /// Process the requests in the vring and dispatch replies
+    pub fn process_command_queue(&mut self, vring: &VringRwLock) -> Result<bool> {
+        let requests: Vec<_> = vring
+            .get_mut()
+            .get_queue_mut()
+            .iter(self.atomic_mem()?.memory())
+            .map_err(|_| VuVideoError::DescriptorNotFound)?
+            .collect();
+
+        if self.process_requests(requests, vring)? {
+            // Send notification once all the requests are processed
+            vring
+                .signal_used_queue()
+                .map_err(|_| VuVideoError::SendNotificationFailed)?;
+        }
+
+        Ok(true)
+    }
+
+    fn process_event(&self, stream_id: u32, eventq: &VringRwLock) -> Result<bool> {
+        if let Some(event) = self.backend.read().unwrap().dequeue_event(stream_id) {
+            let desc_chain = eventq
+                .get_mut()
+                .get_queue_mut()
+                .iter(self.atomic_mem()?.memory())
+                .map_err(|_| VuVideoError::DescriptorNotFound)?
+                .collect::<Vec<_>>()
+                .pop();
+            let desc_chain = match desc_chain {
+                Some(desc_chain) => desc_chain,
+                None => {
+                    warn!("No available buffer found in the event queue.");
+                    return Err(VuVideoError::DescriptorNotFound);
+                }
+            };
+            let descriptors: Vec<_> = desc_chain.clone().collect();
+            if descriptors.len() > 1 {
+                return Err(VuVideoError::UnexpectedDescriptorCount(descriptors.len()));
+            }
+            write_descriptor_data(event, &descriptors[0], &desc_chain, eventq);
+            eventq
+                .signal_used_queue()
+                .map_err(|_| VuVideoError::SendNotificationFailed)?;
+        }
+
+        Ok(true)
+    }
+
+    fn send_dqbuf(&mut self, stream_id: u32, queue_type: video::QueueType) -> Result<bool> {
+        let dqbuf_data = match self
+            .backend
+            .read()
+            .unwrap()
+            .dequeue_resource(stream_id, queue_type)
+        {
+            Some(buf_data) => buf_data,
+            None => return Ok(false),
+        };
+        let mut backend = self.backend.write().unwrap();
+        let stream = backend.stream_mut(&stream_id).unwrap();
+        if dqbuf_data.flags.contains(video::BufferFlags::EOS)
+            && stream.state() == stream::StreamState::Draining
+        {
+            stream.set_state(stream::StreamState::Stopped);
+            if let Err(e) = self.poller.remove(stream.as_raw_fd()) {
+                warn!("{}", e);
+            }
+        }
+        let resource = stream
+            .find_resource_mut_by_index(dqbuf_data.index, queue_type)
+            .unwrap();
+        resource.ready_with(dqbuf_data.flags, dqbuf_data.size);
+
+        Ok(true)
+    }
+
+    pub fn process_video_event(&mut self, eventq: &VringRwLock) -> Result<bool> {
+        let mut epoll_events = vec![PollerEvent::default(); 1024];
+        let events = self.poller.wait(epoll_events.as_mut_slice(), 0).unwrap();
+        for event in events {
+            let stream_id = event.data as u32;
+            if event.have_event {
+                self.process_event(stream_id, eventq)?;
+            }
+            if event.have_read {
+                // TODO: Assumes decoder
+                self.send_dqbuf(stream_id, video::QueueType::OutputQueue)?;
+            }
+            if event.have_write {
+                // TODO: Assumes decoder
+                self.send_dqbuf(stream_id, video::QueueType::InputQueue)?;
+            }
+        }
+
+        Ok(true)
+    }
+}

--- a/staging/vhost-device-video/src/video.rs
+++ b/staging/vhost-device-video/src/video.rs
@@ -1,0 +1,943 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+#![allow(dead_code)] //TODO: remove
+// Struct definitions use the kernel-style naming for consistency
+#![allow(non_camel_case_types)]
+
+use bitflags::bitflags;
+use num_enum::TryFromPrimitive;
+use vm_memory::{ByteValued, Le32, Le64};
+
+use crate::{
+    vhu_video::{self, VuVideoError},
+    vhu_video_thread::ReadObj,
+};
+
+pub(crate) type StreamId = u32;
+
+pub(crate) trait ToBytes {
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+/// Virtio specification definitions
+/// Virtio Video Command types
+pub(crate) const VIRTIO_VIDEO_CMD_QUERY_CAPABILITY: u32 = 0x0100;
+pub(crate) const VIRTIO_VIDEO_CMD_STREAM_CREATE: u32 = 0x0101;
+pub(crate) const VIRTIO_VIDEO_CMD_STREAM_DESTROY: u32 = 0x0102;
+pub(crate) const VIRTIO_VIDEO_CMD_STREAM_DRAIN: u32 = 0x0103;
+pub(crate) const VIRTIO_VIDEO_CMD_RESOURCE_CREATE: u32 = 0x0104;
+pub(crate) const VIRTIO_VIDEO_CMD_RESOURCE_QUEUE: u32 = 0x0105;
+pub(crate) const VIRTIO_VIDEO_CMD_RESOURCE_DESTROY_ALL: u32 = 0x0106;
+pub(crate) const VIRTIO_VIDEO_CMD_QUEUE_CLEAR: u32 = 0x0107;
+/// GET/SET_PARAMS are being replaced with GET/SET_PARAMS_EXT
+pub(crate) const VIRTIO_VIDEO_CMD_GET_PARAMS__UNUSED: u32 = 0x0108;
+pub(crate) const VIRTIO_VIDEO_CMD_SET_PARAMS__UNUSED: u32 = 0x0109;
+pub(crate) const VIRTIO_VIDEO_CMD_QUERY_CONTROL: u32 = 0x010A;
+pub(crate) const VIRTIO_VIDEO_CMD_GET_CONTROL: u32 = 0x010B;
+pub(crate) const VIRTIO_VIDEO_CMD_SET_CONTROL: u32 = 0x010C;
+pub(crate) const VIRTIO_VIDEO_CMD_GET_PARAMS_EXT: u32 = 0x010D;
+pub(crate) const VIRTIO_VIDEO_CMD_SET_PARAMS_EXT: u32 = 0x010E;
+
+/// Virtio Video Response types
+pub(crate) const VIRTIO_VIDEO_RESP_OK_NODATA: u32 = 0x0200;
+pub(crate) const VIRTIO_VIDEO_RESP_OK_QUERY_CAPABILITY: u32 = 0x0201;
+pub(crate) const VIRTIO_VIDEO_RESP_OK_RESOURCE_QUEUE: u32 = 0x0202;
+pub(crate) const VIRTIO_VIDEO_RESP_OK_GET_PARAMS: u32 = 0x0203;
+pub(crate) const VIRTIO_VIDEO_RESP_OK_QUERY_CONTROL: u32 = 0x0204;
+pub(crate) const VIRTIO_VIDEO_RESP_OK_GET_CONTROL: u32 = 0x0205;
+
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_INVALID_OPERATION: u32 = 0x0206;
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_OUT_OF_MEMORY: u32 = 0x0207;
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_INVALID_STREAM_ID: u32 = 0x0208;
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_INVALID_RESOURCE_ID: u32 = 0x0209;
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_INVALID_PARAMETER: u32 = 0x020A;
+pub(crate) const VIRTIO_VIDEO_RESP_ERR_UNSUPPORTED_CONTROL: u32 = 0x020B;
+
+#[derive(Debug, Clone)]
+pub enum CmdError {
+    InvalidOperation,
+    OutOfMemory,
+    InvalidStreamId,
+    InvalidResourceId,
+    InvalidParameter,
+    UnsupportedControl,
+}
+
+#[derive(Debug, Clone)]
+pub enum CmdResponse {
+    OkNoData,
+    QueryCapability(Vec<virtio_video_format_desc>),
+    ResourceQueue {
+        timestamp: u64,
+        flags: u32,
+        size: u32,
+    },
+    GetParams {
+        queue_type: QueueType,
+        params: virtio_video_params,
+    },
+    QueryControl(VideoControl),
+    GetControl(ControlType),
+    SetControl,
+    Error(CmdError),
+}
+
+impl CmdResponse {
+    fn cmd_type(&self) -> Le32 {
+        use CmdResponse::*;
+        Le32::from(match self {
+            OkNoData => VIRTIO_VIDEO_RESP_OK_NODATA,
+            QueryCapability(_) => VIRTIO_VIDEO_RESP_OK_QUERY_CAPABILITY,
+            ResourceQueue { .. } => VIRTIO_VIDEO_RESP_OK_RESOURCE_QUEUE,
+            GetParams { .. } => VIRTIO_VIDEO_RESP_OK_GET_PARAMS,
+            QueryControl(_) => VIRTIO_VIDEO_RESP_OK_QUERY_CONTROL,
+            GetControl(_) => VIRTIO_VIDEO_RESP_OK_GET_CONTROL,
+            SetControl => VIRTIO_VIDEO_RESP_OK_NODATA,
+            Error(e) => match e {
+                CmdError::InvalidOperation => VIRTIO_VIDEO_RESP_ERR_INVALID_OPERATION,
+                CmdError::OutOfMemory => VIRTIO_VIDEO_RESP_ERR_OUT_OF_MEMORY,
+                CmdError::InvalidStreamId => VIRTIO_VIDEO_RESP_ERR_INVALID_STREAM_ID,
+                CmdError::InvalidResourceId => VIRTIO_VIDEO_RESP_ERR_INVALID_RESOURCE_ID,
+                CmdError::InvalidParameter => VIRTIO_VIDEO_RESP_ERR_INVALID_PARAMETER,
+                CmdError::UnsupportedControl => VIRTIO_VIDEO_RESP_ERR_UNSUPPORTED_CONTROL,
+            },
+        })
+    }
+}
+
+impl ToBytes for CmdResponse {
+    fn to_bytes(&self) -> Vec<u8> {
+        use CmdResponse::*;
+        let mut response_raw: Vec<u8> = Vec::new();
+        match self {
+            QueryCapability(descs) => {
+                let mut response = virtio_video_query_capability_resp::default();
+                response.hdr.type_ = self.cmd_type();
+                response.append_descs(descs);
+                response_raw.append(&mut response.to_bytes());
+            }
+            QueryControl(control_type) => {
+                let mut response = virtio_video_query_control_resp::default();
+                response.hdr.type_ = self.cmd_type();
+                response.resp.num = control_type.get_value();
+                response_raw.extend_from_slice(response.as_slice());
+            }
+            GetParams {
+                queue_type: _,
+                params,
+            } => {
+                let mut response = virtio_video_get_params_resp::default();
+                response.hdr.type_ = self.cmd_type();
+                response.params = *params;
+                response_raw.extend_from_slice(response.as_slice());
+            }
+            GetControl(_c) => {
+                let mut response = virtio_video_get_control_resp::default();
+                response.hdr.type_ = self.cmd_type();
+                response_raw.extend_from_slice(response.hdr.as_slice());
+            }
+            ResourceQueue {
+                timestamp,
+                flags,
+                size,
+            } => {
+                let mut response = virtio_video_resource_queue_resp::default();
+                response.hdr.type_ = self.cmd_type();
+                response.timestamp = (*timestamp).into();
+                response.flags = BufferFlags::from_bits_retain(*flags);
+                // Only used for encoder
+                response.size = (*size).into();
+                response_raw.extend_from_slice(response.as_slice());
+            }
+            OkNoData | SetControl | Error(_) => response_raw.extend_from_slice(
+                virtio_video_cmd_hdr {
+                    type_: self.cmd_type(),
+                    ..Default::default()
+                }
+                .as_slice(),
+            ),
+        };
+        response_raw
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CmdResponseType {
+    Sync(CmdResponse),
+    AsyncQueue {
+        stream_id: u32,
+        queue_type: QueueType,
+        resource_id: u32,
+    },
+}
+
+/// Virtio Video Formats
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum Format {
+    /// Raw formats
+    Argb8888 = 1,
+    Bgra8888,
+    Nv12,
+    Yuv420,
+    Yvu420,
+    /// Coded formats
+    Mpeg2 = 0x1000,
+    Mpeg4,
+    H264,
+    Hevc,
+    Vp8,
+    Vp9,
+    #[default]
+    Fwht,
+}
+
+/// Virtio Video Controls
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum ControlType {
+    Bitrate = 1,
+    Profile,
+    Level,
+    ForceKeyframe,
+    BitrateMode,
+    BitratePeak,
+    PrependSpsPpsToIdr,
+}
+
+/// Planes layout
+pub(crate) const VIRTIO_VIDEO_PLANES_LAYOUT_SINGLE_BUFFER: u32 = 1 << 0;
+pub(crate) const VIRTIO_VIDEO_PLANES_LAYOUT_PER_PLANE: u16 = 1 << 1;
+
+/// Queue type
+pub(crate) const VIRTIO_VIDEO_QUEUE_TYPE_INPUT: u32 = 0x100;
+pub(crate) const VIRTIO_VIDEO_QUEUE_TYPE_OUTPUT: u32 = 0x101;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum QueueType {
+    #[default]
+    InputQueue = VIRTIO_VIDEO_QUEUE_TYPE_INPUT,
+    OutputQueue = VIRTIO_VIDEO_QUEUE_TYPE_OUTPUT,
+}
+
+/// Memory type
+pub(crate) const VIRTIO_VIDEO_MEM_TYPE_GUEST_PAGES: u32 = 0;
+pub(crate) const VIRTIO_VIDEO_MEM_TYPE_VIRTIO_OBJECT: u32 = 1;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum MemoryType {
+    #[default]
+    GuestPages = VIRTIO_VIDEO_MEM_TYPE_GUEST_PAGES,
+    VirtioObject = VIRTIO_VIDEO_MEM_TYPE_VIRTIO_OBJECT,
+}
+
+pub(crate) const VIRTIO_VIDEO_MAX_PLANES: u8 = 8;
+
+pub(crate) const MAX_FMT_DESCS: u8 = 64;
+
+pub(crate) trait ToVirtio {
+    fn to_virtio(&self) -> Le32;
+}
+
+pub(crate) trait InitFromValue<T>
+where
+    Self: Sized,
+{
+    fn from_value(value: T) -> Option<Self>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum VideoCmd {
+    QueryCapability {
+        queue_type: QueueType,
+    },
+    StreamCreate {
+        stream_id: StreamId,
+        in_memory_type: MemoryType,
+        out_memory_type: MemoryType,
+        coded_format: Format,
+    },
+    StreamDestroy {
+        stream_id: StreamId,
+    },
+    StreamDrain {
+        stream_id: StreamId,
+    },
+    ResourceCreate {
+        stream_id: StreamId,
+        queue_type: QueueType,
+        resource_id: u32,
+        planes_layout: u32,
+        plane_offsets: Vec<u32>,
+    },
+    ResourceQueue {
+        stream_id: StreamId,
+        queue_type: QueueType,
+        resource_id: u32,
+        timestamp: u64,
+        data_sizes: Vec<u32>,
+    },
+    ResourceDestroyAll {
+        stream_id: StreamId,
+        queue_type: QueueType,
+    },
+    QueueClear {
+        stream_id: StreamId,
+        queue_type: QueueType,
+    },
+    GetParams {
+        stream_id: StreamId,
+        queue_type: QueueType,
+    },
+    SetParams {
+        stream_id: StreamId,
+        queue_type: QueueType,
+        params: virtio_video_params,
+    },
+    QueryControl {
+        control: ControlType,
+        format: Format,
+    },
+    GetControl {
+        stream_id: StreamId,
+        control: ControlType,
+    },
+}
+
+impl VideoCmd {
+    pub fn from_descriptor(
+        desc_chain: &vhu_video::VideoDescriptorChain,
+    ) -> vhu_video::Result<Self> {
+        use self::VideoCmd::*;
+        macro_rules! read_body {
+            ($a: expr) => {
+                desc_chain.read_body(0, $a)
+            };
+        }
+        let header: virtio_video_cmd_hdr = read_body!(false)?;
+        Ok(match header.type_.into() {
+            VIRTIO_VIDEO_CMD_QUERY_CAPABILITY => {
+                let body: virtio_video_query_capability = read_body!(true)?;
+                QueryCapability {
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_QUERY_CONTROL => {
+                let body: virtio_video_query_control = read_body!(true)?;
+                QueryControl {
+                    control: ControlType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.control,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.control).to_string())
+                    })?,
+                    format: Format::try_from_primitive(<Le32 as Into<u32>>::into(body.fmt.format))
+                        .map_err(|_| {
+                            VuVideoError::UnexpectedArgValue(
+                                stringify!(body.fmt.format).to_string(),
+                            )
+                        })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_STREAM_CREATE => {
+                let body: virtio_video_stream_create = read_body!(true)?;
+                StreamCreate {
+                    stream_id: body.hdr.stream_id.into(),
+                    in_memory_type: MemoryType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.in_mem_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.in_mem_type).to_string())
+                    })?,
+                    out_memory_type: MemoryType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.out_mem_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.out_mem_type).to_string())
+                    })?,
+                    coded_format: Format::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.coded_format,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.format).to_string())
+                    })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_STREAM_DESTROY => {
+                let body: virtio_video_cmd_hdr = read_body!(true)?;
+                StreamDestroy {
+                    stream_id: body.stream_id.into(),
+                }
+            }
+            VIRTIO_VIDEO_CMD_STREAM_DRAIN => {
+                let body: virtio_video_cmd_hdr = read_body!(true)?;
+                StreamDrain {
+                    stream_id: body.stream_id.into(),
+                }
+            }
+            VIRTIO_VIDEO_CMD_RESOURCE_CREATE => {
+                let body: virtio_video_resource_create = read_body!(true)?;
+                ResourceCreate {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                    resource_id: body.resource_id.into(),
+                    planes_layout: body.planes_layout.into(),
+                    plane_offsets: body.plane_offsets
+                        [0..<Le32 as Into<u32>>::into(body.num_planes) as usize]
+                        .iter()
+                        .map(|x| Into::<u32>::into(*x))
+                        .collect::<Vec<u32>>(),
+                }
+            }
+            VIRTIO_VIDEO_CMD_RESOURCE_QUEUE => {
+                let body: virtio_video_resource_queue = read_body!(true)?;
+                ResourceQueue {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                    resource_id: body.resource_id.into(),
+                    timestamp: body.timestamp.into(),
+                    data_sizes: body.data_sizes
+                        [0..<Le32 as Into<u32>>::into(body.num_data_sizes) as usize]
+                        .iter()
+                        .map(|x| Into::<u32>::into(*x))
+                        .collect::<Vec<u32>>(),
+                }
+            }
+            VIRTIO_VIDEO_CMD_RESOURCE_DESTROY_ALL => {
+                let body: virtio_video_get_params = read_body!(true)?;
+                ResourceDestroyAll {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_QUEUE_CLEAR => {
+                let body: virtio_video_get_params = read_body!(true)?;
+                QueueClear {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_GET_PARAMS_EXT => {
+                let body: virtio_video_get_params = read_body!(true)?;
+                GetParams {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                }
+            }
+            VIRTIO_VIDEO_CMD_SET_PARAMS_EXT => {
+                let body: virtio_video_set_params = read_body!(true)?;
+                SetParams {
+                    stream_id: body.hdr.stream_id.into(),
+                    queue_type: QueueType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.params.queue_type,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.queue_type).to_string())
+                    })?,
+                    params: body.params,
+                }
+            }
+            VIRTIO_VIDEO_CMD_GET_CONTROL => {
+                let body: virtio_video_get_control = read_body!(true)?;
+                GetControl {
+                    stream_id: body.hdr.stream_id.into(),
+                    control: ControlType::try_from_primitive(<Le32 as Into<u32>>::into(
+                        body.control,
+                    ))
+                    .map_err(|_| {
+                        VuVideoError::UnexpectedArgValue(stringify!(body.control).to_string())
+                    })?,
+                }
+            }
+            _ => return Err(vhu_video::VuVideoError::InvalidCmdType(header.type_.into())),
+        })
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_cmd_hdr {
+    pub type_: Le32,
+    pub stream_id: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_cmd_hdr {}
+
+/// Requests
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_query_capability {
+    pub hdr: virtio_video_cmd_hdr,
+    pub queue_type: Le32,
+    pub padding: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_query_capability {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_query_control_format {
+    pub format: Le32,
+    pub padding: Le32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_query_control {
+    pub hdr: virtio_video_cmd_hdr,
+    pub control: Le32,
+    pub padding: Le32,
+    pub fmt: virtio_video_query_control_format,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_query_control {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_stream_create {
+    pub hdr: virtio_video_cmd_hdr,
+    pub in_mem_type: Le32,
+    pub out_mem_type: Le32,
+    pub coded_format: Le32,
+    pub padding: u32,
+    pub tag: [[u8; 32]; 2],
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_stream_create {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_resource_create {
+    pub hdr: virtio_video_cmd_hdr,
+    pub queue_type: Le32,
+    pub resource_id: Le32,
+    pub planes_layout: Le32,
+    pub num_planes: Le32,
+    pub plane_offsets: [Le32; VIRTIO_VIDEO_MAX_PLANES as usize],
+    pub num_entries: [Le32; VIRTIO_VIDEO_MAX_PLANES as usize],
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_resource_create {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_resource_queue {
+    pub hdr: virtio_video_cmd_hdr,
+    pub queue_type: Le32,
+    pub resource_id: Le32,
+    pub timestamp: Le64,
+    pub num_data_sizes: Le32,
+    pub data_sizes: [Le32; VIRTIO_VIDEO_MAX_PLANES as usize],
+    pub padding: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_resource_queue {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_get_params {
+    pub hdr: virtio_video_cmd_hdr,
+    pub queue_type: Le32,
+    pub padding: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_get_params {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_set_params {
+    pub hdr: virtio_video_cmd_hdr,
+    pub params: virtio_video_params,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_set_params {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_get_control {
+    pub hdr: virtio_video_cmd_hdr,
+    pub control: Le32,
+    pub padding: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_get_control {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct virtio_video_format_range {
+    pub min: Le32,
+    pub max: Le32,
+    pub step: Le32,
+    pub padding: Le32,
+}
+
+impl From<u32> for virtio_video_format_range {
+    fn from(range: u32) -> Self {
+        Self {
+            min: range.into(),
+            max: range.into(),
+            step: 0.into(),
+            padding: 0.into(),
+        }
+    }
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_format_range {}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct virtio_video_format_frame {
+    pub width: virtio_video_format_range,
+    pub length: virtio_video_format_range,
+    pub num_rates: Le32,
+    pub padding: Le32,
+    pub frame_rates: Vec<virtio_video_format_range>,
+}
+
+impl virtio_video_format_frame {
+    pub fn append_frame_rates(&mut self, frames: &mut Vec<virtio_video_format_range>) {
+        self.frame_rates.append(frames);
+        self.num_rates = (self.frame_rates.len() as u32).into();
+    }
+}
+
+impl ToBytes for virtio_video_format_frame {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut ret = [
+            self.width.as_slice(),
+            self.length.as_slice(),
+            self.num_rates.as_slice(),
+            self.padding.as_slice(),
+        ]
+        .concat();
+        self.frame_rates
+            .iter()
+            .for_each(|frame_rate| ret.extend_from_slice(frame_rate.as_slice()));
+        ret
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct virtio_video_format_desc {
+    mask: Le64,
+    pub format: Le32,
+    pub planes_layout: Le32,
+    plane_align: Le32,
+    num_frames: Le32,
+    frames: Vec<virtio_video_format_frame>,
+}
+
+impl virtio_video_format_desc {
+    pub fn append_frames(&mut self, frames: &mut Vec<virtio_video_format_frame>) {
+        self.frames.append(frames);
+        self.num_frames = (self.frames.len() as u32).into();
+    }
+
+    pub fn generate_mask(&mut self, num_formats: usize) {
+        self.mask = (u64::MAX >> (64 - num_formats)).into();
+    }
+}
+
+impl ToBytes for virtio_video_format_desc {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut ret = [
+            self.mask.as_slice(),
+            self.format.as_slice(),
+            self.planes_layout.as_slice(),
+            self.plane_align.as_slice(),
+            self.num_frames.as_slice(),
+        ]
+        .concat();
+        self.frames
+            .iter()
+            .for_each(|frames| ret.append(&mut frames.to_bytes()));
+        ret
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct virtio_video_plane_format {
+    pub plane_size: Le32,
+    pub stride: Le32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct virtio_video_crop {
+    pub left: Le32,
+    pub top: Le32,
+    pub width: Le32,
+    pub heigth: Le32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct virtio_video_params {
+    pub queue_type: Le32,
+    pub format: Le32,
+    pub frame_width: Le32,
+    pub frame_heigth: Le32,
+    pub min_buffers: Le32,
+    pub max_buffers: Le32,
+    pub crop: virtio_video_crop,
+    pub frame_rate: Le32,
+    pub num_planes: Le32,
+    pub plane_formats: [virtio_video_plane_format; VIRTIO_VIDEO_MAX_PLANES as usize],
+    pub resource_type: Le32,
+    pub padding: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_params {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct virtio_video_mem_entry {
+    pub addr: Le64,
+    pub length: Le32,
+    pub padding: Le32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct SingleLayoutBuffer(pub virtio_video_mem_entry);
+
+impl SingleLayoutBuffer {
+    pub fn raw_addr(&self) -> u64 {
+        self.0.addr.into()
+    }
+
+    pub fn raw_len(&self) -> u32 {
+        self.0.length.into()
+    }
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for SingleLayoutBuffer {}
+
+/// Responses
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct virtio_video_query_capability_resp {
+    pub hdr: virtio_video_cmd_hdr,
+    pub num_descs: Le32,
+    pub padding: Le32,
+    pub descs: Vec<virtio_video_format_desc>,
+}
+
+impl virtio_video_query_capability_resp {
+    pub fn append_descs(&mut self, descs: &Vec<virtio_video_format_desc>) {
+        for desc in descs {
+            self.descs.push(desc.clone());
+        }
+        self.num_descs = (self.descs.len() as u32).into();
+    }
+}
+
+impl ToBytes for virtio_video_query_capability_resp {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut ret = [
+            self.hdr.as_slice(),
+            self.num_descs.as_slice(),
+            self.padding.as_slice(),
+        ]
+        .concat();
+        self.descs
+            .iter()
+            .for_each(|desc| ret.append(&mut desc.to_bytes()));
+        ret
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub struct virtio_video_query_control_resp_value {
+    pub num: Le32,
+    pub padding: Le32,
+    pub value: Le32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_query_control_resp {
+    pub hdr: virtio_video_cmd_hdr,
+    pub resp: virtio_video_query_control_resp_value,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_query_control_resp {}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_get_params_resp {
+    pub hdr: virtio_video_cmd_hdr,
+    pub params: virtio_video_params,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_get_params_resp {}
+
+bitflags! {
+    #[derive(Copy, Clone, Debug, Default)]
+    pub struct BufferFlags: u32 {
+        const ERR = 1 << 0;
+        const EOS = 1 << 1;
+        // Encoder only
+        const IFRAME = 1 << 2;
+        const PFRAME = 1 << 3;
+        const BFRAME = 1 << 4;
+    }
+}
+
+impl From<BufferFlags> for Le32 {
+    fn from(val: BufferFlags) -> Self {
+        Le32::from(val.bits())
+    }
+}
+
+impl From<Le32> for BufferFlags {
+    fn from(value: Le32) -> Self {
+        Self::from_bits_retain(<Le32 as Into<u32>>::into(value))
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct virtio_video_resource_queue_resp {
+    pub hdr: virtio_video_cmd_hdr,
+    pub timestamp: Le64,
+    pub flags: BufferFlags,
+    pub size: Le32,
+}
+
+// SAFETY: The layout of the structure is fixed and can be initialized by
+// reading its content from byte array.
+unsafe impl ByteValued for virtio_video_resource_queue_resp {}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum VideoControl {
+    #[default]
+    Default,
+    Bitrate(Le32),
+    BitratePeak(Le32),
+    BitrateMode(Le32),
+    ForceKeyframe(Le32),
+    Profile(Le32),
+    Level(Le32),
+    PrependSpsPpsToIdr(Le32),
+}
+
+impl VideoControl {
+    pub fn new_from_type(control_type: ControlType, value: Le32) -> Self {
+        match control_type {
+            ControlType::Bitrate => Self::Bitrate(value),
+            ControlType::BitrateMode => Self::BitrateMode(value),
+            ControlType::BitratePeak => Self::BitratePeak(value),
+            ControlType::Profile => Self::Profile(value),
+            ControlType::Level => Self::Level(value),
+            ControlType::PrependSpsPpsToIdr => Self::PrependSpsPpsToIdr(value),
+            ControlType::ForceKeyframe => Self::ForceKeyframe(value),
+        }
+    }
+
+    fn get_value(&self) -> Le32 {
+        match self {
+            Self::Default => 0.into(),
+            Self::Bitrate(value)
+            | Self::BitrateMode(value)
+            | Self::BitratePeak(value)
+            | Self::Profile(value)
+            | Self::Level(value)
+            | Self::PrependSpsPpsToIdr(value)
+            | Self::ForceKeyframe(value) => *value,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct virtio_video_get_control_resp {
+    pub hdr: virtio_video_cmd_hdr,
+    pub control: VideoControl,
+}
+
+pub(crate) enum VirtioVideoEventType {
+    Error = 0x0100,
+    DecoderResolutionChanged = 0x0200,
+}
+
+impl From<VirtioVideoEventType> for Le32 {
+    fn from(val: VirtioVideoEventType) -> Self {
+        Le32::from(val as u32)
+    }
+}
+
+#[derive(Debug)]
+pub struct virtio_video_event {
+    pub event_type: Le32,
+    pub stream_id: Le32,
+}
+
+impl ToBytes for virtio_video_event {
+    fn to_bytes(&self) -> Vec<u8> {
+        [self.event_type.as_slice(), self.stream_id.as_slice()].concat()
+    }
+}

--- a/staging/vhost-device-video/src/video_backends.rs
+++ b/staging/vhost-device-video/src/video_backends.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+mod null;
+
+use std::path::Path;
+
+use self::null::NullBackend;
+use crate::{
+    stream::{ResourcePlane, Stream},
+    vhu_video::{BackendType, Result, VuVideoError},
+    video::{
+        virtio_video_event, virtio_video_params, BufferFlags, CmdResponseType, ControlType,
+        QueueType,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct DqBufData {
+    pub index: u32,
+    pub flags: BufferFlags,
+    pub size: u32,
+}
+
+pub trait VideoBackend {
+    fn create_stream(
+        &mut self,
+        stream_id: u32,
+        in_memory_type: u32,
+        out_memory_type: u32,
+        coded_format: u32,
+    ) -> CmdResponseType;
+
+    fn destroy_stream(&mut self, stream_id: u32) -> CmdResponseType;
+
+    fn query_capability(&self, queue_type: QueueType) -> CmdResponseType;
+
+    fn query_control(&self, control: ControlType) -> CmdResponseType;
+
+    fn clear_queue(&mut self, stream_id: u32, queue_type: QueueType) -> CmdResponseType;
+
+    fn get_params(&self, stream_id: u32, queue_type: QueueType) -> CmdResponseType;
+
+    fn set_params(&mut self, stream_id: u32, params: virtio_video_params) -> CmdResponseType;
+
+    fn create_resource(
+        &mut self,
+        stream_id: u32,
+        resource_id: u32,
+        planes_layout: u32,
+        planes: Vec<ResourcePlane>,
+        queue_type: QueueType,
+    ) -> CmdResponseType;
+
+    fn destroy_resources(&mut self, stream_id: u32, queue_type: QueueType) -> CmdResponseType;
+
+    fn queue_resource(
+        &mut self,
+        stream_id: u32,
+        queue_type: QueueType,
+        resource_id: u32,
+        timestamp: u64,
+        bytes_used: Vec<u32>,
+    ) -> CmdResponseType;
+
+    fn dequeue_resource(&self, stream_id: u32, queue_type: QueueType) -> Option<DqBufData>;
+
+    fn drain_stream(&mut self, stream_id: u32) -> CmdResponseType;
+
+    fn dequeue_event(&self, stream_id: u32) -> Option<virtio_video_event>;
+
+    fn stream(&self, _stream_id: &u32) -> Option<&Stream> {
+        None
+    }
+
+    fn stream_mut(&mut self, _stream_id: &u32) -> Option<&mut Stream> {
+        None
+    }
+}
+
+pub(crate) fn alloc_video_backend(
+    backend: BackendType,
+    video_path: &Path,
+) -> Result<Box<dyn VideoBackend + Sync + Send>> {
+    match backend {
+        BackendType::Null => Ok(Box::new(
+            NullBackend::new(video_path).map_err(|_| VuVideoError::AccessVideoDeviceFile)?,
+        )),
+    }
+}

--- a/staging/vhost-device-video/src/video_backends/null.rs
+++ b/staging/vhost-device-video/src/video_backends/null.rs
@@ -137,3 +137,93 @@ impl NullBackend {
         Ok(Self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use assert_matches::assert_matches;
+    use rstest::*;
+    use tempfile::TempDir;
+    use vm_memory::Le32;
+
+    use super::*;
+    use crate::vhu_video::tests::{test_dir, VideoDeviceMock};
+
+    #[rstest]
+    fn test_backend_trait(test_dir: TempDir) {
+        use video::{CmdResponse::*, CmdResponseType::*};
+        // Mock video device, will not answer to requests
+        let v4l2_device = VideoDeviceMock::new(&test_dir);
+        let mut decoder = NullBackend::new(Path::new(&v4l2_device.path)).unwrap();
+        let stream_id = 1;
+        let invalid_stream_id = 2;
+        let resource_id = 1;
+        let queue_type = video::QueueType::OutputQueue;
+        // Create stream
+        assert_matches!(decoder.create_stream(stream_id, 1, 1, 1), Sync(OkNoData));
+        // Null backend does not store any stream, thus it never fetches any
+        assert_matches!(decoder.stream(&stream_id), None);
+        assert_matches!(decoder.stream_mut(&stream_id), None);
+        assert_matches!(decoder.stream(&invalid_stream_id), None);
+        assert_matches!(decoder.stream_mut(&invalid_stream_id), None);
+        // Check capabilities, control, params
+        assert_matches!(
+            decoder.query_capability(queue_type),
+            Sync(QueryCapability(_))
+        );
+        assert_matches!(
+            decoder.query_control(video::ControlType::Bitrate),
+            Sync(QueryControl(_))
+        );
+        let params = video::virtio_video_params {
+            queue_type: <u32 as Into<Le32>>::into(queue_type as u32),
+            ..Default::default()
+        };
+        assert_matches!(decoder.set_params(stream_id, params), Sync(OkNoData));
+        // Create resource, queue, and dequeue it
+        assert_matches!(
+            decoder.create_resource(stream_id, resource_id, 1, Vec::new(), queue_type),
+            Sync(OkNoData)
+        );
+        assert_matches!(
+            decoder.queue_resource(stream_id, queue_type, resource_id, 0, vec![0]),
+            Sync(Error(video::CmdError::InvalidOperation))
+        );
+        assert_matches!(decoder.dequeue_resource(stream_id, queue_type), None);
+        // End of stream
+        assert_matches!(decoder.drain_stream(stream_id), Sync(OkNoData));
+        assert_matches!(
+            decoder.destroy_resources(stream_id, queue_type),
+            Sync(OkNoData)
+        );
+    }
+
+    #[rstest]
+    fn test_backend_trait_errors(test_dir: TempDir) {
+        use video::{CmdResponse::*, CmdResponseType::*};
+        let stream_id = 1;
+        let resource_id = 1;
+        let queue_type = video::QueueType::OutputQueue;
+        let params = video::virtio_video_params {
+            queue_type: <u32 as Into<Le32>>::into(queue_type as u32),
+            ..Default::default()
+        };
+        let v4l2_device = VideoDeviceMock::new(&test_dir);
+        let mut decoder = NullBackend::new(Path::new(&v4l2_device.path)).unwrap();
+        assert_matches!(decoder.set_params(stream_id, params), Sync(OkNoData));
+        assert_matches!(
+            decoder.create_resource(stream_id, resource_id, 1, Vec::new(), queue_type),
+            Sync(OkNoData)
+        );
+        assert_matches!(
+            decoder.queue_resource(stream_id, queue_type, resource_id, 0, vec![0]),
+            Sync(Error(video::CmdError::InvalidOperation))
+        );
+        assert_matches!(decoder.dequeue_resource(stream_id, queue_type), None);
+        assert_matches!(decoder.drain_stream(stream_id), Sync(OkNoData));
+        assert_matches!(
+            decoder.destroy_resources(stream_id, queue_type),
+            Sync(OkNoData)
+        );
+    }
+}

--- a/staging/vhost-device-video/src/video_backends/null.rs
+++ b/staging/vhost-device-video/src/video_backends/null.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{io, path::Path};
+
+use log::info;
+
+use super::{DqBufData, VideoBackend};
+use crate::{
+    stream::ResourcePlane,
+    video::{self, CmdError::*, CmdResponseType::Sync},
+};
+
+pub struct NullBackend;
+
+impl VideoBackend for NullBackend {
+    fn create_stream(
+        &mut self,
+        stream_id: u32,
+        _in_memory_type: u32,
+        _out_memory_type: u32,
+        _coded_format: u32,
+    ) -> video::CmdResponseType {
+        info!("null backend => Creating stream: {}", stream_id);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn destroy_stream(&mut self, stream_id: u32) -> video::CmdResponseType {
+        info!("null backend => Destroying stream: {}", stream_id);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn queue_resource(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+        resource_id: u32,
+        _timestamp: u64,
+        _bytes_used: Vec<u32>,
+    ) -> video::CmdResponseType {
+        info!(
+            "null backend => Queue resource ({:?} queue, id {}), stream {}",
+            queue_type, resource_id, stream_id
+        );
+        Sync(video::CmdResponse::Error(InvalidOperation))
+    }
+
+    fn query_capability(&self, queue_type: video::QueueType) -> video::CmdResponseType {
+        info!("null backend => Queue capability, queue {:?}", queue_type);
+        Sync(video::CmdResponse::QueryCapability(Vec::new()))
+    }
+
+    fn query_control(&self, control: video::ControlType) -> video::CmdResponseType {
+        info!("null backend => Query control: {:?}", control);
+        Sync(video::CmdResponse::QueryControl(
+            video::VideoControl::Default,
+        ))
+    }
+
+    fn clear_queue(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        info!(
+            "null backend => Clear {:?} queue, stream {}",
+            queue_type, stream_id
+        );
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn get_params(&self, stream_id: u32, queue_type: video::QueueType) -> video::CmdResponseType {
+        info!(
+            "null backend => Get {:?} queue params, stream {}",
+            queue_type, stream_id
+        );
+        Sync(video::CmdResponse::Error(InvalidOperation))
+    }
+
+    fn set_params(
+        &mut self,
+        stream_id: u32,
+        _params: video::virtio_video_params,
+    ) -> video::CmdResponseType {
+        info!("null backend => Set params, stream {}", stream_id);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn create_resource(
+        &mut self,
+        stream_id: u32,
+        resource_id: u32,
+        _planes_layout: u32,
+        _planes: Vec<ResourcePlane>,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        info!(
+            "null backend => Create resource {}, {:?} queue, stream {}",
+            resource_id, queue_type, stream_id
+        );
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn destroy_resources(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        info!(
+            "null backend => Clear resources, {:?} queue, stream {}",
+            queue_type, stream_id
+        );
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn drain_stream(&mut self, stream_id: u32) -> video::CmdResponseType {
+        info!("null backend => Drain stream {}", stream_id);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn dequeue_event(&self, _stream_id: u32) -> Option<video::virtio_video_event> {
+        None
+    }
+
+    fn dequeue_resource(
+        &self,
+        _stream_id: u32,
+        _queue_type: video::QueueType,
+    ) -> Option<DqBufData> {
+        None
+    }
+}
+
+impl NullBackend {
+    pub fn new(video_path: &Path) -> io::Result<Self> {
+        // Check if file exists
+        std::fs::File::create(video_path)?;
+        Ok(Self)
+    }
+}

--- a/staging/vhost-device-video/src/video_backends/v4l2_decoder.rs
+++ b/staging/vhost-device-video/src/video_backends/v4l2_decoder.rs
@@ -1,0 +1,801 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{
+    collections::HashMap, fs::File, io, os::unix::io::AsRawFd, path::Path, slice::from_raw_parts,
+};
+
+use log::{debug, warn};
+use v4l2r::{
+    bindings::{
+        v4l2_fmtdesc, v4l2_format, v4l2_frmivalenum, v4l2_frmsizeenum, v4l2_queryctrl, v4l2_rect,
+    },
+    PixelFormat, PlaneLayout,
+};
+use vm_memory::Le32;
+
+use super::{DqBufData, VideoBackend};
+use crate::{
+    stream,
+    video::{
+        self,
+        CmdError::*,
+        CmdResponseType::{AsyncQueue, Sync},
+        InitFromValue, ToVirtio,
+    },
+};
+
+pub(crate) trait ToV4L2 {
+    fn to_v4l2(&self) -> u32;
+}
+
+struct FilePath {
+    _file: File,
+    _path: Box<Path>,
+}
+
+impl AsRawFd for FilePath {
+    fn as_raw_fd(&self) -> i32 {
+        self._file.as_raw_fd()
+    }
+}
+
+impl FilePath {
+    fn new(video_path: &Path) -> io::Result<Self> {
+        Ok(Self {
+            _file: File::create(video_path)?,
+            _path: video_path.into(),
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self._path
+    }
+}
+
+impl ToVirtio for PixelFormat {
+    fn to_virtio(&self) -> Le32 {
+        match self.to_string().as_str() {
+            "ABGR" => (video::Format::Argb8888 as u32).into(),
+            "NV12" => (video::Format::Nv12 as u32).into(),
+            "YU12" => (video::Format::Yuv420 as u32).into(),
+            "YV12" => (video::Format::Yvu420 as u32).into(),
+            "MPG2" => (video::Format::Mpeg2 as u32).into(),
+            "MPG4" => (video::Format::Mpeg4 as u32).into(),
+            "H264" => (video::Format::H264 as u32).into(),
+            "HEVC" => (video::Format::Hevc as u32).into(),
+            "VP80" => (video::Format::Vp8 as u32).into(),
+            "VP90" => (video::Format::Vp9 as u32).into(),
+            "FWHT" => (video::Format::Fwht as u32).into(),
+            _ => 0.into(),
+        }
+    }
+}
+
+impl InitFromValue<u32> for v4l2r::QueueType {
+    fn from_value(value: u32) -> Option<Self> {
+        match value {
+            video::VIRTIO_VIDEO_QUEUE_TYPE_INPUT => Some(v4l2r::QueueType::VideoOutputMplane),
+            video::VIRTIO_VIDEO_QUEUE_TYPE_OUTPUT => Some(v4l2r::QueueType::VideoCaptureMplane),
+            _ => None,
+        }
+    }
+}
+
+impl ToVirtio for v4l2r::QueueType {
+    fn to_virtio(&self) -> Le32 {
+        match self {
+            v4l2r::QueueType::VideoCaptureMplane => video::VIRTIO_VIDEO_QUEUE_TYPE_OUTPUT.into(),
+            v4l2r::QueueType::VideoOutputMplane => video::VIRTIO_VIDEO_QUEUE_TYPE_INPUT.into(),
+            _ => 0.into(),
+        }
+    }
+}
+
+impl ToV4L2 for video::QueueType {
+    fn to_v4l2(&self) -> u32 {
+        match self {
+            video::QueueType::OutputQueue => v4l2r::QueueType::VideoCaptureMplane as u32,
+            video::QueueType::InputQueue => v4l2r::QueueType::VideoOutputMplane as u32,
+        }
+    }
+}
+
+impl ToV4L2 for video::MemoryType {
+    fn to_v4l2(&self) -> u32 {
+        match self {
+            Self::GuestPages => v4l2r::bindings::v4l2_memory_V4L2_MEMORY_USERPTR,
+            Self::VirtioObject => v4l2r::bindings::v4l2_memory_V4L2_MEMORY_DMABUF,
+        }
+    }
+}
+
+impl ToV4L2 for video::ControlType {
+    fn to_v4l2(&self) -> u32 {
+        match self {
+            Self::Bitrate => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_BITRATE,
+            Self::BitratePeak => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_BITRATE_PEAK,
+            Self::BitrateMode => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_BITRATE_MODE,
+            Self::Profile => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_H264_PROFILE,
+            Self::Level => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_H264_LEVEL,
+            Self::ForceKeyframe => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME,
+            Self::PrependSpsPpsToIdr => v4l2r::bindings::V4L2_CID_MPEG_VIDEO_PREPEND_SPSPPS_TO_IDR,
+        }
+    }
+}
+
+impl ToVirtio for v4l2r::ioctl::BufferFlags {
+    fn to_virtio(&self) -> Le32 {
+        let mut flags = video::BufferFlags::default();
+        if self.contains(v4l2r::ioctl::BufferFlags::ERROR) {
+            flags.insert(video::BufferFlags::ERR);
+        }
+        if self.contains(v4l2r::ioctl::BufferFlags::LAST) {
+            flags.insert(video::BufferFlags::EOS);
+        }
+        flags.into()
+    }
+}
+
+impl video::virtio_video_format_desc {
+    fn as_virtio_format(&mut self, pixelformat: u32) {
+        self.format = PixelFormat::from(pixelformat).to_virtio();
+        self.planes_layout = video::VIRTIO_VIDEO_PLANES_LAYOUT_SINGLE_BUFFER.into();
+    }
+}
+
+impl From<v4l2_frmsizeenum> for video::virtio_video_format_frame {
+    fn from(frame: v4l2_frmsizeenum) -> Self {
+        match frame.size() {
+            Some(v4l2r::ioctl::FrmSizeTypes::Discrete(size)) => Self {
+                width: size.width.into(),
+                length: size.height.into(),
+                num_rates: 0.into(),
+                padding: 0.into(),
+                frame_rates: Vec::new(),
+            },
+            Some(v4l2r::ioctl::FrmSizeTypes::StepWise(size)) => Self {
+                width: video::virtio_video_format_range {
+                    min: size.min_width.into(),
+                    max: size.max_width.into(),
+                    step: size.step_width.into(),
+                    padding: 0.into(),
+                },
+                length: video::virtio_video_format_range {
+                    min: size.min_height.into(),
+                    max: size.max_height.into(),
+                    step: size.step_height.into(),
+                    padding: 0.into(),
+                },
+                num_rates: 0.into(),
+                padding: 0.into(),
+                frame_rates: Vec::new(),
+            },
+            None => {
+                warn!("Unexpected frame type: {}", frame.type_);
+                Self::default()
+            }
+        }
+    }
+}
+
+impl From<v4l2_frmivalenum> for video::virtio_video_format_range {
+    fn from(ival: v4l2_frmivalenum) -> Self {
+        let mut frate = video::virtio_video_format_range::default();
+        match ival.intervals() {
+            Some(v4l2r::ioctl::FrmIvalTypes::Discrete(fract)) => {
+                frate.min = fract.denominator.into()
+            }
+            Some(v4l2r::ioctl::FrmIvalTypes::StepWise(interval)) => {
+                frate.min = interval.min.denominator.into();
+                frate.max = interval.max.denominator.into();
+                if ival.type_ == v4l2r::bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_CONTINUOUS {
+                    frate.step = 1.into();
+                } else {
+                    frate.step = interval.step.denominator.into();
+                }
+            }
+            None => warn!("Unexpected ival type: {}", ival.type_),
+        }
+        frate
+    }
+}
+
+fn process_timestamp(timestamp: u64) -> (i64, i64) {
+    let n_per_sec: i64 = 1_000_000_000;
+    let tv_sec: i64 = timestamp as i64 / n_per_sec;
+    let nsec: i64 = tv_sec * n_per_sec;
+    let tv_usec: i64 = (timestamp as i64 - nsec) / 1_000;
+    (tv_sec, tv_usec)
+}
+
+pub struct V4L2Decoder {
+    streams: HashMap<u32, stream::Stream>,
+    video_device: FilePath,
+}
+
+impl VideoBackend for V4L2Decoder {
+    fn stream(&self, stream_id: &u32) -> Option<&stream::Stream> {
+        self.streams.get(stream_id)
+    }
+
+    fn stream_mut(&mut self, stream_id: &u32) -> Option<&mut stream::Stream> {
+        self.streams.get_mut(stream_id)
+    }
+
+    fn create_stream(
+        &mut self,
+        stream_id: u32,
+        in_memory_type: u32,
+        out_memory_type: u32,
+        coded_format: u32,
+    ) -> video::CmdResponseType {
+        let stream = match stream::Stream::new(
+            stream_id,
+            self.video_device.path(),
+            in_memory_type,
+            out_memory_type,
+            coded_format,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("{}", e);
+                return Sync(video::CmdResponse::Error(InvalidParameter));
+            }
+        };
+        self.streams.insert(stream_id, stream);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn destroy_stream(&mut self, stream_id: u32) -> video::CmdResponseType {
+        self.streams.remove(&stream_id);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn queue_resource(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+        resource_id: u32,
+        timestamp: u64,
+        bytes_used: Vec<u32>,
+    ) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        // Clone stream to burrow the fd as inmutable
+        let fd = stream.clone().file;
+        let memory_type = stream.memory(queue_type);
+        let memory = v4l2r::memory::MemoryType::n(memory_type.to_v4l2()).unwrap();
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        let bufcount = match queue_type {
+            video::QueueType::InputQueue => stream.inputq_resources.map.len(),
+            video::QueueType::OutputQueue => stream.outputq_resources.map.len(),
+        };
+        let all_created = stream.all_created(queue_type);
+        let res = match stream.find_resource_mut(resource_id, queue_type) {
+            Some(resource) => resource,
+            None => {
+                warn!("Invalid resource if: {}", resource_id);
+                return Sync(video::CmdResponse::Error(InvalidParameter));
+            }
+        };
+        if bufcount > 0 && all_created {
+            if let Err(e) = v4l2r::ioctl::reqbufs::<()>(&fd, queue, memory, bufcount as u32) {
+                warn!("reqbufs failed: {}", e);
+                return Sync(video::CmdResponse::Error(InvalidParameter));
+            }
+            res.set_queried();
+        }
+
+        if res.planes.len() != bytes_used.len() {
+            warn!("Number of planes mismatch");
+            return Sync(video::CmdResponse::Error(InvalidParameter));
+        }
+        res.buffer_data.write().unwrap().timestamp = timestamp;
+        // Assumes UserPtrHandle
+        if memory_type == video::MemoryType::VirtioObject {
+            warn!("Virtio Object Memory NOT YET supported");
+            return Sync(video::CmdResponse::Error(InvalidParameter));
+        }
+        let planes: Vec<v4l2r::ioctl::QBufPlane> = res
+            .planes
+            .iter()
+            .map(|plane| {
+                let handle = v4l2r::memory::UserPtrHandle::from(
+                    // SAFETY: the address pointer memory is initialized by the guest.
+                    unsafe { from_raw_parts(plane.address as *const u8, plane.length as usize) },
+                );
+                v4l2r::ioctl::QBufPlane::new_from_handle(&handle, plane.length as usize)
+            })
+            .collect();
+        let (sec, usec) = process_timestamp(timestamp);
+        let qbuffer: v4l2r::ioctl::QBuffer<v4l2r::memory::UserPtrHandle<Vec<u8>>> =
+            v4l2r::ioctl::QBuffer {
+                planes,
+                ..Default::default()
+            }
+            .set_timestamp(sec, usec);
+        match v4l2r::ioctl::qbuf::<_, ()>(&fd, queue, res.index as usize, qbuffer) {
+            Ok(_) => {
+                res.set_queued();
+            }
+            Err(e) => {
+                warn!("qbuf failed: {}", e);
+                return Sync(video::CmdResponse::Error(InvalidParameter));
+            }
+        }
+
+        if stream.state() == stream::StreamState::Stopped {
+            if let Err(e) = v4l2r::ioctl::subscribe_event(
+                stream,
+                v4l2r::ioctl::EventType::SourceChange(0),
+                v4l2r::ioctl::SubscribeEventFlags::empty(),
+            ) {
+                warn!("subscribe_event failed: {}", e);
+            }
+
+            if let Err(e) = v4l2r::ioctl::subscribe_event(
+                stream,
+                v4l2r::ioctl::EventType::Eos,
+                v4l2r::ioctl::SubscribeEventFlags::empty(),
+            ) {
+                warn!("subscribe_event failed: {}", e);
+            }
+            stream.set_state(stream::StreamState::Subscribed);
+        }
+
+        if stream::StreamState::Draining != stream.state() && !stream.is_queue_streaming(queue_type)
+        {
+            if let Err(e) = v4l2r::ioctl::streamon(stream, queue) {
+                warn!("streamon failed: {}", e);
+            }
+            stream.set_queue_streaming(queue_type);
+            stream.set_state(stream::StreamState::Streaming);
+        }
+
+        AsyncQueue {
+            stream_id: stream.stream_id,
+            queue_type,
+            resource_id,
+        }
+    }
+
+    fn query_capability(&self, queue_type: video::QueueType) -> video::CmdResponseType {
+        let mut index: u32 = 0;
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        let mut desc_list: Vec<video::virtio_video_format_desc> = Vec::new();
+        loop {
+            let fmtdesc: v4l2_fmtdesc =
+                match v4l2r::ioctl::enum_fmt(&self.video_device, queue, index) {
+                    Ok(fmtdesc) => fmtdesc,
+                    Err(e) => {
+                        warn!("fmtdesc failed: {}", e);
+                        break;
+                    }
+                };
+
+            if index != fmtdesc.index {
+                warn!("v4l2 driver modified index {}", fmtdesc.index);
+            }
+
+            let format = PixelFormat::from(fmtdesc.pixelformat);
+            if format.to_virtio() == 0 {
+                debug!(
+                    "Unsupported format for virtio-video ({}), skipping.",
+                    format.to_string()
+                );
+                index += 1;
+                continue;
+            }
+
+            let mut desc = video::virtio_video_format_desc::default();
+            desc.append_frames(&mut self.video_enum_frame_sizes(fmtdesc.pixelformat));
+            desc.as_virtio_format(fmtdesc.pixelformat);
+            desc_list.push(desc);
+            index += 1;
+        }
+
+        debug!("Enumerated {} formats:", desc_list.len());
+        let num_formats = desc_list.len();
+        for desc in &mut desc_list {
+            desc.generate_mask(num_formats);
+            debug!("{:?}", desc);
+        }
+
+        Sync(video::CmdResponse::QueryCapability(desc_list))
+    }
+
+    fn query_control(&self, control: video::ControlType) -> video::CmdResponseType {
+        let (id, flags) = v4l2r::ioctl::parse_ctrl_id_and_flags(control.to_v4l2());
+        let queryctrl: v4l2_queryctrl = match v4l2r::ioctl::queryctrl(&self.video_device, id, flags)
+        {
+            Ok(queryctrl) => queryctrl,
+            Err(e) => {
+                warn!("queryctrl failed: {}", e);
+                return Sync(video::CmdResponse::Error(UnsupportedControl));
+            }
+        };
+
+        Sync(video::CmdResponse::QueryControl(
+            video::VideoControl::new_from_type(control, queryctrl.type_.into()),
+        ))
+    }
+
+    fn clear_queue(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        // send replies for all in-flight buffers
+        for resource in stream.queued_resources_mut(queue_type) {
+            resource.ready_with(video::BufferFlags::ERR, 0);
+        }
+        /*
+         * QUEUE_CLEAR behaviour from virtio-video spec
+         * Return already queued buffers back from the input or the output queue
+         * of the device. The device SHOULD return all of the buffers from the
+         * respective queue as soon as possible without pushing the buffers through
+         * the processing pipeline.
+         *
+         * From v4l2 PoV we issue a VIDIOC_STREAMOFF on the queue which will abort
+         * or finish any DMA in progress, unlocks any user pointer buffers locked
+         * in physical memory, and it removes all buffers from the incoming and
+         * outgoing queues.
+         */
+        if let Err(e) = v4l2r::ioctl::streamoff(stream, queue) {
+            warn!("streamoff failed: {}", e);
+            return Sync(video::CmdResponse::Error(InvalidParameter));
+        }
+
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn get_params(&self, stream_id: u32, queue_type: video::QueueType) -> video::CmdResponseType {
+        let stream = match self.streams.get(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        let mut params = video::virtio_video_params::default();
+        let format: v4l2_format = match v4l2r::ioctl::g_fmt(stream, queue) {
+            Ok(format) => format,
+            Err(e) => {
+                warn!("g_fmt failed: {}", e);
+                return Sync(video::CmdResponse::Error(InvalidParameter));
+            }
+        };
+
+        params.queue_type = (queue_type as u32).into();
+        params.min_buffers = 1.into();
+        params.max_buffers = 32.into();
+        // SAFETY: The member of the union that gets initialised is determined
+        // by the implementation, as it only supports multiplanar video devices.
+        let pix_fmt = unsafe { &format.fmt.pix_mp };
+        params.format = PixelFormat::from(pix_fmt.pixelformat).to_virtio();
+        params.frame_width = pix_fmt.width.into();
+        params.frame_heigth = pix_fmt.height.into();
+        params.num_planes = (pix_fmt.num_planes as u32).into();
+
+        for i in 0..pix_fmt.num_planes {
+            params.plane_formats[i as usize].stride =
+                pix_fmt.plane_fmt[i as usize].bytesperline.into();
+            params.plane_formats[i as usize].plane_size =
+                pix_fmt.plane_fmt[i as usize].sizeimage.into();
+        }
+
+        if queue.direction() == v4l2r::QueueDirection::Capture {
+            if let Some(sel) = Self::get_selection(stream, queue) {
+                params.crop.left = (sel.left as u32).into();
+                params.crop.top = (sel.top as u32).into();
+                params.crop.width = sel.width.into();
+                params.crop.heigth = sel.height.into();
+            }
+        }
+
+        Sync(video::CmdResponse::GetParams { queue_type, params })
+    }
+
+    fn set_params(
+        &mut self,
+        stream_id: u32,
+        params: video::virtio_video_params,
+    ) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        let queue_type = v4l2r::QueueType::from_value(params.queue_type.into()).unwrap();
+        let mut format = v4l2r::Format {
+            width: params.frame_width.into(),
+            height: params.frame_heigth.into(),
+            pixelformat: PixelFormat::from(<Le32 as Into<u32>>::into(params.format)),
+            ..Default::default()
+        };
+        for plane_fmt in params.plane_formats {
+            format.plane_fmt.push(PlaneLayout {
+                sizeimage: plane_fmt.plane_size.into(),
+                bytesperline: plane_fmt.stride.into(),
+            })
+        }
+        if let Err(e) = v4l2r::ioctl::s_fmt::<_, v4l2r::Format>(stream, (queue_type, &format)) {
+            warn!("s_fmt failed: {}", e);
+            return Sync(video::CmdResponse::Error(InvalidParameter));
+        };
+
+        /*if queue_type.direction() == v4l2r::QueueDirection::Capture {
+            todo!("compose on CAPTURE");
+        }*/
+
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn create_resource(
+        &mut self,
+        stream_id: u32,
+        resource_id: u32,
+        planes_layout: u32,
+        planes: Vec<stream::ResourcePlane>,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        if stream.find_resource(resource_id, queue_type).is_some() {
+            return Sync(video::CmdResponse::Error(InvalidResourceId));
+        }
+        if planes_layout == video::VIRTIO_VIDEO_PLANES_LAYOUT_SINGLE_BUFFER {
+            stream.add_resource(resource_id, planes_layout, planes, queue_type);
+        } else {
+            todo!();
+        }
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn destroy_resources(
+        &mut self,
+        stream_id: u32,
+        queue_type: video::QueueType,
+    ) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        let memory_type = stream.memory(queue_type);
+        let memory = v4l2r::memory::MemoryType::n(memory_type.to_v4l2()).unwrap();
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        if let Err(e) = v4l2r::ioctl::reqbufs::<()>(stream, queue, memory, 0) {
+            warn!("reqbufs failed: {}", e);
+        }
+        stream.empty_resources(queue_type);
+
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn drain_stream(&mut self, stream_id: u32) -> video::CmdResponseType {
+        let stream = match self.streams.get_mut(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return Sync(video::CmdResponse::Error(InvalidStreamId));
+            }
+        };
+        if let Err(e) =
+            v4l2r::ioctl::decoder_cmd::<_, ()>(stream, v4l2r::ioctl::DecoderCommand::Stop)
+        {
+            warn!("decoder_cmd failed: {}", e);
+            return Sync(video::CmdResponse::Error(InvalidParameter));
+        }
+        stream.set_state(stream::StreamState::Draining);
+        Sync(video::CmdResponse::OkNoData)
+    }
+
+    fn dequeue_event(&self, stream_id: u32) -> Option<video::virtio_video_event> {
+        let stream = match self.streams.get(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return None;
+            }
+        };
+        let event = match v4l2r::ioctl::dqevent(stream) {
+            Ok(event) => event,
+            Err(e) => {
+                warn!("dqevent failed: {}", e);
+                return Some(video::virtio_video_event {
+                    event_type: video::VirtioVideoEventType::Error.into(),
+                    stream_id: stream_id.into(),
+                });
+            }
+        };
+
+        match event {
+            v4l2r::ioctl::Event::SrcChangeEvent(changes) => {
+                debug!("Source change event: {:?}", changes);
+                Some(video::virtio_video_event {
+                    event_type: video::VirtioVideoEventType::DecoderResolutionChanged.into(),
+                    stream_id: stream_id.into(),
+                })
+            }
+            v4l2r::ioctl::Event::Eos => {
+                debug!("Received EOS event");
+                None
+            }
+        }
+    }
+
+    fn dequeue_resource(&self, stream_id: u32, queue_type: video::QueueType) -> Option<DqBufData> {
+        let stream = match self.streams.get(&stream_id) {
+            Some(stream) => stream,
+            None => {
+                return None;
+            }
+        };
+        let queue = v4l2r::QueueType::from_value(queue_type as u32).unwrap();
+        let v4l2_buffer = match v4l2r::ioctl::dqbuf::<v4l2r::ioctl::V4l2Buffer>(stream, queue) {
+            Ok(buffer) => buffer,
+            Err(e) => {
+                warn!("dqbuf failed: {}", e);
+                return None;
+            }
+        };
+        Some(DqBufData {
+            index: v4l2_buffer.index(),
+            flags: video::BufferFlags::from(v4l2_buffer.flags().to_virtio()),
+            size: v4l2_buffer.get_first_plane().bytesused(),
+        })
+    }
+}
+
+impl V4L2Decoder {
+    pub fn new(video_path: &Path) -> io::Result<Self> {
+        Ok(Self {
+            streams: HashMap::new(),
+            video_device: FilePath::new(video_path)?,
+        })
+    }
+
+    fn video_enum_frame_sizes(&self, pixformat: u32) -> Vec<video::virtio_video_format_frame> {
+        let mut index: u32 = 0;
+        let mut frames: Vec<video::virtio_video_format_frame> = Vec::new();
+        loop {
+            let pixelformat: PixelFormat = PixelFormat::from(pixformat);
+            let frame: v4l2_frmsizeenum =
+                match v4l2r::ioctl::enum_frame_sizes(&self.video_device, index, pixelformat) {
+                    Ok(frmsizeenum) => frmsizeenum,
+                    Err(e) => {
+                        warn!("enum_frame_sizes failed: {}", e);
+                        break;
+                    }
+                };
+            if index != frame.index {
+                warn!("driver returned wrong frame index: {}", frame.index);
+            }
+            if pixformat != frame.pixel_format {
+                warn!(
+                    "driver returned wrong frame pixel format: {:#x}",
+                    frame.pixel_format
+                );
+            }
+
+            let mut format_frame: video::virtio_video_format_frame = frame.into();
+            match frame.size() {
+                Some(v4l2r::ioctl::FrmSizeTypes::Discrete(size)) => format_frame
+                    .append_frame_rates(&mut self.video_enum_frame_intervals(
+                        pixformat,
+                        size.width,
+                        size.height,
+                    )),
+                Some(v4l2r::ioctl::FrmSizeTypes::StepWise(size)) => {
+                    if frame.type_
+                        == v4l2r::bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_CONTINUOUS
+                        && format_frame.width.step != 1
+                        && format_frame.length.step != 1
+                    {
+                        warn!("invalid step for continious framesize");
+                        break;
+                    }
+
+                    format_frame.append_frame_rates(&mut self.video_enum_frame_intervals(
+                        pixformat,
+                        size.max_width,
+                        size.max_height,
+                    ));
+                }
+                None => {
+                    warn!("Unexpected frame type: {}", frame.type_);
+                    break;
+                }
+            }
+            frames.push(format_frame);
+            index += 1;
+        }
+
+        frames
+    }
+
+    fn video_enum_frame_intervals(
+        &self,
+        pixformat: u32,
+        width: u32,
+        height: u32,
+    ) -> Vec<video::virtio_video_format_range> {
+        let mut index: u32 = 0;
+        let mut frame_rates: Vec<video::virtio_video_format_range> = Vec::new();
+        loop {
+            let pixelformat = PixelFormat::from(pixformat);
+            let ival: v4l2_frmivalenum = match v4l2r::ioctl::enum_frame_intervals(
+                &self.video_device,
+                index,
+                pixelformat,
+                width,
+                height,
+            ) {
+                Ok(frmivalenum) => frmivalenum,
+                Err(e) => {
+                    warn!("enum_frame_intervals failed! {}", e);
+                    break;
+                }
+            };
+
+            if index != ival.index {
+                warn!("driver returned wrong ival index: {}", ival.index);
+            }
+            if pixformat != ival.pixel_format {
+                warn!(
+                    "driver returned wrong ival pixel format: {:#x}",
+                    ival.pixel_format
+                );
+            }
+            if width != ival.width {
+                warn!("driver returned wrong ival width: {}", ival.width);
+            }
+            if height != ival.height {
+                warn!("driver returned wrong ival heigth: {}", ival.height);
+            }
+
+            frame_rates.push(video::virtio_video_format_range::from(ival));
+            index += 1;
+        }
+
+        frame_rates
+    }
+
+    fn get_selection<T: AsRawFd>(fd: &T, queue_type: v4l2r::QueueType) -> Option<v4l2_rect> {
+        let sel_type: v4l2r::ioctl::SelectionType = match queue_type {
+            v4l2r::QueueType::VideoCaptureMplane => v4l2r::ioctl::SelectionType::Capture,
+            v4l2r::QueueType::VideoOutputMplane => v4l2r::ioctl::SelectionType::Output,
+            _ => return None,
+        };
+        let sel_target: v4l2r::ioctl::SelectionTarget =
+            if queue_type.direction() == v4l2r::QueueDirection::Capture {
+                v4l2r::ioctl::SelectionTarget::Compose
+            } else {
+                v4l2r::ioctl::SelectionTarget::Crop
+            };
+
+        match v4l2r::ioctl::g_selection(fd, sel_type, sel_target) {
+            Ok(rect) => Some(rect),
+            Err(e) => {
+                warn!("g_selection failed: {}", e);
+                None
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary of the PR

This PR adds an experimental virtio-video vhost-user backend, that support v4l2 decoding.

### Comments

The virtio specification concerning virtio-video is still being discussed. As such, this device should be considered as `experimental`. It is based in the [v3](http://archive.lwn.net:8080/linux-media/6557912.4vTCxPXJkl@os-lin-dmo/T/) patch of the specification, as it has its driver working, and even included in some
out-of-tree kernels (e.g. [chromeos](https://chromium.googlesource.com/chromiumos/third_party/kernel/+/refs/heads/chromeos-5.4/drivers/media/virtio/) and [AAOS](https://github.com/OpenSynergy/android-kernel-common/tree/opsy/android11-5.4-trout/drivers/media/virtio)). This version of the specification patch was also used for the experimental support of virtio-video in [crosvm](https://crosvm.dev/book/devices/video.html).

In that sense, I have these branches available to be able to test the device using Qemu:

The driver is available at
https://github.com/aesteve-rh/linux

And the Qemu backend device is available at
https://github.com/aesteve-rh/qemu/tree/virtio-video-v3

The plan in the long term is to update this crate to follow virtio specification once it gets agreed on and published, at which point it will lose its `experimental` status. In the meantime this can be used as PoC, add encoder support, or be used as a basis for verifying a later revision of the specs and help to get them merged.

Related: https://github.com/rust-vmm/vhost-device/issues/364

### Requirements

These items may not be covered by the patch, I'll address (and mark) them ASAP.

- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
