### PR TITLE
vsock: increase test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,7 @@ dependencies = [
 name = "vhost-device-vsock"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "byteorder",
  "clap",
  "config",

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 73.42,
+  "coverage_score": 77.28,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -31,5 +31,6 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 
 [dev-dependencies]
+assert_matches = "1.5"
 virtio-queue = { version = "0.9", features = ["test-utils"] }
 tempfile = "3.6.0"

--- a/vhost-device-vsock/src/rxops.rs
+++ b/vhost-device-vsock/src/rxops.rs
@@ -26,6 +26,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_rxops() {
+        let rx = RxOps::Request;
+        // Increase coverage testing Clone and Debug traits
+        assert_eq!(rx, rx.clone());
+        assert_eq!(format!("{rx:?}"), "Request");
+    }
+
+    #[test]
     fn test_bitmask() {
         assert_eq!(1, RxOps::Request.bitmask());
         assert_eq!(2, RxOps::Rw.bitmask());

--- a/vhost-device-vsock/src/rxqueue.rs
+++ b/vhost-device-vsock/src/rxqueue.rs
@@ -154,4 +154,11 @@ mod tests {
         rxqueue.queue = 1;
         assert!(rxqueue.pending_rx());
     }
+
+    #[test]
+    fn test_debug() {
+        let rxqueue = RxQueue::new();
+
+        assert_eq!(format!("{rxqueue:?}"), "RxQueue { queue: 0 }");
+    }
 }

--- a/vhost-device-vsock/src/txbuf.rs
+++ b/vhost-device-vsock/src/txbuf.rs
@@ -230,4 +230,14 @@ mod tests {
             assert_eq!(cmp_vec, data[..n]);
         }
     }
+
+    #[test]
+    fn test_txbuf_debug() {
+        let loc_tx_buf = LocalTxBuf::new(1);
+
+        assert_eq!(
+            format!("{loc_tx_buf:?}"),
+            "LocalTxBuf { buf: [0], head: 0, tail: 0 }"
+        );
+    }
 }

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -540,4 +540,28 @@ mod tests {
 
         test_dir.close().unwrap();
     }
+
+    #[test]
+    fn test_vhu_vsock_structs() {
+        let config = VsockConfig::new(0, String::new(), String::new(), 0, vec![String::new()]);
+
+        assert_eq!(format!("{config:?}"), "VsockConfig { guest_cid: 0, socket: \"\", uds_path: \"\", tx_buffer_size: 0, groups: [\"\"] }");
+
+        let conn_map = ConnMapKey::new(0, 0);
+        assert_eq!(
+            format!("{conn_map:?}"),
+            "ConnMapKey { local_port: 0, peer_port: 0 }"
+        );
+        assert_eq!(conn_map, conn_map.clone());
+
+        let virtio_config = VirtioVsockConfig::default();
+        assert_eq!(
+            format!("{virtio_config:?}"),
+            "VirtioVsockConfig { guest_cid: Le64(0) }"
+        );
+        assert_eq!(virtio_config, virtio_config.clone());
+
+        let error = Error::HandleEventNotEpollIn;
+        assert_eq!(format!("{error:?}"), "HandleEventNotEpollIn");
+    }
 }

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -22,7 +22,6 @@ use crate::{
     vhu_vsock_thread::VhostUserVsockThread,
 };
 
-#[derive(Debug)]
 pub(crate) struct VsockConnection<S> {
     /// Host-side stream corresponding to this vsock connection.
     pub stream: S,
@@ -519,7 +518,8 @@ mod tests {
     #[test]
     fn test_vsock_conn_init() {
         // new locally inititated connection
-        let dummy_file = VsockDummySocket::new();
+        let mut dummy_file = VsockDummySocket::new();
+        assert!(dummy_file.flush().is_ok());
         let mut conn_local = VsockConnection::new_local_init(
             dummy_file,
             VSOCK_HOST_CID,


### PR DESCRIPTION
### Summary of the PR

Add more tests in vhost-device-vsock to increase the coverage.

Some of them are really simple and perhaps nonsensical (tests for
Debug, Clone, etc.), but for now we don't know how to disable this
in the tool, so let's cover these cases.

The first patch is a fix of an issue I discovered while implementing the test.

The vhost-device-vsock functions coverage increases from 70.73% to
90.45%:
```
Filename             Functions  Missed Functions  Executed
----------------------------------------------------------
main.rs                     51                12    76.47%
rxops.rs                     8                 0   100.00%
rxqueue.rs                  20                 0   100.00%
thread_backend.rs           20                 3    85.00%
txbuf.rs                    17                 0   100.00%
vhu_vsock.rs                37                 1    97.30%
vhu_vsock_thread.rs         40                 5    87.50%
vsock_conn.rs               27                 0   100.00%
----------------------------------------------------------
TOTAL                      220                21    90.45%
```
Closes #229

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
