### PR TITLE
Fix for removing the handling of descriptors in audio backends

### DIFF
--- a/staging/vhost-device-sound/src/audio_backends.rs
+++ b/staging/vhost-device-sound/src/audio_backends.rs
@@ -15,14 +15,14 @@ use self::alsa::AlsaBackend;
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{device::ControlMessage, stream::Stream, BackendType, Result};
+use crate::{device::ControlMessage, stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
 
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
 
     fn read(&self, stream_id: u32) -> Result<()>;
 
-    fn set_parameters(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+    fn set_parameters(&self, _stream_id: u32, _: VirtioSndPcmSetParams) -> Result<()> {
         Ok(())
     }
 

--- a/staging/vhost-device-sound/src/audio_backends.rs
+++ b/staging/vhost-device-sound/src/audio_backends.rs
@@ -15,7 +15,7 @@ use self::alsa::AlsaBackend;
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{device::ControlMessage, stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
+use crate::{stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
 
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
@@ -30,7 +30,7 @@ pub trait AudioBackend {
         Ok(())
     }
 
-    fn release(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+    fn release(&self, _stream_id: u32) -> Result<()> {
         Ok(())
     }
 

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -30,8 +30,6 @@ use spa::{
         SPA_AUDIO_FORMAT_UNKNOWN,
     },
 };
-use virtio_queue::Descriptor;
-use vm_memory::Bytes;
 
 use super::AudioBackend;
 use crate::{
@@ -50,7 +48,6 @@ use crate::{
         VIRTIO_SND_PCM_RATE_384000, VIRTIO_SND_PCM_RATE_44100, VIRTIO_SND_PCM_RATE_48000,
         VIRTIO_SND_PCM_RATE_5512, VIRTIO_SND_PCM_RATE_64000, VIRTIO_SND_PCM_RATE_8000,
         VIRTIO_SND_PCM_RATE_88200, VIRTIO_SND_PCM_RATE_96000, VIRTIO_SND_S_BAD_MSG,
-        VIRTIO_SND_S_NOT_SUPP,
     },
     Direction, Error, Result, Stream,
 };
@@ -156,42 +153,26 @@ impl AudioBackend for PwBackend {
         Ok(())
     }
 
-    fn set_parameters(&self, stream_id: u32, mut msg: ControlMessage) -> Result<()> {
-        let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
-        let desc_request = &descriptors[0];
-        let request = msg
-            .desc_chain
-            .memory()
-            .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
-            .unwrap();
-        {
-            let stream_clone = self.stream_params.clone();
-            let mut stream_params = stream_clone.write().unwrap();
-            if let Some(st) = stream_params.get_mut(stream_id as usize) {
-                if let Err(err) = st.state.set_parameters() {
-                    log::error!("Stream {} set_parameters {}", stream_id, err);
-                    msg.code = VIRTIO_SND_S_BAD_MSG;
-                    drop(msg);
-                    return Err(Error::Stream(err));
-                } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
-                    msg.code = VIRTIO_SND_S_NOT_SUPP;
-                    drop(msg);
-                    return Err(Error::UnexpectedAudioBackendConfiguration);
-                } else {
-                    st.params.features = request.features;
-                    st.params.buffer_bytes = request.buffer_bytes;
-                    st.params.period_bytes = request.period_bytes;
-                    st.params.channels = request.channels;
-                    st.params.format = request.format;
-                    st.params.rate = request.rate;
-                }
+    fn set_parameters(&self, stream_id: u32, request: VirtioSndPcmSetParams) -> Result<()> {
+        let stream_clone = self.stream_params.clone();
+        let mut stream_params = stream_clone.write().unwrap();
+        if let Some(st) = stream_params.get_mut(stream_id as usize) {
+            if let Err(err) = st.state.set_parameters() {
+                log::error!("Stream {} set_parameters {}", stream_id, err);
+                return Err(Error::Stream(err));
+            } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
+                return Err(Error::UnexpectedAudioBackendConfiguration);
             } else {
-                msg.code = VIRTIO_SND_S_BAD_MSG;
-                drop(msg);
-                return Err(Error::StreamWithIdNotFound(stream_id));
+                st.params.features = request.features;
+                st.params.buffer_bytes = request.buffer_bytes;
+                st.params.period_bytes = request.period_bytes;
+                st.params.channels = request.channels;
+                st.params.format = request.format;
+                st.params.rate = request.rate;
             }
+        } else {
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
-        drop(msg);
 
         Ok(())
     }
@@ -592,7 +573,8 @@ mod tests {
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
     use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue, QueueOwnedT};
     use vm_memory::{
-        Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap,
+        Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
+        GuestMemoryMmap,
     };
 
     use super::{test_utils::PipewireTestHarness, *};
@@ -673,19 +655,24 @@ mod tests {
         let pw_backend = PwBackend::new(stream_params);
         assert_eq!(pw_backend.stream_hash.read().unwrap().len(), 0);
         assert_eq!(pw_backend.stream_listener.read().unwrap().len(), 0);
+        // set up minimal configuration for test
+        let request = VirtioSndPcmSetParams {
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_11025,
+            channels: 1,
+            ..Default::default()
+        };
+        pw_backend.set_parameters(0, request).unwrap();
         pw_backend.prepare(0).unwrap();
         pw_backend.start(0).unwrap();
+        pw_backend.write(0).unwrap();
+        pw_backend.read(0).unwrap();
         pw_backend.stop(0).unwrap();
-        let msg = ctrlmsg();
-        pw_backend.set_parameters(0, msg).unwrap();
         let release_msg = ctrlmsg();
         pw_backend.release(0, release_msg).unwrap();
-        pw_backend.write(0).unwrap();
 
         let streams = streams.read().unwrap();
         assert_eq!(streams[0].buffers.len(), 0);
-
-        pw_backend.read(0).unwrap();
     }
 
     #[test]
@@ -696,15 +683,12 @@ mod tests {
 
         let pw_backend = PwBackend::new(stream_params);
 
-        let msg = ctrlmsg();
-
-        _ = pw_backend.set_parameters(0, msg.clone());
-        let resp: VirtioSoundHeader = msg
-            .desc_chain
-            .memory()
-            .read_obj(msg.descriptor.addr())
-            .unwrap();
-        assert_eq!(resp.code, VIRTIO_SND_S_BAD_MSG);
+        let request = VirtioSndPcmSetParams::default();
+        let res = pw_backend.set_parameters(0, request);
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            Error::StreamWithIdNotFound(0).to_string()
+        );
 
         for res in [
             pw_backend.prepare(0),

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -33,7 +33,6 @@ use spa::{
 
 use super::AudioBackend;
 use crate::{
-    device::ControlMessage,
     stream::PCMState,
     virtio_sound::{
         VirtioSndPcmSetParams, VIRTIO_SND_PCM_FMT_A_LAW, VIRTIO_SND_PCM_FMT_FLOAT,
@@ -47,7 +46,7 @@ use crate::{
         VIRTIO_SND_PCM_RATE_192000, VIRTIO_SND_PCM_RATE_22050, VIRTIO_SND_PCM_RATE_32000,
         VIRTIO_SND_PCM_RATE_384000, VIRTIO_SND_PCM_RATE_44100, VIRTIO_SND_PCM_RATE_48000,
         VIRTIO_SND_PCM_RATE_5512, VIRTIO_SND_PCM_RATE_64000, VIRTIO_SND_PCM_RATE_8000,
-        VIRTIO_SND_PCM_RATE_88200, VIRTIO_SND_PCM_RATE_96000, VIRTIO_SND_S_BAD_MSG,
+        VIRTIO_SND_PCM_RATE_88200, VIRTIO_SND_PCM_RATE_96000,
     },
     Direction, Error, Result, Stream,
 };
@@ -478,22 +477,18 @@ impl AudioBackend for PwBackend {
         Ok(())
     }
 
-    fn release(&self, stream_id: u32, mut msg: ControlMessage) -> Result<()> {
+    fn release(&self, stream_id: u32) -> Result<()> {
         debug!("pipewire backend, release function");
         let release_result = self
             .stream_params
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| {
-                msg.code = VIRTIO_SND_S_BAD_MSG;
-                Error::StreamWithIdNotFound(stream_id)
-            })?
+            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
             .state
             .release();
         if let Err(err) = release_result {
             log::error!("Stream {} release {}", stream_id, err);
-            msg.code = VIRTIO_SND_S_BAD_MSG;
             return Err(Error::Stream(err));
         }
         let lock_guard = self.thread_loop.lock();
@@ -569,81 +564,7 @@ mod test_utils;
 
 #[cfg(test)]
 mod tests {
-    use vhost_user_backend::{VringRwLock, VringT};
-    use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue, QueueOwnedT};
-    use vm_memory::{
-        Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
-        GuestMemoryMmap,
-    };
-
     use super::{test_utils::PipewireTestHarness, *};
-    use crate::{ControlMessageKind, SoundDescriptorChain, VirtioSoundHeader};
-
-    // Prepares a single chain of descriptors for request queue
-    fn prepare_desc_chain<R: ByteValued>(
-        start_addr: GuestAddress,
-        hdr: R,
-        response_len: u32,
-    ) -> SoundDescriptorChain {
-        let mem = &GuestMemoryMmap::<()>::from_ranges(&[(start_addr, 0x1000)]).unwrap();
-        let vq = MockSplitQueue::new(mem, 16);
-        let mut next_addr = vq.desc_table().total_size() + 0x100;
-        let mut index = 0;
-
-        let desc_out = Descriptor::new(
-            next_addr,
-            size_of::<R>() as u32,
-            VRING_DESC_F_NEXT as u16,
-            index + 1,
-        );
-
-        mem.write_obj::<R>(hdr, desc_out.addr()).unwrap();
-        vq.desc_table().store(index, desc_out).unwrap();
-        next_addr += u64::from(desc_out.len());
-        index += 1;
-
-        // In response descriptor
-        let desc_in = Descriptor::new(next_addr, response_len, VRING_DESC_F_WRITE as u16, 0);
-        vq.desc_table().store(index, desc_in).unwrap();
-
-        // Put the descriptor index 0 in the first available ring position.
-        mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
-            .unwrap();
-
-        // Set `avail_idx` to 1.
-        mem.write_obj(1u16, vq.avail_addr().unchecked_add(2))
-            .unwrap();
-
-        // Create descriptor chain from pre-filled memory
-        vq.create_queue::<Queue>()
-            .unwrap()
-            .iter(GuestMemoryAtomic::new(mem.clone()).memory())
-            .unwrap()
-            .next()
-            .unwrap()
-    }
-
-    fn ctrlmsg() -> ControlMessage {
-        let hdr = VirtioSndPcmSetParams::default();
-
-        let resp_len: u32 = 1;
-        let mem = &GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let memr = GuestMemoryAtomic::new(
-            GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap(),
-        );
-        let vq = MockSplitQueue::new(mem, 16);
-        let next_addr = vq.desc_table().total_size() + 0x100;
-        let index = 0;
-        let vring = VringRwLock::new(memr, 0x1000).unwrap();
-        ControlMessage {
-            kind: ControlMessageKind::PcmInfo,
-            code: 0,
-            desc_chain: prepare_desc_chain::<VirtioSndPcmSetParams>(GuestAddress(0), hdr, resp_len),
-            descriptor: Descriptor::new(next_addr, 0x200, VRING_DESC_F_NEXT as u16, index + 1),
-            vring,
-        }
-    }
 
     #[test]
     fn test_pipewire_backend_success() {
@@ -668,9 +589,7 @@ mod tests {
         pw_backend.write(0).unwrap();
         pw_backend.read(0).unwrap();
         pw_backend.stop(0).unwrap();
-        let release_msg = ctrlmsg();
-        pw_backend.release(0, release_msg).unwrap();
-
+        pw_backend.release(0).unwrap();
         let streams = streams.read().unwrap();
         assert_eq!(streams[0].buffers.len(), 0);
     }
@@ -701,13 +620,10 @@ mod tests {
             );
         }
 
-        let msg = ctrlmsg();
-        _ = pw_backend.release(0, msg.clone());
-        let resp: VirtioSoundHeader = msg
-            .desc_chain
-            .memory()
-            .read_obj(msg.descriptor.addr())
-            .unwrap();
-        assert_eq!(resp.code, VIRTIO_SND_S_BAD_MSG);
+        let res = pw_backend.release(0);
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            Error::StreamWithIdNotFound(0).to_string()
+        );
     }
 }

--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -322,21 +322,8 @@ impl VhostUserSoundThread {
                         audio_backend
                             .read()
                             .unwrap()
-                            .set_parameters(
-                                stream_id,
-                                ControlMessage {
-                                    kind: code,
-                                    code: VIRTIO_SND_S_OK,
-                                    desc_chain,
-                                    descriptor: desc_hdr,
-                                    vring: vring.clone(),
-                                },
-                            )
+                            .set_parameters(stream_id, request)
                             .unwrap();
-
-                        // PcmSetParams needs check valid formats/rates; the audio backend will
-                        // reply when it drops the ControlMessage.
-                        continue;
                     }
                 }
                 ControlMessageKind::PcmPrepare => {

--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -29,7 +29,7 @@ use vmm_sys_util::{
 use crate::{
     audio_backends::{alloc_audio_backend, AudioBackend},
     stream::{Buffer, Error as StreamError, Stream},
-    virtio_sound::{self, *},
+    virtio_sound::*,
     ControlMessageKind, Direction, Error, IOMessage, Result, SoundConfig,
 };
 
@@ -351,24 +351,7 @@ impl VhostUserSoundThread {
                         log::error!("{}", Error::from(StreamError::InvalidStreamId(stream_id)));
                         resp.code = VIRTIO_SND_S_BAD_MSG.into();
                     } else {
-                        audio_backend
-                            .write()
-                            .unwrap()
-                            .release(
-                                stream_id,
-                                ControlMessage {
-                                    kind: code,
-                                    code: VIRTIO_SND_S_OK,
-                                    desc_chain,
-                                    descriptor: desc_hdr,
-                                    vring: vring.clone(),
-                                },
-                            )
-                            .unwrap();
-
-                        // PcmRelease needs to flush IO messages; the audio backend will reply when
-                        // it drops the ControlMessage.
-                        continue;
+                        audio_backend.write().unwrap().release(stream_id).unwrap();
                     }
                 }
                 ControlMessageKind::PcmStart => {
@@ -769,62 +752,6 @@ impl VhostUserBackend for VhostUserSoundBackend {
 
     fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
         self.exit_event.try_clone().ok()
-    }
-}
-
-#[cfg_attr(test, derive(Clone))]
-pub struct ControlMessage {
-    pub kind: ControlMessageKind,
-    pub code: u32,
-    pub desc_chain: SoundDescriptorChain,
-    pub descriptor: virtio_queue::Descriptor,
-    pub vring: VringRwLock,
-}
-
-impl std::fmt::Debug for ControlMessage {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct(stringify!(ControlMessage))
-            .field("kind", &self.kind)
-            .field("code", &self.code)
-            .finish()
-    }
-}
-
-impl Drop for ControlMessage {
-    fn drop(&mut self) {
-        log::trace!(
-            "dropping ControlMessage {:?} reply = {}",
-            self.kind,
-            match self.code {
-                virtio_sound::VIRTIO_SND_S_OK => "VIRTIO_SND_S_OK",
-                virtio_sound::VIRTIO_SND_S_BAD_MSG => "VIRTIO_SND_S_BAD_MSG",
-                virtio_sound::VIRTIO_SND_S_NOT_SUPP => "VIRTIO_SND_S_NOT_SUPP",
-                virtio_sound::VIRTIO_SND_S_IO_ERR => "VIRTIO_SND_S_IO_ERR",
-                _ => "other",
-            }
-        );
-        let resp = VirtioSoundHeader {
-            code: self.code.into(),
-        };
-
-        if let Err(err) = self
-            .desc_chain
-            .memory()
-            .write_obj(resp, self.descriptor.addr())
-        {
-            log::error!("Error::DescriptorWriteFailed: {}", err);
-            return;
-        }
-        if self
-            .vring
-            .add_used(self.desc_chain.head_index(), resp.as_slice().len() as u32)
-            .is_err()
-        {
-            log::error!("Couldn't add used");
-        }
-        if self.vring.signal_used_queue().is_err() {
-            log::error!("Couldn't signal used queue");
-        }
     }
 }
 

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -118,6 +118,10 @@ pub enum Error {
     SoundReqMissingData,
     #[error("Audio backend not supported")]
     AudioBackendNotSupported,
+    #[error("Audio backend unexpected error")]
+    UnexpectedAudioBackendError,
+    #[error("Audio backend configuration not supported")]
+    UnexpectedAudioBackendConfiguration,
     #[error("No memory configured")]
     NoMemoryConfigured,
     #[error("Invalid virtio_snd_hdr size, expected: {0}, found: {1}")]

--- a/staging/vhost-device-sound/src/stream.rs
+++ b/staging/vhost-device-sound/src/stream.rs
@@ -11,6 +11,8 @@ use crate::{virtio_sound::*, Direction, IOMessage, SUPPORTED_FORMATS, SUPPORTED_
 /// Stream errors.
 #[derive(Debug, ThisError, PartialEq, Eq)]
 pub enum Error {
+    #[error("Guest driver request in an invalid stream state {0}")]
+    InvalidState(PCMState),
     #[error("Guest driver request an invalid stream state transition from {0} to {1}.")]
     InvalidStateTransition(PCMState, PCMState),
     #[error("Guest requested an invalid stream id: {0}")]


### PR DESCRIPTION
### Summary of the PR
This PR is an effort to prepare virtio-sound device to be independent of the descriptor distribution by using the `descriptor_utils` module or something like that. I thought that something should be done before a PR that uses such a module. This PR aims at removing any handling of descriptors in audio backends. To do this, the PR does the following:
* limit the need for sending notifications to guests from the audio backends only when it is strictly required. For example, this PR removes the need of the Control Message parameter in the `set_param()` and `release()` methods. This also cleans up the tests in the pw audio backend regarding descriptors.
* remove the use of a runner thread in the alsa backend. By removing the runner thread, the notification to guests can be sent by the device after the audio backend has processed the request so there is no need to have a Control message as parameter of the method nor an extra thread. Also, it is possible to propagate the result of the operation from the audio backend to the device. Before this PR, there were no mechanism to get the result from the runner thread. Now, all that processing shall happen only once for all backends in the device.

Thanks for reviewing! 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
