### PR TITLE
vsock/test: fix intermittent failures

### DIFF
--- a/vhost-device-vsock/src/main.rs
+++ b/vhost-device-vsock/src/main.rs
@@ -621,7 +621,11 @@ mod tests {
             "CouldNotCreateBackend(CidAlreadyInUse)"
         );
 
-        test_dir.close().unwrap();
+        // In slow systems it can happen that one thread is exiting due to
+        // an error and another thread is creating files (Unix socket),
+        // so sometimes this call fails because after deleting all the
+        // files it finds more. So let's discard eventual errors.
+        let _ = test_dir.close();
     }
 
     #[test]


### PR DESCRIPTION
### Summary of the PR

`test_start_backend_servers_failure` is failing intermittently. In slow systems it can happen that one thread is exiting due to an error (in this case we expect a CidAlreadyInUse error) and another thread is creating files (Unix socket), so sometimes test_dir.close() fails because after deleting all the files it finds more. So let's discard eventual errors.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
