### PR TITLE
sound/test: add tests for device.rs

### DIFF
--- a/staging/coverage_config_x86_64.json
+++ b/staging/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 57.35,
+  "coverage_score": 56.58,
   "exclude_path": "",
   "crate_features": ""
 }


### PR DESCRIPTION
### Summary of the PR
Adds tests in test_sound_thread_failure to test that process_control() returns Err() in the following four conditions:
* control request with a single descriptor
* control request in which first descriptor is write-only
* control request in which second descriptor is read-only
* control request with less than three descriptors for control requests that require three, e.g., PcmInfo, ChmapInfo

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
