### PR TITLE
dependabot: run it also for staging crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
       vhost-device:
         patterns:
           - "*"
+- package-ecosystem: cargo
+  directory: "/staging/"
+  schedule:
+    interval: weekly
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
+  groups:
+      vhost-device:
+        patterns:
+          - "*"
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
We forgot to tell dependabot to also run in the "staging" nested workspace. Let's enable it.

Closes #536 
