### PR TITLE
staging: update coverage target

### DIFF
--- a/staging/coverage_config_x86_64.json
+++ b/staging/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 50.43,
+  "coverage_score": 57.35,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
### Summary of the PR

Update staging coverage target value to current mainline value:

```
FAILED ../rust-vmm-ci/integration_tests/test_coverage.py::test_coverage - ValueError: Current code coverage (57.35%) deviates by -6.92% from the previous code coverage 50.43%.Current ...
```

Found in https://github.com/rust-vmm/vhost-device/pull/496.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
