### PR TITLE
sound/pipewire: add test util harness for launching pipewire+dbus

### DIFF
--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -557,6 +557,11 @@ impl AudioBackend for PwBackend {
 }
 
 #[cfg(test)]
+/// Utilities for building a temporary Dbus session and a pipewire instance for
+/// testing.
+mod test_utils;
+
+#[cfg(test)]
 mod tests {
     use vhost_user_backend::{VringRwLock, VringT};
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
@@ -565,7 +570,7 @@ mod tests {
         Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
     };
 
-    use super::*;
+    use super::{test_utils::PipewireTestHarness, *};
     use crate::{ControlMessageKind, SoundDescriptorChain, VirtioSoundHeader};
 
     // Prepares a single chain of descriptors for request queue
@@ -638,6 +643,8 @@ mod tests {
         let streams = Arc::new(RwLock::new(vec![Stream::default()]));
         let stream_params = streams.clone();
 
+        let _test_harness = PipewireTestHarness::new();
+
         let pw_backend = PwBackend::new(stream_params);
         assert_eq!(pw_backend.stream_hash.read().unwrap().len(), 0);
         assert_eq!(pw_backend.stream_listener.read().unwrap().len(), 0);
@@ -659,6 +666,8 @@ mod tests {
     #[test]
     fn test_pipewire_backend_invalid_stream() {
         let stream_params = Arc::new(RwLock::new(vec![]));
+
+        let _test_harness = PipewireTestHarness::new();
 
         let pw_backend = PwBackend::new(stream_params);
 

--- a/staging/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
@@ -1,0 +1,134 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{
+    io::Read,
+    path::Path,
+    process::{Child, Command, Stdio},
+};
+
+use tempfile::{tempdir, TempDir};
+
+/// Temporary Dbus session which is killed in drop().
+pub struct DbusSession {
+    pub child: Child,
+    pub address: String,
+}
+
+impl DbusSession {
+    pub fn new(working_dir: &Path) -> Self {
+        let address_prefix = format!("unix:path={}", working_dir.join("dbus").display());
+        let child = Command::new("/usr/bin/dbus-daemon")
+            .args(["--session", "--address", &address_prefix, "--print-address"])
+            .env("DBUS_VERBOSE", "1")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::null())
+            .current_dir(working_dir)
+            .spawn()
+            .expect("ERROR: dbus-daemon binary not found");
+
+        Self {
+            child,
+            address: address_prefix,
+        }
+    }
+}
+
+impl Drop for DbusSession {
+    fn drop(&mut self) {
+        println!("INFO: Killing Dbus session {}", self.child.id());
+        if let Err(err) = self.child.kill() {
+            println!(
+                "ERROR: could not kill dbus process {}: {err}",
+                self.child.id()
+            );
+        }
+        // We mustn't panic in drop(), so use a wrapper function for convenience
+        print_output(&mut self.child, "dbus");
+    }
+}
+
+/// The pipewire test harness. It must only be constructed via
+/// `PipewireTestHarness::new()`.
+#[non_exhaustive]
+pub struct PipewireTestHarness {
+    pub dbus: DbusSession,
+    pub pipewire_child: Child,
+    pub tempdir: TempDir,
+}
+
+pub fn launch_pipewire(
+    tempdir: &Path,
+    dbus_session_bus_address: &Path,
+) -> Result<Child, std::io::Error> {
+    Command::new("pipewire")
+        .env("DBUS_SESSION_BUS_ADDRESS", dbus_session_bus_address)
+        .env("XDG_RUNTIME_DIR", tempdir)
+        .current_dir(tempdir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .spawn()
+}
+
+impl PipewireTestHarness {
+    pub fn new() -> Self {
+        let tempdir = tempdir().unwrap();
+
+        let dbus_session = DbusSession::new(tempdir.path());
+        println!("INFO: dbus_session_bus_address={}", dbus_session.address);
+
+        println!("INFO: Wait for dbus to setup...");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        println!("INFO: Launch pipewire.");
+        let pipewire_child = launch_pipewire(tempdir.path(), Path::new(&dbus_session.address))
+            .expect("ERROR: Could not launch pipewire");
+        println!("INFO: Wait for pipewire to setup...");
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        std::env::set_var("DBUS_SESSION_BUS_ADDRESS", &dbus_session.address);
+        std::env::set_var("XDG_RUNTIME_DIR", tempdir.path());
+
+        Self {
+            dbus: dbus_session,
+            pipewire_child,
+            tempdir,
+        }
+    }
+}
+
+impl Drop for PipewireTestHarness {
+    fn drop(&mut self) {
+        println!("INFO: Killing pipewire pid {}", self.pipewire_child.id());
+        if let Err(err) = self.pipewire_child.kill() {
+            println!(
+                "ERROR: could not kill Pipewire process {}: {err}",
+                self.pipewire_child.id()
+            );
+        }
+        // We mustn't panic in drop(), so use a wrapper function for convenience
+        print_output(&mut self.pipewire_child, "pipewire");
+    }
+}
+
+fn print_output(child: &mut Child, id: &'static str) -> Option<()> {
+    let mut stdout = child.stdout.take()?;
+    let mut stderr = child.stderr.take()?;
+
+    let mut buf = String::new();
+    stdout.read_to_string(&mut buf).ok()?;
+    if !buf.trim().is_empty() {
+        println!("INFO: {id} stdout {buf}");
+    }
+
+    buf.clear();
+
+    stderr.read_to_string(&mut buf).ok()?;
+    if !buf.trim().is_empty() {
+        println!("ERROR: {id} stderr {buf}");
+    }
+
+    None
+}


### PR DESCRIPTION


### Summary of the PR

Add test utility to launch a temporary dbus daemon, pipewire. This is necessary to run pipewire tests under CI.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
