### PR TITLE
dependabot: enable update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 3
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  groups:
+      vhost-device:
+        patterns:
+          - "*"
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
This should group updates into a single PR. Hopefully, that simplfies updates.

Updates that do _actually_ require code changes, will need a separate PR anyway, after which dependabot can be asked to rebase/recreate.

Suggested-by: Patrick Roy <roypat@amazon.co.uk>
Suggested-by: Stefano Garzarella <sgarzare@redhat.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
