### PR TITLE
CODEOWNERS: add epilys, remove mathieupoirier 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add the list of code owners here (using their GitHub username)
-* @mathieupoirier @stsquad @vireshk @stefano-garzarella
+* @stsquad @vireshk @stefano-garzarella @epilys


### PR DESCRIPTION

Add self to CODEOWNERS to contribute with reviewing, merging other PRs and maintaining the vhost-device-sound crate.

Also remove @mathieupoirier, who is unavailable for maintainer duties at
this time.