### PR TITLE
Add `[workspace.lints]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,39 @@ members = [
     "vhost-device-vsock",
     "xtask",
 ]
+
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "deny"
+
+[workspace.lints.rustdoc]
+broken_intra_doc_links = "deny"
+redundant_explicit_links = "deny"
+
+[workspace.lints.clippy]
+enum_glob_use = "deny"
+# groups
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }
+#nursery = { level = "deny", priority = -1 }
+# restriction
+dbg_macro = "deny"
+rc_buffer = "deny"
+as_underscore = "deny"
+assertions_on_result_states = "deny"
+# pedantic
+cast_lossless = "deny"
+cast_possible_wrap = "deny"
+cast_ptr_alignment = "deny"
+naive_bytecount = "deny"
+ptr_as_ptr = "deny"
+bool_to_int_with_if = "deny"
+borrow_as_ptr = "deny"
+case_sensitive_file_extension_comparisons = "deny"
+significant_drop_in_scrutinee = "allow"
+significant_drop_tightening = "allow"
+missing_safety_doc = "deny"
+undocumented_unsafe_blocks = "deny"
+option_if_let_else = "allow"

--- a/vhost-device-can/src/can.rs
+++ b/vhost-device-can/src/can.rs
@@ -160,7 +160,7 @@ impl CanController {
 
     pub fn read_can_socket(controller: Arc<RwLock<CanController>>) -> Result<()> {
         let can_name = &controller.read().unwrap().can_name.clone();
-        dbg!("Start reading from {} socket!", &can_name);
+        log::debug!("Start reading from {can_name} socket!");
         let socket = match CanFdSocket::open(can_name) {
             Ok(socket) => socket,
             Err(_) => {
@@ -182,7 +182,7 @@ impl CanController {
         loop {
             // If the status variable is false then break and exit.
             if !controller.read().unwrap().status {
-                dbg!("exit read can thread");
+                log::debug!("exit read can thread");
                 return Ok(());
             }
 

--- a/vhost-device-can/src/vhu_can.rs
+++ b/vhost-device-can/src/vhu_can.rs
@@ -637,7 +637,8 @@ impl VhostUserBackendMut for VhostUserCanBackend {
                     .config()
                     .as_slice()
                     .as_ptr()
-                    .offset(offset as isize) as *const _ as *const _,
+                    .offset(offset as isize)
+                    .cast::<u8>(),
                 size as usize,
             )
             .to_vec()

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -34,3 +34,6 @@ vmm-sys-util = "0.14"
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-gpio/src/vhu_gpio.rs
+++ b/vhost-device-gpio/src/vhu_gpio.rs
@@ -421,7 +421,8 @@ impl<D: 'static + GpioDevice + Sync + Send> VhostUserBackendMut for VhostUserGpi
                     .config()
                     .as_slice()
                     .as_ptr()
-                    .offset(offset as isize) as *const _ as *const _,
+                    .offset(offset as isize)
+                    .cast::<u8>(),
                 size as usize,
             )
             .to_vec()
@@ -1157,7 +1158,7 @@ mod tests {
             // reading its content from byte array.
             unsafe {
                 from_raw_parts(
-                    &config as *const _ as *const _,
+                    (&raw const config).cast::<u8>(),
                     size_of::<VirtioGpioConfig>(),
                 )
                 .to_vec()

--- a/vhost-device-i2c/Cargo.toml
+++ b/vhost-device-i2c/Cargo.toml
@@ -31,3 +31,6 @@ vmm-sys-util = "0.14"
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-i2c/src/i2c.rs
+++ b/vhost-device-i2c/src/i2c.rs
@@ -242,7 +242,8 @@ impl SmbusMsg {
                             // Special Read requests, reqs[0].len can be 0 or 1 only.
                             Err(Error::MessageLengthInvalid("read", 3))
                         } else {
-                            data.word = reqs[0].buf[1] as u16 | ((reqs[0].buf[2] as u16) << 8);
+                            data.word =
+                                u16::from(reqs[0].buf[1]) | (u16::from(reqs[0].buf[2]) << 8);
                             Ok(SmbusMsg {
                                 read_write,
                                 command: reqs[0].buf[0],

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -407,7 +407,7 @@ mod tests {
         vq.desc_table()
             .store(index, RawDescriptor::from(desc_out))
             .unwrap();
-        next_addr += desc_out.len() as u64;
+        next_addr += u64::from(desc_out.len());
         index += 1;
 
         // Buf descriptor: optional
@@ -430,7 +430,7 @@ mod tests {
             vq.desc_table()
                 .store(index, RawDescriptor::from(desc_buf))
                 .unwrap();
-            next_addr += desc_buf.len() as u64;
+            next_addr += u64::from(desc_buf.len());
             index += 1;
         }
 

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -306,7 +306,7 @@ impl<D: 'static + I2cDevice + Sync + Send> VhostUserBackendMut for VhostUserI2cB
     }
 
     fn set_event_idx(&mut self, enabled: bool) {
-        dbg!(self.event_idx = enabled);
+        self.event_idx = enabled;
     }
 
     fn update_memory(&mut self, mem: GuestMemoryAtomic<GuestMemoryMmap>) -> IoResult<()> {

--- a/vhost-device-input/Cargo.toml
+++ b/vhost-device-input/Cargo.toml
@@ -35,3 +35,6 @@ nix = { version = "0.30", features = ["ioctl"] }
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-input/src/input.rs
+++ b/vhost-device-input/src/input.rs
@@ -64,7 +64,7 @@ macro_rules! ioctl_read_buf {
             for item in data.iter_mut() {
                 *item = $nr as u8;
             }
-            Ok(data.len() as i32)
+            Ok(data.len().try_into().unwrap())
         }
     )
 }

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -148,7 +148,9 @@ impl<T: InputDevice> VuInputBackend<T> {
         let last_sync_index = self
             .ev_list
             .iter()
-            .rposition(|event| event.ev_type == EV_SYN as u16 && event.code == SYN_REPORT as u16)
+            .rposition(|event| {
+                event.ev_type == u16::from(EV_SYN) && event.code == u16::from(SYN_REPORT)
+            })
             .unwrap_or(0);
 
         if last_sync_index == 0 {
@@ -609,15 +611,15 @@ mod tests {
             .unwrap();
 
         let ev_raw_data = VuInputEvent {
-            ev_type: EV_KEY as u16,
-            code: SYN_REPORT as u16,
+            ev_type: u16::from(EV_KEY),
+            code: u16::from(SYN_REPORT),
             value: 0,
         };
         backend.ev_list.push_back(ev_raw_data);
 
         let ev_raw_data = VuInputEvent {
-            ev_type: EV_SYN as u16,
-            code: SYN_REPORT as u16,
+            ev_type: u16::from(EV_SYN),
+            code: u16::from(SYN_REPORT),
             value: 0,
         };
         backend.ev_list.push_back(ev_raw_data);
@@ -630,15 +632,15 @@ mod tests {
         assert_eq!(backend.ev_list.len(), 0);
 
         let ev_raw_data = VuInputEvent {
-            ev_type: EV_KEY as u16,
-            code: SYN_REPORT as u16,
+            ev_type: u16::from(EV_KEY),
+            code: u16::from(SYN_REPORT),
             value: 0,
         };
         backend.ev_list.push_back(ev_raw_data);
 
         let ev_raw_data = VuInputEvent {
-            ev_type: EV_SYN as u16,
-            code: SYN_REPORT as u16,
+            ev_type: u16::from(EV_SYN),
+            code: u16::from(SYN_REPORT),
             value: 0,
         };
         backend.ev_list.push_back(ev_raw_data);
@@ -854,7 +856,7 @@ mod tests {
 
         assert_eq!(backend.queues_per_thread(), vec![0xffff_ffff]);
         assert_eq!(backend.get_config(0, 0), vec![]);
-        assert!(backend.update_memory(mem.clone()).is_ok());
+        backend.update_memory(mem.clone()).unwrap();
 
         backend.set_event_idx(true);
         assert!(backend.event_idx);

--- a/vhost-device-rng/Cargo.toml
+++ b/vhost-device-rng/Cargo.toml
@@ -32,3 +32,6 @@ vmm-sys-util = "0.14"
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -232,7 +232,7 @@ impl<T: 'static + ReadVolatile + Sync + Send> VhostUserBackendMut for VuRngBacke
     }
 
     fn set_event_idx(&mut self, enabled: bool) {
-        dbg!(self.event_idx = enabled);
+        self.event_idx = enabled;
     }
 
     fn update_memory(

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -369,7 +369,7 @@ mod tests {
             };
 
             let desc = RawDescriptor::from(SplitDescriptor::new(
-                (0x100 * (i + 1)) as u64,
+                u64::from(0x100 * (i + 1)),
                 0x200,
                 desc_flags,
                 i + 1,
@@ -579,7 +579,7 @@ mod tests {
 
         assert_eq!(backend.queues_per_thread(), vec![0xffff_ffff]);
         assert_eq!(backend.get_config(0, 0), vec![]);
-        assert!(backend.update_memory(mem).is_ok());
+        backend.update_memory(mem).unwrap();
 
         backend.set_event_idx(true);
         assert!(backend.event_idx);

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -25,3 +25,6 @@ vmm-sys-util = "0.14"
 [dev-dependencies]
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/vhost-device-scmi/src/devices/iio.rs
+++ b/vhost-device-scmi/src/devices/iio.rs
@@ -442,7 +442,7 @@ impl SensorT for IIOSensor {
             return Err(ScmiDeviceError::GenericError);
         }
 
-        let sample_byte = (scan_type.realbits as f64 / 8_f64).ceil() as usize;
+        let sample_byte = (f64::from(scan_type.realbits) / 8_f64).ceil() as usize;
         let sample_buffer_len = sample_byte * self.axes.len();
         let mut buffer = vec![0u8; sample_buffer_len];
         let mut file = self.sensor().notify_dev.as_ref().unwrap();
@@ -467,7 +467,7 @@ impl SensorT for IIOSensor {
                         let value =
                             i16::from_le_bytes(buffer[i * 2..i * 2 + 2].try_into().unwrap());
                         let value_i64 = self
-                            .deal_axis_raw_data(value as i64, &self.axes[i])
+                            .deal_axis_raw_data(i64::from(value), &self.axes[i])
                             .unwrap();
                         let sensor_value_low = (value_i64 & 0xffff_ffff) as i32;
                         let sensor_value_high = (value_i64 >> 32) as i32;
@@ -607,10 +607,10 @@ impl IIOSensor {
                 custom_exponent -= 1;
                 // Calculate the resolution of scale
                 custom_resolution =
-                    (scale * 10i32.pow(-custom_exponent as u32) as f64).trunc() as u64;
+                    (scale * f64::from(10i32.pow(-custom_exponent as u32))).trunc() as u64;
             } else {
                 custom_resolution =
-                    (scale / 10i32.pow(custom_exponent as u32) as f64).trunc() as u64;
+                    (scale / f64::from(10i32.pow(custom_exponent as u32))).trunc() as u64;
             }
             // The SCMI exponent (unit_exponent + custom_exponent) can have max. 5 bits:
             custom_exponent = min(15 - unit_exponent, custom_exponent);

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -778,9 +778,9 @@ impl ScmiHandler {
                         // message_type = 0x3 [9:8]
                         // protocol_id=0x15; [17:10]
                         // 0x1 | (0x3<<8) | (0x15<<10)
-                        let notify_header: MessageHeader = (SENSOR_UPDATE as u32)
+                        let notify_header: MessageHeader = u32::from(SENSOR_UPDATE)
                             | ((MessageType::Notification as u32) << 8)
-                            | ((SENSOR_PROTOCOL_ID as u32) << 10);
+                            | (u32::from(SENSOR_PROTOCOL_ID) << 10);
 
                         Some(ScmiResponse::from(
                             notify_header,
@@ -1564,12 +1564,12 @@ mod tests {
         for iteration in 0..2 {
             for sensor_id in 0..2 {
                 let notification = handler.notify(NOTIFY_ALLOW_START_FD + sensor_id).unwrap();
-                let notify_header: MessageHeader = (SENSOR_UPDATE as u32)
+                let notify_header: MessageHeader = u32::from(SENSOR_UPDATE)
                     | ((MessageType::Notification as u32) << 8)
-                    | ((SENSOR_PROTOCOL_ID as u32) << 10);
+                    | (u32::from(SENSOR_PROTOCOL_ID) << 10);
                 let mut result = vec![];
                 result.push(MessageValue::Unsigned(0));
-                result.push(MessageValue::Unsigned(sensor_id as u32));
+                result.push(MessageValue::Unsigned(u32::from(sensor_id)));
                 for i in 0..3 {
                     result.push(MessageValue::Signed(iteration + 100 * i));
                     result.push(MessageValue::Signed(0));

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -158,7 +158,7 @@ impl VuScmiBackend {
         let eventfd_list = self.scmi_handler.get_device_eventfd_list();
         for (device_notify_fd, device_event) in eventfd_list {
             handlers[0]
-                .register_listener(device_notify_fd, EventSet::IN, device_event as u64)
+                .register_listener(device_notify_fd, EventSet::IN, u64::from(device_event))
                 .unwrap();
         }
     }

--- a/vhost-device-scsi/Cargo.toml
+++ b/vhost-device-scsi/Cargo.toml
@@ -32,3 +32,6 @@ vmm-sys-util = "0.14"
 assert_matches = "1.5"
 tempfile = "3.20.0"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
+
+[lints]
+workspace = true

--- a/vhost-device-scsi/src/vhu_scsi.rs
+++ b/vhost-device-scsi/src/vhu_scsi.rs
@@ -298,7 +298,7 @@ impl VhostUserBackendMut for VhostUserScsiBackend {
         // access up to the size of the struct.
         let config_slice = unsafe {
             slice::from_raw_parts(
-                &config as *const virtio_scsi_config as *const u8,
+                (&raw const config).cast::<u8>(),
                 mem::size_of::<virtio_scsi_config>(),
             )
         };

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -42,3 +42,6 @@ vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] 
 [target.'cfg(target_env = "gnu")'.dev-dependencies]
 rand = { version = "0.9.2" }
 rusty-fork = { version = "0.3.0" }
+
+[lints]
+workspace = true

--- a/vhost-device-sound/src/stream.rs
+++ b/vhost-device-sound/src/stream.rs
@@ -156,21 +156,20 @@ impl PCMState {
 
 impl std::fmt::Display for PCMState {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        use PCMState::*;
-        match *self {
-            SetParameters => {
+        match self {
+            Self::SetParameters => {
                 write!(fmt, "VIRTIO_SND_R_PCM_SET_PARAMS")
             }
-            Prepare => {
+            Self::Prepare => {
                 write!(fmt, "VIRTIO_SND_R_PCM_PREPARE")
             }
-            Release => {
+            Self::Release => {
                 write!(fmt, "VIRTIO_SND_R_PCM_RELEASE")
             }
-            Start => {
+            Self::Start => {
                 write!(fmt, "VIRTIO_SND_R_PCM_START")
             }
-            Stop => {
+            Self::Stop => {
                 write!(fmt, "VIRTIO_SND_R_PCM_STOP")
             }
         }

--- a/vhost-device-spi/Cargo.toml
+++ b/vhost-device-spi/Cargo.toml
@@ -33,3 +33,6 @@ bitflags = "2.9.1"
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-spi/src/linux_spi.rs
+++ b/vhost-device-spi/src/linux_spi.rs
@@ -58,7 +58,7 @@ pub fn spi_ioc_message(n: u32) -> u64 {
     if n * 32 < (1 << _IOC_SIZEBITS) {
         size = n * 32;
     }
-    (SPI_IOC_MESSAGE_BASE | (size << _IOC_SIZESHIFT)) as u64
+    u64::from(SPI_IOC_MESSAGE_BASE | (size << _IOC_SIZESHIFT))
 }
 
 bitflags! {

--- a/vhost-device-spi/src/vhu_spi.rs
+++ b/vhost-device-spi/src/vhu_spi.rs
@@ -1423,7 +1423,7 @@ mod tests {
             // reading its content from byte array.
             unsafe {
                 from_raw_parts(
-                    &dummy_config as *const _ as *const _,
+                    (&raw const dummy_config).cast::<u8>(),
                     size_of::<VirtioSpiConfig>(),
                 )
                 .to_vec()

--- a/vhost-device-template/Cargo.toml
+++ b/vhost-device-template/Cargo.toml
@@ -32,3 +32,6 @@ vmm-sys-util = "0.14"
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[lints]
+workspace = true

--- a/vhost-device-template/src/vhu_foo.rs
+++ b/vhost-device-template/src/vhu_foo.rs
@@ -293,7 +293,7 @@ mod tests {
             VRING_DESC_F_NEXT as u16,
             index + 1,
         );
-        next_addr += desc_out.len() as u64;
+        next_addr += u64::from(desc_out.len());
         index += 1;
 
         mem.write_obj::<VirtioFooOutHdr>(out_hdr, desc_out.addr())
@@ -308,7 +308,7 @@ mod tests {
                 (VRING_DESC_F_WRITE | VRING_DESC_F_NEXT) as u16,
                 index + 1,
             );
-            next_addr += desc_buf.len() as u64;
+            next_addr += u64::from(desc_buf.len());
 
             mem.write(buf, desc_buf.addr()).unwrap();
             descriptors.push(desc_buf);

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -37,3 +37,6 @@ serde = { version = "1", features = ["derive"] }
 assert_matches = "1.5"
 virtio-queue = { version = "0.16", features = ["test-utils"] }
 tempfile = "3.20.0"
+
+[lints]
+workspace = true

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -563,26 +563,26 @@ mod tests {
             Error::EmptyBackendRxQ.to_string()
         );
 
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
         packet.set_type(VSOCK_TYPE_STREAM);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
         packet.set_src_cid(CID);
         packet.set_dst_cid(VSOCK_HOST_CID);
         packet.set_dst_port(VSOCK_PEER_PORT);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
         packet.set_op(VSOCK_OP_REQUEST);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
         packet.set_op(VSOCK_OP_RW);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
         packet.set_op(VSOCK_OP_RST);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
 
-        assert!(vtp.recv_pkt(&mut packet).is_ok());
+        vtp.recv_pkt(&mut packet).unwrap();
 
         // TODO: it is a nop for now
         vtp.enq_rst();
@@ -714,7 +714,7 @@ mod tests {
             .unwrap()
             .copy_from(&[0xCAu8, 0xFEu8, 0xBAu8, 0xBEu8]);
 
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
         assert!(sibling_backend.threads[0]
             .lock()
             .unwrap()
@@ -722,7 +722,7 @@ mod tests {
             .pending_raw_pkts());
 
         packet.set_dst_cid(SIBLING2_CID);
-        assert!(vtp.send_pkt(&packet).is_ok());
+        vtp.send_pkt(&packet).unwrap();
         // packet should be discarded since sibling2 is not in the same group
         assert!(!sibling2_backend.threads[0]
             .lock()
@@ -737,12 +737,12 @@ mod tests {
             // SAFETY: Safe as recvd_hdr_raw and recvd_data_raw are guaranteed to be valid.
             unsafe { VsockPacket::new(recvd_hdr_raw, Some(recvd_data_raw)).unwrap() };
 
-        assert!(sibling_backend.threads[0]
+        sibling_backend.threads[0]
             .lock()
             .unwrap()
             .thread_backend
             .recv_raw_pkt(&mut recvd_packet)
-            .is_ok());
+            .unwrap();
 
         assert_eq!(recvd_packet.type_(), VSOCK_TYPE_STREAM);
         assert_eq!(recvd_packet.src_cid(), CID);

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -508,7 +508,7 @@ impl VsockThreadBackend {
     /// Enqueue RST packets to be sent to guest.
     fn enq_rst(&mut self) {
         // TODO
-        dbg!("New guest conn error: Enqueue RST");
+        log::debug!("New guest conn error: Enqueue RST");
     }
 }
 

--- a/vhost-device-vsock/src/txbuf.rs
+++ b/vhost-device-vsock/src/txbuf.rs
@@ -147,7 +147,7 @@ mod tests {
 
         // push data into empty tx buffer
         let res_push = loc_tx_buf.push(&data);
-        assert!(res_push.is_ok());
+        res_push.unwrap();
         assert_eq!(loc_tx_buf.head, Wrapping(0));
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE));
 
@@ -158,7 +158,7 @@ mod tests {
         // head and tail wrap at full
         loc_tx_buf.head = Wrapping(CONN_TX_BUF_SIZE);
         let res_push = loc_tx_buf.push(&data);
-        assert!(res_push.is_ok());
+        res_push.unwrap();
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE * 2));
 
         // only tail wraps at full
@@ -168,7 +168,7 @@ mod tests {
         loc_tx_buf.head = Wrapping(2);
         loc_tx_buf.tail = Wrapping(CONN_TX_BUF_SIZE - 2);
         let res_push = loc_tx_buf.push(&data);
-        assert!(res_push.is_ok());
+        res_push.unwrap();
         assert_eq!(loc_tx_buf.head, Wrapping(2));
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE + 2));
         assert_eq!(loc_tx_buf.buf[0..2], buf[2..4]);
@@ -197,7 +197,7 @@ mod tests {
 
         // flush data of CONN_TX_BUF_SIZE amount
         let res_push = loc_tx_buf.push(&data);
-        assert!(res_push.is_ok());
+        res_push.unwrap();
         let res_flush = loc_tx_buf.flush_to(&mut cmp_vec);
         if let Ok(n) = res_flush {
             assert_eq!(loc_tx_buf.head, Wrapping(n as u32));
@@ -215,7 +215,7 @@ mod tests {
         loc_tx_buf.head = Wrapping(0);
         loc_tx_buf.tail = Wrapping(0);
         let res_push = loc_tx_buf.push(&data);
-        assert!(res_push.is_ok());
+        res_push.unwrap();
         cmp_vec.clear();
         loc_tx_buf.head = Wrapping(CONN_TX_BUF_SIZE / 2);
         loc_tx_buf.tail = Wrapping(CONN_TX_BUF_SIZE + (CONN_TX_BUF_SIZE / 2));

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -434,7 +434,7 @@ mod tests {
         vrings[1].set_queue_info(0x1100, 0x1200, 0x1300).unwrap();
         vrings[1].set_queue_ready(true);
 
-        assert!(backend.update_memory(mem).is_ok());
+        backend.update_memory(mem).unwrap();
 
         let queues_per_thread = backend.queues_per_thread();
         assert_eq!(queues_per_thread.len(), 1);
@@ -450,16 +450,16 @@ mod tests {
         exit.unwrap().write(1).unwrap();
 
         let ret = backend.handle_event(RX_QUEUE_EVENT, EventSet::IN, &vrings, 0);
-        assert!(ret.is_ok());
+        ret.unwrap();
 
         let ret = backend.handle_event(TX_QUEUE_EVENT, EventSet::IN, &vrings, 0);
-        assert!(ret.is_ok());
+        ret.unwrap();
 
         let ret = backend.handle_event(EVT_QUEUE_EVENT, EventSet::IN, &vrings, 0);
-        assert!(ret.is_ok());
+        ret.unwrap();
 
         let ret = backend.handle_event(BACKEND_EVENT, EventSet::IN, &vrings, 0);
-        assert!(ret.is_ok());
+        ret.unwrap();
     }
 
     #[test]

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -456,7 +456,7 @@ impl VhostUserVsockThread {
                                 .push_back(ConnMapKey::new(conn.local_port, conn.peer_port));
                         }
                         Err(e) => {
-                            dbg!("Error: {:?}", e);
+                            log::debug!("Error: {e:?}");
                         }
                     }
                     return;
@@ -743,7 +743,7 @@ impl VhostUserVsockThread {
             ) {
                 Ok(pkt) => pkt,
                 Err(e) => {
-                    dbg!("vsock: error reading TX packet: {:?}", e);
+                    log::debug!("vsock: error reading TX packet: {e:?}");
                     continue;
                 }
             };

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -252,7 +252,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                     Some(buf) => {
                         if let Err(err) = self.send_bytes(buf) {
                             // TODO: Terminate this connection
-                            dbg!("err:{:?}", err);
+                            log::debug!("err:{err:?}");
                             return Ok(());
                         }
                     }
@@ -318,12 +318,12 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                 if e.kind() == ErrorKind::WouldBlock {
                     0
                 } else {
-                    dbg!("send_bytes error: {:?}", e);
+                    log::debug!("send_bytes error: {e:?}");
                     return Err(Error::StreamWrite);
                 }
             }
             Err(e) => {
-                dbg!("send_bytes error: {:?}", e);
+                log::debug!("send_bytes error: {e:?}");
                 return Err(Error::StreamWrite);
             }
         };


### PR DESCRIPTION
### Summary of the PR

This PR enables all crates of the staging workspace to share lints. With 1.74 it is now possible to define them in `Cargo.toml`.

Note: In older versions you'll simply get a "warning: unused manifest key" when using cargo.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
