### PR TITLE
vsock: avoid circular references

### DIFF
--- a/vhost-device-vsock/src/main.rs
+++ b/vhost-device-vsock/src/main.rs
@@ -234,13 +234,13 @@ pub(crate) fn start_backend_server(
         )
         .map_err(BackendError::CouldNotCreateDaemon)?;
 
-        let mut vring_workers = daemon.get_epoll_handlers();
+        let mut epoll_handlers = daemon.get_epoll_handlers();
 
         for thread in backend.threads.iter() {
             thread
                 .lock()
                 .unwrap()
-                .set_vring_worker(Some(vring_workers.remove(0)));
+                .register_listeners(epoll_handlers.remove(0));
         }
 
         daemon.start(listener).unwrap();


### PR DESCRIPTION
### Summary of the PR

We have the following circular references found by Li Zebin:
    VhostUserBackend ==> VhostUserVsockThread ==> VringEpollHandler

In addition to causing a resource leak, this causes also an error after we merged commit 38caab2 ("vsock: Don't allow duplicate CIDs"). When the VM reboot or shutdown, the application exits with the following error:

    [ERROR vhost_device_vsock] Could not create backend:
        CID already in use by another vsock device

This happened because we have these circular references and VhostUserVsockThread::drop() is never invoked. So, we don't remove the cid from the map.

Let's fix this problem by simply removing the reference to VringEpollHandler from VhostUserVsockThread. In fact, we do not need to keep the reference for the lifetime of VhostUserVsockThread, as we only need to add the handlers once.

Let's also rename the fields to follow the current VhostUserDaemon API.

Closes #438

Reported-by: Li Zebin <cutelizebin@gmail.com>

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
