### PR TITLE
vsock: Use PathBuf for socket paths instead of Strings

### DIFF
--- a/vhost-device-gpio/src/backend.rs
+++ b/vhost-device-gpio/src/backend.rs
@@ -7,6 +7,7 @@
 
 use log::error;
 use std::num::ParseIntError;
+use std::path::PathBuf;
 use std::process::exit;
 use std::sync::{Arc, RwLock};
 use std::thread::{spawn, JoinHandle};
@@ -58,7 +59,7 @@ Example, \"-c 4 -l 3:s4:6:s1\"\n";
 struct GpioArgs {
     /// Location of vhost-user Unix domain socket. This is suffixed by 0,1,2..socket_count-1.
     #[clap(short, long)]
-    socket_path: String,
+    socket_path: PathBuf,
 
     /// Number of guests (sockets) to connect to.
     #[clap(short = 'c', long, default_value_t = 1)]
@@ -143,7 +144,7 @@ impl TryFrom<&str> for DeviceConfig {
 
 #[derive(PartialEq, Debug)]
 struct GpioConfiguration {
-    socket_path: String,
+    socket_path: PathBuf,
     socket_count: usize,
     devices: DeviceConfig,
 }
@@ -173,7 +174,7 @@ impl TryFrom<GpioArgs> for GpioConfiguration {
     }
 }
 
-fn start_device_backend<D: GpioDevice>(device: D, socket: String) -> Result<()> {
+fn start_device_backend<D: GpioDevice>(device: D, socket: PathBuf) -> Result<()> {
     let controller = GpioController::new(device).map_err(Error::CouldNotCreateGpioController)?;
     let backend = Arc::new(RwLock::new(
         VhostUserGpioBackend::new(controller).map_err(Error::CouldNotCreateBackend)?,
@@ -196,7 +197,7 @@ fn start_backend(args: GpioArgs) -> Result<()> {
     let mut handles = Vec::new();
 
     for i in 0..config.socket_count {
-        let socket = config.socket_path.to_owned() + &i.to_string();
+        let socket = config.socket_path.join(i.to_string());
         let cfg = config.devices.inner[i];
 
         let handle: JoinHandle<Result<()>> = spawn(move || loop {
@@ -258,9 +259,9 @@ mod tests {
         }
     }
 
-    fn get_cmd_args(path: &str, devices: &str, count: usize) -> GpioArgs {
+    fn get_cmd_args(path: PathBuf, devices: &str, count: usize) -> GpioArgs {
         GpioArgs {
-            socket_path: path.to_string(),
+            socket_path: path,
             socket_count: count,
             device_list: devices.to_string(),
         }
@@ -287,31 +288,31 @@ mod tests {
 
     #[test]
     fn test_gpio_parse_failure() {
-        let socket_name = "vgpio.sock";
+        let socket_name = PathBuf::from("vgpio.sock");
 
         // Invalid device number
-        let cmd_args = get_cmd_args(socket_name, "1:4d:5", 3);
+        let cmd_args = get_cmd_args(socket_name.clone(), "1:4d:5", 3);
         assert_matches!(
             GpioConfiguration::try_from(cmd_args).unwrap_err(),
             Error::ParseFailure(e) if e == "4d".parse::<u32>().unwrap_err()
         );
 
         // Zero socket count
-        let cmd_args = get_cmd_args(socket_name, "1:4", 0);
+        let cmd_args = get_cmd_args(socket_name.clone(), "1:4", 0);
         assert_matches!(
             GpioConfiguration::try_from(cmd_args).unwrap_err(),
             Error::SocketCountInvalid(0)
         );
 
         // Duplicate client address: 4
-        let cmd_args = get_cmd_args(socket_name, "1:4:5:6:4", 5);
+        let cmd_args = get_cmd_args(socket_name.clone(), "1:4:5:6:4", 5);
         assert_matches!(
             GpioConfiguration::try_from(cmd_args).unwrap_err(),
             Error::DeviceDuplicate(4)
         );
 
         // Device count mismatch
-        let cmd_args = get_cmd_args(socket_name, "1:4:5:6", 5);
+        let cmd_args = get_cmd_args(socket_name.clone(), "1:4:5:6", 5);
         assert_matches!(
             GpioConfiguration::try_from(cmd_args).unwrap_err(),
             Error::DeviceCountMismatch(5, 4)
@@ -324,16 +325,16 @@ mod tests {
 
     #[test]
     fn test_gpio_parse_successful() {
-        let socket_name = "vgpio.sock";
+        let socket_name = PathBuf::from("vgpio.sock");
 
         // Match expected and actual configuration
-        let cmd_args = get_cmd_args(socket_name, "1:4:32:21:5", 5);
+        let cmd_args = get_cmd_args(socket_name.clone(), "1:4:32:21:5", 5);
         let config = GpioConfiguration::try_from(cmd_args).unwrap();
 
         let expected_devices = DeviceConfig::new_with(vec![1, 4, 32, 21, 5]);
         let expected_config = GpioConfiguration {
             socket_count: 5,
-            socket_path: String::from(socket_name),
+            socket_path: socket_name,
             devices: expected_devices,
         };
 
@@ -342,8 +343,9 @@ mod tests {
 
     #[test]
     fn test_gpio_fail_listener_mock() {
-        let socket_name = "~/path/not/present/gpio";
-        let cmd_args = get_cmd_args(socket_name, "s1:s4:s3:s5", 4);
+        // This will fail the listeners and thread will panic.
+        let socket_name = PathBuf::from("~/path/not/present/gpio");
+        let cmd_args = get_cmd_args(socket_name, "1:4:3:5", 4);
 
         assert_matches!(start_backend(cmd_args).unwrap_err(), Error::ServeFailed(_));
     }

--- a/vhost-device-rng/src/main.rs
+++ b/vhost-device-rng/src/main.rs
@@ -195,8 +195,8 @@ mod tests {
             period: VHU_RNG_MAX_PERIOD_MS,
             max_bytes: usize::MAX,
             socket_count: 1,
-            socket_path: "/some/socket_path".into(),
-            rng_source: "/dev/urandom".into(),
+            socket_path: PathBuf::from("/some/socket_path"),
+            rng_source: PathBuf::from("/dev/urandom"),
         };
 
         // All configuration elements should be what we expect them to be.
@@ -248,14 +248,14 @@ mod tests {
     fn verify_start_backend() {
         let dir = tempdir().unwrap();
         let random_path = dir.path().join("urandom");
-        let _random_file = File::create(random_path.clone());
+        let _random_file = File::create(&random_path);
 
         let mut config = VuRngConfig {
             period_ms: 1000,
             max_bytes: 512,
             count: 1,
-            socket_path: "/invalid/path".into(),
-            rng_source: "/invalid/path".into(),
+            socket_path: PathBuf::from("/invalid/path"),
+            rng_source: PathBuf::from("/invalid/path"),
         };
 
         // An invalid RNG source file should trigger an AccessRngSourceFile error.

--- a/vhost-device-scmi/src/main.rs
+++ b/vhost-device-scmi/src/main.rs
@@ -165,13 +165,14 @@ mod tests {
 
     #[test]
     fn test_command_line() {
-        let path = "/foo/scmi.sock".to_owned();
+        let path = PathBuf::from("/foo/scmi.sock");
         let params_string = format!(
             "binary \
                      --device dummy \
-                     -s {path} \
+                     -s {} \
                      --device fake,name=foo,prop=value \
-                     -d fake,name=bar"
+                     -d fake,name=bar",
+            path.display()
         );
         let params: Vec<&str> = params_string.split_whitespace().collect();
         let args: ScmiArgs = Parser::parse_from(params);

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -442,6 +442,8 @@ impl VhostUserBackendMut for VuScmiBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
     use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
@@ -587,7 +589,7 @@ mod tests {
 
     fn make_backend() -> VuScmiBackend {
         let config = VuScmiConfig {
-            socket_path: "/foo/scmi.sock".into(),
+            socket_path: PathBuf::from("/foo/scmi.sock"),
             devices: vec![],
         };
         VuScmiBackend::new(&config).unwrap()

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -726,7 +726,7 @@ mod tests {
     #[test]
     fn test_sound_thread_success() {
         crate::init_logger();
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(SOCKET_PATH.into(), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -821,7 +821,7 @@ mod tests {
     #[test]
     fn test_sound_thread_failure() {
         crate::init_logger();
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(SOCKET_PATH.into(), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -902,7 +902,7 @@ mod tests {
     fn test_sound_backend() {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
-        let socket_path = test_dir.path().join(SOCKET_PATH).display().to_string();
+        let socket_path = test_dir.path().join(SOCKET_PATH);
         let config = SoundConfig::new(socket_path, false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config).expect("Could not create backend.");
 
@@ -980,11 +980,7 @@ mod tests {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
 
-        let socket_path = test_dir
-            .path()
-            .join("sound_failures.socket")
-            .display()
-            .to_string();
+        let socket_path = test_dir.path().join("sound_failures.socket");
         let config = SoundConfig::new(socket_path, false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config);
 

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -46,6 +46,7 @@ use std::{
     convert::TryFrom,
     io::{Error as IoError, ErrorKind},
     mem::size_of,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -255,7 +256,7 @@ impl TryFrom<Le32> for ControlMessageKind {
 /// is allowed to configure the backend.
 pub struct SoundConfig {
     /// vhost-user Unix domain socket
-    socket: String,
+    socket: PathBuf,
     /// use multiple threads to hanlde the virtqueues
     multi_thread: bool,
     /// audio backend variant
@@ -265,7 +266,7 @@ pub struct SoundConfig {
 impl SoundConfig {
     /// Create a new instance of the SoundConfig struct, containing the
     /// parameters to be fed into the sound-backend server.
-    pub const fn new(socket: String, multi_thread: bool, audio_backend: BackendType) -> Self {
+    pub const fn new(socket: PathBuf, multi_thread: bool, audio_backend: BackendType) -> Self {
         Self {
             socket,
             multi_thread,
@@ -275,8 +276,8 @@ impl SoundConfig {
 
     /// Return the path of the unix domain socket which is listening to
     /// requests from the guest.
-    pub fn get_socket_path(&self) -> String {
-        String::from(&self.socket)
+    pub fn get_socket_path(&self) -> &Path {
+        self.socket.as_path()
     }
 
     pub const fn get_audio_backend(&self) -> BackendType {
@@ -344,7 +345,7 @@ impl Drop for IOMessage {
 /// vhost-device-sound backend server.
 pub fn start_backend_server(config: SoundConfig) {
     log::trace!("Using config {:?}.", &config);
-    let socket = config.get_socket_path();
+    let socket = config.get_socket_path().to_path_buf();
     let backend = Arc::new(VhostUserSoundBackend::new(config).unwrap());
 
     let mut daemon = VhostUserDaemon::new(
@@ -372,7 +373,7 @@ mod tests {
         const SOCKET_PATH: &str = "vsound.socket";
         crate::init_logger();
 
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(SOCKET_PATH.into(), false, BackendType::Null);
 
         let backend = Arc::new(VhostUserSoundBackend::new(config).unwrap());
         let daemon = VhostUserDaemon::new(

--- a/vhost-device-sound/src/main.rs
+++ b/vhost-device-sound/src/main.rs
@@ -1,7 +1,7 @@
 // Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
 // Stefano Garzarella <sgarzare@redhat.com>
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
-use std::convert::TryFrom;
+use std::{convert::TryFrom, path::PathBuf};
 
 use clap::Parser;
 use vhost_device_sound::{start_backend_server, BackendType, Error, Result, SoundConfig};
@@ -11,7 +11,7 @@ use vhost_device_sound::{start_backend_server, BackendType, Error, Result, Sound
 struct SoundArgs {
     /// vhost-user Unix domain socket path.
     #[clap(long)]
-    socket: String,
+    socket: PathBuf,
     /// audio backend to be used
     #[clap(long)]
     #[clap(value_enum)]
@@ -22,9 +22,7 @@ impl TryFrom<SoundArgs> for SoundConfig {
     type Error = Error;
 
     fn try_from(cmd_args: SoundArgs) -> Result<Self> {
-        let socket = cmd_args.socket.trim().to_string();
-
-        Ok(SoundConfig::new(socket, false, cmd_args.backend))
+        Ok(SoundConfig::new(cmd_args.socket, false, cmd_args.backend))
     }
 }
 
@@ -45,9 +43,9 @@ mod tests {
     use super::*;
 
     impl SoundArgs {
-        fn from_args(socket: &str) -> Self {
+        fn from_args(socket: PathBuf) -> Self {
             SoundArgs {
-                socket: socket.to_string(),
+                socket,
                 backend: BackendType::default(),
             }
         }
@@ -61,13 +59,16 @@ mod tests {
     #[test]
     fn test_sound_config_setup() {
         init_logger();
-        let args = SoundArgs::from_args("/tmp/vhost-sound.socket");
+        let args = SoundArgs::from_args(PathBuf::from("/tmp/vhost-sound.socket"));
 
         let config = SoundConfig::try_from(args);
         assert!(config.is_ok());
 
         let config = config.unwrap();
-        assert_eq!(config.get_socket_path(), "/tmp/vhost-sound.socket");
+        assert_eq!(
+            config.get_socket_path(),
+            PathBuf::from("/tmp/vhost-sound.socket")
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
### Summary of the PR

For reasons I ignore, String was used all over the place where a PathBuf makes more sense.

cc @Ablu, similar to yesterday's discussion regarding vhost-video 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
