### PR TITLE
staging: add custom pipelines to run CI tests

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -1,0 +1,81 @@
+{
+  "tests": [
+    {
+      "test_name": "staging: build-gnu",
+      "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo build --release",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: build-musl",
+      "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: style",
+      "command": "cd staging && cargo fmt --all -- --check --config format_code_in_doc_comments=true"
+    },
+    {
+      "test_name": "staging: unittests-gnu",
+      "command": "cd staging && cargo test --all-features --workspace",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: unittests-musl",
+      "command": "cd staging && cargo test --all-features --workspace --target {target_platform}-unknown-linux-musl",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: clippy",
+      "command": "cd staging && cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: check-warnings",
+      "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo check --all-targets --all-features --workspace",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "staging: coverage",
+      "command": "cd staging && pytest $(find .. -type f -name \"test_coverage.py\")",
+      "soft_fail": "true",
+      "docker_plugin": {
+        "privileged": true
+      },
+      "platform": [
+        "x86_64"
+      ]
+    },
+    {
+      "test_name": "staging: cargo-audit",
+      "command": "cd staging && cargo audit -q --deny warnings",
+      "soft_fail": "true",
+      "platform": [
+        "x86_64"
+      ]
+    }
+  ]
+}

--- a/staging/coverage_config_x86_64.json
+++ b/staging/coverage_config_x86_64.json
@@ -1,0 +1,5 @@
+{
+  "coverage_score": 7.94,
+  "exclude_path": "",
+  "crate_features": ""
+}


### PR DESCRIPTION
### Summary of the PR

Let's use custom pipelines to run CI tests in the nested worskpace.
    
We have included all the tests we usually run in the main workspace (rust-vmm-ci/.buildkite/test_description.json), except for "commit-format" which also covers commits for staging crates.
    
Let's add a `staging\coverage_config_x86_64.json` for testing coverage of crates in staging.
    
All staging tests have `soft_fail = true` to prevent failures in staging from affecting the CI of the main workspace.

Closes #478

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
