### PR TITLE
sound: add `virtualization` in Cargo.toml categories [trivial]

### DIFF
--- a/staging/vhost-device-sound/Cargo.toml
+++ b/staging/vhost-device-sound/Cargo.toml
@@ -6,7 +6,7 @@ description = "A virtio-sound device using the vhost-user protocol."
 repository = "https://github.com/rust-vmm/vhost-device"
 readme = "README.md"
 keywords = ["vhost", "sound", "virtio-sound", "virtio-snd", "virtio"]
-categories = ["multimedia::audio"]
+categories = ["multimedia::audio", "virtualization"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 


### PR DESCRIPTION
Previous commit added categories to Cargo.toml, but the only value was `multimedia::audio`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
