### PR TITLE
sound/alsa: stop actual playback after PCM_STOP

### DIFF
--- a/staging/vhost-device-sound/CHANGELOG.md
+++ b/staging/vhost-device-sound/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Upcoming Release
 
 - First initial daemon implementation.
+- Fixed stale buffer reading

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -425,15 +425,13 @@ impl AlsaBackend {
                         msg.code = VIRTIO_SND_S_BAD_MSG;
                         continue;
                     };
-                    let release_result = streams.write().unwrap()[stream_id].state.release();
-                    if let Err(err) = release_result {
+                    if let Err(err) = streams.write().unwrap()[stream_id].state.release() {
                         log::error!("Stream {} release {}", stream_id, err);
                         msg.code = VIRTIO_SND_S_BAD_MSG;
-                    } else {
-                        senders[stream_id].send(false).unwrap();
-                        let mut streams = streams.write().unwrap();
-                        std::mem::take(&mut streams[stream_id].buffers);
                     }
+                    senders[stream_id].send(false).unwrap();
+                    let mut streams = streams.write().unwrap();
+                    std::mem::take(&mut streams[stream_id].buffers);
                 }
                 AlsaAction::SetParameters(stream_id, mut msg) => {
                     if stream_id >= streams_no {

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -145,17 +145,13 @@ fn write_samples_direct(
         let Some(buffer) = stream.buffers.front_mut() else {
             return Ok(false);
         };
-        let mut buf = vec![0; buffer.data_descriptor.len() as usize];
-        let read_bytes = buffer
-            .consume(&mut buf)
-            .expect("failed to read buffer from guest");
-        let mut iter = buf[0..read_bytes as usize].iter().cloned();
+        let mut iter = buffer.bytes[buffer.pos..].iter().cloned();
         let frames = mmap.write(&mut iter);
         let written_bytes = pcm.frames_to_bytes(frames);
         if let Ok(written_bytes) = usize::try_from(written_bytes) {
             buffer.pos += written_bytes;
         }
-        if buffer.pos >= buffer.data_descriptor.len() as usize {
+        if buffer.pos >= buffer.bytes.len() {
             stream.buffers.pop_front();
         }
     }
@@ -195,14 +191,7 @@ fn write_samples_io(
             let Some(buffer) = stream.buffers.front_mut() else {
                 return 0;
             };
-            let mut data = vec![0; buffer.data_descriptor.len() as usize];
-
-            // consume() always reads (buffer.data_descriptor.len() -
-            // buffer.pos) bytes
-            let read_bytes = buffer
-                .consume(&mut data)
-                .expect("failed to read buffer from guest");
-            let mut iter = data[0..read_bytes as usize].iter().cloned();
+            let mut iter = buffer.bytes[buffer.pos..].iter().cloned();
 
             let mut written_bytes = 0;
             for (sample, byte) in buf.iter_mut().zip(&mut iter) {
@@ -210,7 +199,7 @@ fn write_samples_io(
                 written_bytes += 1;
             }
             buffer.pos += written_bytes as usize;
-            if buffer.pos >= buffer.data_descriptor.len() as usize {
+            if buffer.pos >= buffer.bytes.len() {
                 stream.buffers.pop_front();
             }
             p.bytes_to_frames(written_bytes)
@@ -364,16 +353,17 @@ impl AlsaBackend {
                         );
                         continue;
                     };
-
-                    let start_result = streams.write().unwrap()[stream_id].state.start();
-                    if let Err(err) = start_result {
-                        log::error!("Stream {} start {}", stream_id, err);
-                    } else {
-                        let pcm = &pcms[stream_id];
-                        let lck = pcm.lock().unwrap();
-                        match lck.state() {
-                            State::Running => {}
-                            _ => lck.start()?,
+                    streams.write().unwrap()[stream_id].state.start();
+                    let pcm = &pcms[stream_id];
+                    let lck = pcm.lock().unwrap();
+                    if !matches!(lck.state(), State::Running) {
+                        // Fail gracefully if Start does not succeed.
+                        if let Err(err) = lck.start() {
+                            log::error!(
+                                "Could not start stream {}; ALSA returned: {}",
+                                stream_id,
+                                err
+                            );
                         }
                     }
                 }
@@ -387,10 +377,7 @@ impl AlsaBackend {
                         );
                         continue;
                     };
-                    let stop_result = streams.write().unwrap()[stream_id].state.stop();
-                    if let Err(err) = stop_result {
-                        log::error!("Stream {} stop {}", stream_id, err);
-                    }
+                    streams.write().unwrap()[stream_id].state.stop();
                 }
                 AlsaAction::Prepare(stream_id) => {
                     if stream_id >= streams_no {
@@ -402,15 +389,17 @@ impl AlsaBackend {
                         );
                         continue;
                     };
-                    let prepare_result = streams.write().unwrap()[stream_id].state.prepare();
-                    if let Err(err) = prepare_result {
-                        log::error!("Stream {} prepare {}", stream_id, err);
-                    } else {
-                        let pcm = &pcms[stream_id];
-                        let lck = pcm.lock().unwrap();
-                        match lck.state() {
-                            State::Running => {}
-                            _ => lck.prepare()?,
+                    streams.write().unwrap()[stream_id].state.prepare();
+                    let pcm = &pcms[stream_id];
+                    let lck = pcm.lock().unwrap();
+                    if !matches!(lck.state(), State::Running) {
+                        // Fail gracefully if Prepare does not succeed.
+                        if let Err(err) = lck.prepare() {
+                            log::error!(
+                                "Could not prepare stream {}; ALSA returned: {}",
+                                stream_id,
+                                err
+                            );
                         }
                     }
                 }
@@ -425,13 +414,10 @@ impl AlsaBackend {
                         msg.code = VIRTIO_SND_S_BAD_MSG;
                         continue;
                     };
-                    if let Err(err) = streams.write().unwrap()[stream_id].state.release() {
-                        log::error!("Stream {} release {}", stream_id, err);
-                        msg.code = VIRTIO_SND_S_BAD_MSG;
-                    }
                     senders[stream_id].send(false).unwrap();
-                    let mut streams = streams.write().unwrap();
-                    std::mem::take(&mut streams[stream_id].buffers);
+                    let mut streams_lck = streams.write().unwrap();
+                    streams_lck[stream_id].state.release();
+                    std::mem::take(&mut streams_lck[stream_id].buffers);
                 }
                 AlsaAction::SetParameters(stream_id, mut msg) => {
                     if stream_id >= streams_no {
@@ -454,14 +440,10 @@ impl AlsaBackend {
                     {
                         let mut streams = streams.write().unwrap();
                         let st = &mut streams[stream_id];
-                        if let Err(err) = st.state.set_parameters() {
-                            log::error!("Stream {} set_parameters {}", stream_id, err);
-                            msg.code = VIRTIO_SND_S_BAD_MSG;
-                            continue;
-                        } else if !st.supports_format(request.format)
-                            || !st.supports_rate(request.rate)
-                        {
+                        st.state.set_parameters();
+                        if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
                             msg.code = VIRTIO_SND_S_NOT_SUPP;
+                            // Drop `msg` and skip `update_pcm`
                             continue;
                         } else {
                             st.params.buffer_bytes = request.buffer_bytes;

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -49,7 +49,7 @@ use crate::{
         VIRTIO_SND_PCM_RATE_32000, VIRTIO_SND_PCM_RATE_384000, VIRTIO_SND_PCM_RATE_44100,
         VIRTIO_SND_PCM_RATE_48000, VIRTIO_SND_PCM_RATE_5512, VIRTIO_SND_PCM_RATE_64000,
         VIRTIO_SND_PCM_RATE_8000, VIRTIO_SND_PCM_RATE_88200, VIRTIO_SND_PCM_RATE_96000,
-        VIRTIO_SND_S_BAD_MSG, VIRTIO_SND_S_NOT_SUPP,
+        VIRTIO_SND_S_NOT_SUPP,
     },
     Error, Result, Stream,
 };
@@ -140,10 +140,8 @@ impl AudioBackend for PwBackend {
             let st = stream_params
                 .get_mut(stream_id as usize)
                 .expect("Stream does not exist");
-            if let Err(err) = st.state.set_parameters() {
-                log::error!("Stream {} set_parameters {}", stream_id, err);
-                msg.code = VIRTIO_SND_S_BAD_MSG;
-            } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
+            st.state.set_parameters();
+            if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
                 msg.code = VIRTIO_SND_S_NOT_SUPP;
             } else {
                 st.params.features = request.features;
@@ -161,305 +159,279 @@ impl AudioBackend for PwBackend {
 
     fn prepare(&self, stream_id: u32) -> Result<()> {
         debug!("pipewire prepare");
-        let prepare_result = self.stream_params.write().unwrap()[stream_id as usize]
+        self.stream_params.write().unwrap()[stream_id as usize]
             .state
             .prepare();
-        if let Err(err) = prepare_result {
-            log::error!("Stream {} prepare {}", stream_id, err);
-        } else {
-            let mut stream_hash = self.stream_hash.write().unwrap();
-            let mut stream_listener = self.stream_listener.write().unwrap();
-            let lock_guard = self.thread_loop.lock();
-            let stream_params = self.stream_params.read().unwrap();
+        let mut stream_hash = self.stream_hash.write().unwrap();
+        let mut stream_listener = self.stream_listener.write().unwrap();
+        let lock_guard = self.thread_loop.lock();
+        let stream_params = self.stream_params.read().unwrap();
+        let params = &stream_params[stream_id as usize].params;
 
-            let params = &stream_params[stream_id as usize].params;
+        let mut pos: [u32; 64] = [SPA_AUDIO_CHANNEL_UNKNOWN; 64];
 
-            let mut pos: [u32; 64] = [SPA_AUDIO_CHANNEL_UNKNOWN; 64];
-
-            match params.channels {
-                6 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_FL;
-                    pos[1] = SPA_AUDIO_CHANNEL_FR;
-                    pos[2] = SPA_AUDIO_CHANNEL_FC;
-                    pos[3] = SPA_AUDIO_CHANNEL_LFE;
-                    pos[4] = SPA_AUDIO_CHANNEL_RL;
-                    pos[5] = SPA_AUDIO_CHANNEL_RR;
-                }
-                5 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_FL;
-                    pos[1] = SPA_AUDIO_CHANNEL_FR;
-                    pos[2] = SPA_AUDIO_CHANNEL_FC;
-                    pos[3] = SPA_AUDIO_CHANNEL_LFE;
-                    pos[4] = SPA_AUDIO_CHANNEL_RC;
-                }
-                4 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_FL;
-                    pos[1] = SPA_AUDIO_CHANNEL_FR;
-                    pos[2] = SPA_AUDIO_CHANNEL_FC;
-                    pos[3] = SPA_AUDIO_CHANNEL_RC;
-                }
-                3 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_FL;
-                    pos[1] = SPA_AUDIO_CHANNEL_FR;
-                    pos[2] = SPA_AUDIO_CHANNEL_LFE;
-                }
-                2 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_FL;
-                    pos[1] = SPA_AUDIO_CHANNEL_FR;
-                }
-                1 => {
-                    pos[0] = SPA_AUDIO_CHANNEL_MONO;
-                }
-                _ => {
-                    return Err(Error::ChannelNotSupported(params.channels));
-                }
+        match params.channels {
+            6 => {
+                pos[0] = SPA_AUDIO_CHANNEL_FL;
+                pos[1] = SPA_AUDIO_CHANNEL_FR;
+                pos[2] = SPA_AUDIO_CHANNEL_FC;
+                pos[3] = SPA_AUDIO_CHANNEL_LFE;
+                pos[4] = SPA_AUDIO_CHANNEL_RL;
+                pos[5] = SPA_AUDIO_CHANNEL_RR;
             }
-
-            let info = spa_audio_info_raw {
-                format: match params.format {
-                    VIRTIO_SND_PCM_FMT_MU_LAW => SPA_AUDIO_FORMAT_ULAW,
-                    VIRTIO_SND_PCM_FMT_A_LAW => SPA_AUDIO_FORMAT_ALAW,
-                    VIRTIO_SND_PCM_FMT_S8 => SPA_AUDIO_FORMAT_S8,
-                    VIRTIO_SND_PCM_FMT_U8 => SPA_AUDIO_FORMAT_U8,
-                    VIRTIO_SND_PCM_FMT_S16 => SPA_AUDIO_FORMAT_S16,
-                    VIRTIO_SND_PCM_FMT_U16 => SPA_AUDIO_FORMAT_U16,
-                    VIRTIO_SND_PCM_FMT_S18_3 => SPA_AUDIO_FORMAT_S18_LE,
-                    VIRTIO_SND_PCM_FMT_U18_3 => SPA_AUDIO_FORMAT_U18_LE,
-                    VIRTIO_SND_PCM_FMT_S20_3 => SPA_AUDIO_FORMAT_S20_LE,
-                    VIRTIO_SND_PCM_FMT_U20_3 => SPA_AUDIO_FORMAT_U20_LE,
-                    VIRTIO_SND_PCM_FMT_S24_3 => SPA_AUDIO_FORMAT_S24_LE,
-                    VIRTIO_SND_PCM_FMT_U24_3 => SPA_AUDIO_FORMAT_U24_LE,
-                    VIRTIO_SND_PCM_FMT_S20 => SPA_AUDIO_FORMAT_S20,
-                    VIRTIO_SND_PCM_FMT_U20 => SPA_AUDIO_FORMAT_U20,
-                    VIRTIO_SND_PCM_FMT_S24 => SPA_AUDIO_FORMAT_S24,
-                    VIRTIO_SND_PCM_FMT_U24 => SPA_AUDIO_FORMAT_U24,
-                    VIRTIO_SND_PCM_FMT_S32 => SPA_AUDIO_FORMAT_S32,
-                    VIRTIO_SND_PCM_FMT_U32 => SPA_AUDIO_FORMAT_U32,
-                    VIRTIO_SND_PCM_FMT_FLOAT => SPA_AUDIO_FORMAT_F32,
-                    VIRTIO_SND_PCM_FMT_FLOAT64 => SPA_AUDIO_FORMAT_F64,
-                    _ => SPA_AUDIO_FORMAT_UNKNOWN,
-                },
-                rate: match params.rate {
-                    VIRTIO_SND_PCM_RATE_5512 => 5512,
-                    VIRTIO_SND_PCM_RATE_8000 => 8000,
-                    VIRTIO_SND_PCM_RATE_11025 => 11025,
-                    VIRTIO_SND_PCM_RATE_16000 => 16000,
-                    VIRTIO_SND_PCM_RATE_22050 => 22050,
-                    VIRTIO_SND_PCM_RATE_32000 => 32000,
-                    VIRTIO_SND_PCM_RATE_44100 => 44100,
-                    VIRTIO_SND_PCM_RATE_48000 => 48000,
-                    VIRTIO_SND_PCM_RATE_64000 => 64000,
-                    VIRTIO_SND_PCM_RATE_88200 => 88200,
-                    VIRTIO_SND_PCM_RATE_96000 => 96000,
-                    VIRTIO_SND_PCM_RATE_176400 => 176400,
-                    VIRTIO_SND_PCM_RATE_192000 => 192000,
-                    VIRTIO_SND_PCM_RATE_384000 => 384000,
-                    _ => 44100,
-                },
-                flags: 0,
-                channels: params.channels as u32,
-                position: pos,
-            };
-
-            let mut audio_info = AudioInfoRaw::new();
-            audio_info.set_format(AudioFormat::S16LE);
-            audio_info.set_rate(info.rate);
-            audio_info.set_channels(info.channels);
-
-            let values: Vec<u8> = PodSerializer::serialize(
-                std::io::Cursor::new(Vec::new()),
-                &Value::Object(Object {
-                    type_: SPA_TYPE_OBJECT_Format,
-                    id: SPA_PARAM_EnumFormat,
-                    properties: audio_info.into(),
-                }),
-            )
-            .unwrap()
-            .0
-            .into_inner();
-
-            let value_clone = values.clone();
-
-            let mut param = [Pod::from_bytes(&values).unwrap()];
-
-            let props = properties! {
-                *pw::keys::MEDIA_TYPE => "Audio",
-                *pw::keys::MEDIA_CATEGORY => "Playback",
-            };
-
-            let stream = pw::stream::Stream::new(&self.core, "audio-output", props)
-                .expect("could not create new stream");
-
-            let streams = self.stream_params.clone();
-
-            let listener_stream = stream
-                .add_local_listener()
-                .state_changed(|old, new| {
-                    debug!("State changed: {:?} -> {:?}", old, new);
-                })
-                .param_changed(move |stream, id, _data, param| {
-                    let Some(_param) = param else {
-                        return;
-                    };
-                    if id != ParamType::Format.as_raw() {
-                        return;
-                    }
-                    let mut param = [Pod::from_bytes(&value_clone).unwrap()];
-
-                    //callback to negotiate new set of streams
-                    stream
-                        .update_params(&mut param)
-                        .expect("could not update params");
-                })
-                .process(move |stream, _data| match stream.dequeue_buffer() {
-                    None => debug!("No buffer recieved"),
-                    Some(mut buf) => {
-                        let datas = buf.datas_mut();
-                        let frame_size = info.channels * size_of::<i16>() as u32;
-                        let data = &mut datas[0];
-                        let n_bytes = if let Some(slice) = data.data() {
-                            let mut n_bytes = slice.len();
-                            let mut streams = streams.write().unwrap();
-                            let streams = streams
-                                .get_mut(stream_id as usize)
-                                .expect("Stream does not exist");
-                            let Some(buffer) = streams.buffers.front_mut() else {
-                                return;
-                            };
-
-                            let mut start = buffer.pos;
-
-                            let avail = (buffer.data_descriptor.len() - start as u32) as i32;
-
-                            if avail < n_bytes as i32 {
-                                n_bytes = avail.try_into().unwrap();
-                            }
-                            let p = &mut slice[0..n_bytes];
-                            if avail <= 0 {
-                                // pad with silence
-                                unsafe {
-                                    ptr::write_bytes(p.as_mut_ptr(), 0, n_bytes);
-                                }
-                            } else {
-                                // consume() always reads (buffer.data_descriptor.len() -
-                                // buffer.pos) bytes
-                                buffer.consume(p).expect("failed to read buffer from guest");
-
-                                start += n_bytes;
-
-                                buffer.pos = start;
-
-                                if start >= buffer.data_descriptor.len() as usize {
-                                    streams.buffers.pop_front();
-                                }
-                            }
-                            n_bytes
-                        } else {
-                            0
-                        };
-                        let chunk = data.chunk_mut();
-                        *chunk.offset_mut() = 0;
-                        *chunk.stride_mut() = frame_size as _;
-                        *chunk.size_mut() = n_bytes as _;
-                    }
-                })
-                .register()
-                .expect("failed to register stream listener");
-
-            stream_listener.insert(stream_id, listener_stream);
-
-            let direction = match stream_params[stream_id as usize].direction {
-                VIRTIO_SND_D_OUTPUT => spa::Direction::Output,
-                VIRTIO_SND_D_INPUT => spa::Direction::Input,
-                _ => panic!("Invalid direction"),
-            };
-
-            stream
-                .connect(
-                    direction,
-                    Some(pw::constants::ID_ANY),
-                    pw::stream::StreamFlags::RT_PROCESS
-                        | pw::stream::StreamFlags::AUTOCONNECT
-                        | pw::stream::StreamFlags::INACTIVE
-                        | pw::stream::StreamFlags::MAP_BUFFERS,
-                    &mut param,
-                )
-                .expect("could not connect to the stream");
-
-            // insert created stream in a hash table
-            stream_hash.insert(stream_id, stream);
-
-            lock_guard.unlock();
+            5 => {
+                pos[0] = SPA_AUDIO_CHANNEL_FL;
+                pos[1] = SPA_AUDIO_CHANNEL_FR;
+                pos[2] = SPA_AUDIO_CHANNEL_FC;
+                pos[3] = SPA_AUDIO_CHANNEL_LFE;
+                pos[4] = SPA_AUDIO_CHANNEL_RC;
+            }
+            4 => {
+                pos[0] = SPA_AUDIO_CHANNEL_FL;
+                pos[1] = SPA_AUDIO_CHANNEL_FR;
+                pos[2] = SPA_AUDIO_CHANNEL_FC;
+                pos[3] = SPA_AUDIO_CHANNEL_RC;
+            }
+            3 => {
+                pos[0] = SPA_AUDIO_CHANNEL_FL;
+                pos[1] = SPA_AUDIO_CHANNEL_FR;
+                pos[2] = SPA_AUDIO_CHANNEL_LFE;
+            }
+            2 => {
+                pos[0] = SPA_AUDIO_CHANNEL_FL;
+                pos[1] = SPA_AUDIO_CHANNEL_FR;
+            }
+            1 => {
+                pos[0] = SPA_AUDIO_CHANNEL_MONO;
+            }
+            _ => {
+                return Err(Error::ChannelNotSupported(params.channels));
+            }
         }
 
+        let info = spa_audio_info_raw {
+            format: match params.format {
+                VIRTIO_SND_PCM_FMT_MU_LAW => SPA_AUDIO_FORMAT_ULAW,
+                VIRTIO_SND_PCM_FMT_A_LAW => SPA_AUDIO_FORMAT_ALAW,
+                VIRTIO_SND_PCM_FMT_S8 => SPA_AUDIO_FORMAT_S8,
+                VIRTIO_SND_PCM_FMT_U8 => SPA_AUDIO_FORMAT_U8,
+                VIRTIO_SND_PCM_FMT_S16 => SPA_AUDIO_FORMAT_S16,
+                VIRTIO_SND_PCM_FMT_U16 => SPA_AUDIO_FORMAT_U16,
+                VIRTIO_SND_PCM_FMT_S18_3 => SPA_AUDIO_FORMAT_S18_LE,
+                VIRTIO_SND_PCM_FMT_U18_3 => SPA_AUDIO_FORMAT_U18_LE,
+                VIRTIO_SND_PCM_FMT_S20_3 => SPA_AUDIO_FORMAT_S20_LE,
+                VIRTIO_SND_PCM_FMT_U20_3 => SPA_AUDIO_FORMAT_U20_LE,
+                VIRTIO_SND_PCM_FMT_S24_3 => SPA_AUDIO_FORMAT_S24_LE,
+                VIRTIO_SND_PCM_FMT_U24_3 => SPA_AUDIO_FORMAT_U24_LE,
+                VIRTIO_SND_PCM_FMT_S20 => SPA_AUDIO_FORMAT_S20,
+                VIRTIO_SND_PCM_FMT_U20 => SPA_AUDIO_FORMAT_U20,
+                VIRTIO_SND_PCM_FMT_S24 => SPA_AUDIO_FORMAT_S24,
+                VIRTIO_SND_PCM_FMT_U24 => SPA_AUDIO_FORMAT_U24,
+                VIRTIO_SND_PCM_FMT_S32 => SPA_AUDIO_FORMAT_S32,
+                VIRTIO_SND_PCM_FMT_U32 => SPA_AUDIO_FORMAT_U32,
+                VIRTIO_SND_PCM_FMT_FLOAT => SPA_AUDIO_FORMAT_F32,
+                VIRTIO_SND_PCM_FMT_FLOAT64 => SPA_AUDIO_FORMAT_F64,
+                _ => SPA_AUDIO_FORMAT_UNKNOWN,
+            },
+            rate: match params.rate {
+                VIRTIO_SND_PCM_RATE_5512 => 5512,
+                VIRTIO_SND_PCM_RATE_8000 => 8000,
+                VIRTIO_SND_PCM_RATE_11025 => 11025,
+                VIRTIO_SND_PCM_RATE_16000 => 16000,
+                VIRTIO_SND_PCM_RATE_22050 => 22050,
+                VIRTIO_SND_PCM_RATE_32000 => 32000,
+                VIRTIO_SND_PCM_RATE_44100 => 44100,
+                VIRTIO_SND_PCM_RATE_48000 => 48000,
+                VIRTIO_SND_PCM_RATE_64000 => 64000,
+                VIRTIO_SND_PCM_RATE_88200 => 88200,
+                VIRTIO_SND_PCM_RATE_96000 => 96000,
+                VIRTIO_SND_PCM_RATE_176400 => 176400,
+                VIRTIO_SND_PCM_RATE_192000 => 192000,
+                VIRTIO_SND_PCM_RATE_384000 => 384000,
+                _ => 44100,
+            },
+            flags: 0,
+            channels: params.channels as u32,
+            position: pos,
+        };
+
+        let mut audio_info = AudioInfoRaw::new();
+        audio_info.set_format(AudioFormat::S16LE);
+        audio_info.set_rate(info.rate);
+        audio_info.set_channels(info.channels);
+
+        let values: Vec<u8> = PodSerializer::serialize(
+            std::io::Cursor::new(Vec::new()),
+            &Value::Object(Object {
+                type_: SPA_TYPE_OBJECT_Format,
+                id: SPA_PARAM_EnumFormat,
+                properties: audio_info.into(),
+            }),
+        )
+        .unwrap()
+        .0
+        .into_inner();
+
+        let value_clone = values.clone();
+
+        let mut param = [Pod::from_bytes(&values).unwrap()];
+
+        let props = properties! {
+            *pw::keys::MEDIA_TYPE => "Audio",
+            *pw::keys::MEDIA_CATEGORY => "Playback",
+        };
+
+        let stream = pw::stream::Stream::new(&self.core, "audio-output", props)
+            .expect("could not create new stream");
+
+        let streams = self.stream_params.clone();
+
+        let listener_stream = stream
+            .add_local_listener()
+            .state_changed(|old, new| {
+                debug!("State changed: {:?} -> {:?}", old, new);
+            })
+            .param_changed(move |stream, id, _data, param| {
+                let Some(_param) = param else {
+                    return;
+                };
+                if id != ParamType::Format.as_raw() {
+                    return;
+                }
+                let mut param = [Pod::from_bytes(&value_clone).unwrap()];
+
+                //callback to negotiate new set of streams
+                stream
+                    .update_params(&mut param)
+                    .expect("could not update params");
+            })
+            .process(move |stream, _data| match stream.dequeue_buffer() {
+                None => debug!("No buffer recieved"),
+                Some(mut buf) => {
+                    let datas = buf.datas_mut();
+                    let frame_size = info.channels * size_of::<i16>() as u32;
+                    let data = &mut datas[0];
+                    let n_bytes = if let Some(slice) = data.data() {
+                        let mut n_bytes = slice.len();
+                        let mut streams = streams.write().unwrap();
+                        let streams = streams
+                            .get_mut(stream_id as usize)
+                            .expect("Stream does not exist");
+                        let Some(buffer) = streams.buffers.front_mut() else {
+                            return;
+                        };
+
+                        let mut start = buffer.pos;
+
+                        let avail = (buffer.bytes.len() - start) as i32;
+
+                        if avail < n_bytes as i32 {
+                            n_bytes = avail.try_into().unwrap();
+                        }
+                        let p = &mut slice[buffer.pos..start + n_bytes];
+                        if avail <= 0 {
+                            // pad with silence
+                            unsafe {
+                                ptr::write_bytes(p.as_mut_ptr(), 0, n_bytes);
+                            }
+                        } else {
+                            let slice = &buffer.bytes[buffer.pos..start + n_bytes];
+                            p.copy_from_slice(slice);
+
+                            start += n_bytes;
+
+                            buffer.pos = start;
+
+                            if start >= buffer.bytes.len() {
+                                streams.buffers.pop_front();
+                            }
+                        }
+                        n_bytes
+                    } else {
+                        0
+                    };
+                    let chunk = data.chunk_mut();
+                    *chunk.offset_mut() = 0;
+                    *chunk.stride_mut() = frame_size as _;
+                    *chunk.size_mut() = n_bytes as _;
+                }
+            })
+            .register()
+            .expect("failed to register stream listener");
+
+        stream_listener.insert(stream_id, listener_stream);
+
+        let direction = match stream_params[stream_id as usize].direction {
+            VIRTIO_SND_D_OUTPUT => spa::Direction::Output,
+            VIRTIO_SND_D_INPUT => spa::Direction::Input,
+            _ => panic!("Invalid direction"),
+        };
+
+        stream
+            .connect(
+                direction,
+                Some(pw::constants::ID_ANY),
+                pw::stream::StreamFlags::RT_PROCESS
+                    | pw::stream::StreamFlags::AUTOCONNECT
+                    | pw::stream::StreamFlags::INACTIVE
+                    | pw::stream::StreamFlags::MAP_BUFFERS,
+                &mut param,
+            )
+            .expect("could not connect to the stream");
+
+        // insert created stream in a hash table
+        stream_hash.insert(stream_id, stream);
+        lock_guard.unlock();
         Ok(())
     }
 
-    fn release(&self, stream_id: u32, mut msg: ControlMessage) -> Result<()> {
+    fn release(&self, stream_id: u32, _msg: ControlMessage) -> Result<()> {
         debug!("pipewire backend, release function");
-        let release_result = self.stream_params.write().unwrap()[stream_id as usize]
+        self.stream_params.write().unwrap()[stream_id as usize]
             .state
             .release();
-        if let Err(err) = release_result {
-            log::error!("Stream {} release {}", stream_id, err);
-            msg.code = VIRTIO_SND_S_BAD_MSG;
-        } else {
-            let lock_guard = self.thread_loop.lock();
-            let mut stream_hash = self.stream_hash.write().unwrap();
-            let mut stream_listener = self.stream_listener.write().unwrap();
-            let st_buffer = &mut self.stream_params.write().unwrap();
-
-            let Some(stream) = stream_hash.get(&stream_id) else {
-                return Err(Error::StreamWithIdNotFound(stream_id));
-            };
-            stream.disconnect().expect("could not disconnect stream");
-            std::mem::take(&mut st_buffer[stream_id as usize].buffers);
-            stream_hash.remove(&stream_id);
-            stream_listener.remove(&stream_id);
-
-            lock_guard.unlock();
-        }
-
+        let lock_guard = self.thread_loop.lock();
+        let mut stream_hash = self.stream_hash.write().unwrap();
+        let mut stream_listener = self.stream_listener.write().unwrap();
+        let st_buffer = &mut self.stream_params.write().unwrap();
+        let Some(stream) = stream_hash.get(&stream_id) else {
+            return Err(Error::StreamWithIdNotFound(stream_id));
+        };
+        stream.disconnect().expect("could not disconnect stream");
+        std::mem::take(&mut st_buffer[stream_id as usize].buffers);
+        stream_hash.remove(&stream_id);
+        stream_listener.remove(&stream_id);
+        lock_guard.unlock();
         Ok(())
     }
 
     fn start(&self, stream_id: u32) -> Result<()> {
         debug!("pipewire start");
-        let start_result = self.stream_params.write().unwrap()[stream_id as usize]
+        self.stream_params.write().unwrap()[stream_id as usize]
             .state
             .start();
-        if let Err(err) = start_result {
-            // log the error and continue
-            log::error!("Stream {} start {}", stream_id, err);
-        } else {
-            let lock_guard = self.thread_loop.lock();
-            let stream_hash = self.stream_hash.read().unwrap();
-            let Some(stream) = stream_hash.get(&stream_id) else {
-                return Err(Error::StreamWithIdNotFound(stream_id));
-            };
-            stream.set_active(true).expect("could not start stream");
-            lock_guard.unlock();
-        }
+        let lock_guard = self.thread_loop.lock();
+        let stream_hash = self.stream_hash.read().unwrap();
+        let Some(stream) = stream_hash.get(&stream_id) else {
+            return Err(Error::StreamWithIdNotFound(stream_id));
+        };
+        stream.set_active(true).expect("could not start stream");
+        lock_guard.unlock();
         Ok(())
     }
 
     fn stop(&self, stream_id: u32) -> Result<()> {
         debug!("pipewire stop");
-        let stop_result = self.stream_params.write().unwrap()[stream_id as usize]
+        self.stream_params.write().unwrap()[stream_id as usize]
             .state
             .stop();
-        if let Err(err) = stop_result {
-            log::error!("Stream {} stop {}", stream_id, err);
-        } else {
-            let lock_guard = self.thread_loop.lock();
-            let stream_hash = self.stream_hash.read().unwrap();
-            let Some(stream) = stream_hash.get(&stream_id) else {
-                return Err(Error::StreamWithIdNotFound(stream_id));
-            };
-            stream.set_active(false).expect("could not stop stream");
-            lock_guard.unlock();
-        }
-
+        let lock_guard = self.thread_loop.lock();
+        let stream_hash = self.stream_hash.read().unwrap();
+        let Some(stream) = stream_hash.get(&stream_id) else {
+            return Err(Error::StreamWithIdNotFound(stream_id));
+        };
+        stream.set_active(false).expect("could not stop stream");
+        lock_guard.unlock();
         Ok(())
     }
 }

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -325,6 +325,14 @@ impl AudioBackend for PwBackend {
                         let Some(buffer) = streams.buffers.front_mut() else {
                             return;
                         };
+                        if let Err(err) = buffer.read() {
+                            log::error!(
+                                "Could not read TX buffer, dropping it immediately: {}",
+                                err
+                            );
+                            streams.buffers.pop_front();
+                            return;
+                        }
 
                         let mut start = buffer.pos;
 

--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -542,14 +542,7 @@ impl VhostUserSoundThread {
                         .into());
                     }
                     TxState::WaitingBufferForStreamId(_stream_id) => {
-                        let mut buf = vec![0; descriptor.len() as usize];
-                        let bytes_read = desc_chain
-                            .memory()
-                            .read(&mut buf, descriptor.addr())
-                            .map_err(|_| Error::DescriptorReadFailed)?;
-                        buf.truncate(bytes_read);
-
-                        buffers.push(Buffer::new(buf, Arc::clone(&message)));
+                        buffers.push(Buffer::new(*descriptor, Arc::clone(&message)));
                     }
                 }
             }

--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -542,16 +542,14 @@ impl VhostUserSoundThread {
                         .into());
                     }
                     TxState::WaitingBufferForStreamId(_stream_id) => {
-                        /*
-                        Rather than copying the content of a descriptor, buffer keeps a pointer to it.
-                        When we copy just after the request is enqueued, the guest's userspace may or
-                        may not have updated the buffer contents. Guest driver simply moves buffers
-                        from the used ring to the available ring without knowing whether the content
-                        has been updated. The device only reads the buffer from guest memory when the
-                        audio engine requires it, which is about after a period thus ensuring that the
-                        buffer is up-to-date.
-                        */
-                        buffers.push(Buffer::new(*descriptor, Arc::clone(&message)));
+                        let mut buf = vec![0; descriptor.len() as usize];
+                        let bytes_read = desc_chain
+                            .memory()
+                            .read(&mut buf, descriptor.addr())
+                            .map_err(|_| Error::DescriptorReadFailed)?;
+                        buf.truncate(bytes_read);
+
+                        buffers.push(Buffer::new(buf, Arc::clone(&message)));
                     }
                 }
             }

--- a/staging/vhost-device-sound/src/stream.rs
+++ b/staging/vhost-device-sound/src/stream.rs
@@ -4,7 +4,7 @@
 use std::{collections::VecDeque, sync::Arc};
 
 use thiserror::Error as ThisError;
-use vm_memory::{Address, Bytes, Le32, Le64};
+use vm_memory::{Le32, Le64};
 
 use crate::{virtio_sound::*, IOMessage, SUPPORTED_FORMATS, SUPPORTED_RATES};
 
@@ -15,11 +15,7 @@ pub enum Error {
     InvalidStateTransition(PCMState, PCMState),
     #[error("Guest requested an invalid stream id: {0}")]
     InvalidStreamId(u32),
-    #[error("Descriptor read failed")]
-    DescriptorReadFailed,
 }
-
-type Result<T> = std::result::Result<T, Error>;
 
 /// PCM stream state machine.
 ///
@@ -108,12 +104,11 @@ pub enum PCMState {
 
 macro_rules! set_new_state {
     ($new_state_fn:ident, $new_state:expr, $($valid_source_states:tt)*) => {
-        pub fn $new_state_fn(&mut self) -> Result<()> {
-            if !matches!(self, $($valid_source_states)*) {
-                return Err(Error::InvalidStateTransition(*self, $new_state));
+        pub fn $new_state_fn(&mut self) {
+            if !matches!(*self, $($valid_source_states)*) {
+                log::error!("{}", Error::InvalidStateTransition(*self, $new_state));
             }
             *self = $new_state;
-            Ok(())
         }
     };
 }
@@ -236,8 +231,7 @@ impl Default for PcmParams {
 }
 
 pub struct Buffer {
-    // TODO: to make private and add len usize
-    pub data_descriptor: virtio_queue::Descriptor,
+    pub bytes: Vec<u8>,
     pub pos: usize,
     pub message: Arc<IOMessage>,
 }
@@ -245,6 +239,7 @@ pub struct Buffer {
 impl std::fmt::Debug for Buffer {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         fmt.debug_struct(stringify!(Buffer))
+            .field("bytes", &self.bytes.len())
             .field("pos", &self.pos)
             .field("message", &Arc::as_ptr(&self.message))
             .finish()
@@ -252,28 +247,12 @@ impl std::fmt::Debug for Buffer {
 }
 
 impl Buffer {
-    pub fn new(data_descriptor: virtio_queue::Descriptor, message: Arc<IOMessage>) -> Self {
+    pub fn new(bytes: Vec<u8>, message: Arc<IOMessage>) -> Self {
         Self {
+            bytes,
             pos: 0,
-            data_descriptor,
             message,
         }
-    }
-
-    pub fn consume(&self, buf: &mut [u8]) -> Result<u32> {
-        let addr = self.data_descriptor.addr();
-        let offset = self.pos as u64;
-        let len = self
-            .message
-            .desc_chain
-            .memory()
-            .read(
-                buf,
-                addr.checked_add(offset)
-                    .expect("invalid guest memory address"),
-            )
-            .map_err(|_| Error::DescriptorReadFailed)?;
-        Ok(len as u32)
     }
 }
 


### PR DESCRIPTION
Depends on #483 

### Summary of the PR

> Queued buffers were played even after the guest issued PCM_STOP.
> 
> This commit makes the ALSA worker threads respect the stopped status
> instead.
> 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
