### PR TITLE
vhost-device: Don't return bool unnecessarily

### DIFF
--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -129,7 +129,7 @@ impl VhostUserSoundThread {
         &self,
         vring: &VringRwLock,
         audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
-    ) -> IoResult<bool> {
+    ) -> IoResult<()> {
         let Some(ref atomic_mem) = self.mem else {
             return Err(Error::NoMemoryConfigured.into());
         };
@@ -141,7 +141,7 @@ impl VhostUserSoundThread {
             .collect();
 
         if requests.is_empty() {
-            return Ok(true);
+            return Ok(());
         }
 
         // Reply to some requests right away, and defer others to the audio backend (for
@@ -445,12 +445,12 @@ impl VhostUserSoundThread {
             log::error!("Couldn't signal used queue");
         }
 
-        Ok(!any)
+        Ok(())
     }
 
-    fn process_event(&self, _vring: &VringRwLock) -> IoResult<bool> {
+    fn process_event(&self, _vring: &VringRwLock) -> IoResult<()> {
         log::trace!("process_event");
-        Ok(false)
+        Ok(())
     }
 
     fn process_io(
@@ -458,7 +458,7 @@ impl VhostUserSoundThread {
         vring: &VringRwLock,
         audio_backend: &RwLock<Box<dyn AudioBackend + Send + Sync>>,
         direction: Direction,
-    ) -> IoResult<bool> {
+    ) -> IoResult<()> {
         let Some(ref atomic_mem) = self.mem else {
             return Err(Error::NoMemoryConfigured.into());
         };
@@ -470,7 +470,7 @@ impl VhostUserSoundThread {
             .collect();
 
         if requests.is_empty() {
-            return Ok(true);
+            return Ok(());
         }
 
         // Instead of counting descriptor chain lengths, encode the "parsing" logic in
@@ -592,7 +592,7 @@ impl VhostUserSoundThread {
             }
         }
 
-        Ok(false)
+        Ok(())
     }
 }
 

--- a/staging/vhost-device-video/src/vhu_video_thread.rs
+++ b/staging/vhost-device-video/src/vhu_video_thread.rs
@@ -472,7 +472,7 @@ impl VhostUserVideoThread {
     }
 
     /// Process the requests in the vring and dispatch replies
-    pub fn process_command_queue(&mut self, vring: &VringRwLock) -> Result<bool> {
+    pub fn process_command_queue(&mut self, vring: &VringRwLock) -> Result<()> {
         let requests: Vec<_> = vring
             .get_mut()
             .get_queue_mut()
@@ -487,10 +487,10 @@ impl VhostUserVideoThread {
                 .map_err(|_| VuVideoError::SendNotificationFailed)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 
-    fn process_event(&self, stream_id: u32, eventq: &VringRwLock) -> Result<bool> {
+    fn process_event(&self, stream_id: u32, eventq: &VringRwLock) -> Result<()> {
         if let Some(event) = self.backend.read().unwrap().dequeue_event(stream_id) {
             let desc_chain = eventq
                 .get_mut()
@@ -516,10 +516,10 @@ impl VhostUserVideoThread {
                 .map_err(|_| VuVideoError::SendNotificationFailed)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 
-    fn send_dqbuf(&mut self, stream_id: u32, queue_type: video::QueueType) -> Result<bool> {
+    fn send_dqbuf(&mut self, stream_id: u32, queue_type: video::QueueType) -> Result<()> {
         let dqbuf_data = match self
             .backend
             .read()
@@ -527,7 +527,7 @@ impl VhostUserVideoThread {
             .dequeue_resource(stream_id, queue_type)
         {
             Some(buf_data) => buf_data,
-            None => return Ok(false),
+            None => return Ok(()),
         };
         let mut backend = self.backend.write().unwrap();
         let stream = backend.stream_mut(&stream_id).unwrap();
@@ -544,10 +544,10 @@ impl VhostUserVideoThread {
             .unwrap();
         resource.ready_with(dqbuf_data.flags, dqbuf_data.size);
 
-        Ok(true)
+        Ok(())
     }
 
-    pub fn process_video_event(&mut self, eventq: &VringRwLock) -> Result<bool> {
+    pub fn process_video_event(&mut self, eventq: &VringRwLock) -> Result<()> {
         let mut epoll_events = vec![PollerEvent::default(); 1024];
         let events = self.poller.wait(epoll_events.as_mut_slice(), 0).unwrap();
         for event in events {
@@ -565,7 +565,7 @@ impl VhostUserVideoThread {
             }
         }
 
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -257,7 +257,7 @@ impl<D: I2cDevice> VhostUserI2cBackend<D> {
     }
 
     /// Process the requests in the vring and dispatch replies
-    fn process_queue(&self, vring: &VringRwLock) -> Result<bool> {
+    fn process_queue(&self, vring: &VringRwLock) -> Result<()> {
         let requests: Vec<_> = vring
             .get_mut()
             .get_queue_mut()
@@ -272,7 +272,7 @@ impl<D: I2cDevice> VhostUserI2cBackend<D> {
                 .map_err(|_| Error::NotificationFailed)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -182,7 +182,7 @@ impl<T: ReadVolatile> VuRngBackend<T> {
     }
 
     /// Process the requests in the vring and dispatch replies
-    fn process_queue(&mut self, vring: &VringRwLock) -> Result<bool> {
+    fn process_queue(&mut self, vring: &VringRwLock) -> Result<()> {
         let requests: Vec<_> = vring
             .get_mut()
             .get_queue_mut()
@@ -197,7 +197,7 @@ impl<T: ReadVolatile> VuRngBackend<T> {
                 .map_err(|_| VuRngError::SendNotificationFailed)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 }
 

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -136,9 +136,9 @@ impl VuScmiBackend {
         &mut self,
         requests: Vec<ScmiDescriptorChain>,
         vring: &VringRwLock,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         if requests.is_empty() {
-            return Ok(true);
+            return Ok(());
         }
 
         for desc_chain in requests {
@@ -230,7 +230,7 @@ impl VuScmiBackend {
                 error!("Couldn't return used descriptors to the ring");
             }
         }
-        Ok(true)
+        Ok(())
     }
 
     fn process_command_queue(&mut self, vring: &VringRwLock) -> Result<()> {
@@ -271,7 +271,7 @@ impl VuScmiBackend {
         &mut self,
         requests: Vec<ScmiDescriptorChain>,
         _vring: &VringRwLock,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         // The requests here are notifications from the guest about adding
         // fresh buffers for the used ring. The Linux driver allocates 256
         // buffers for the event queue initially (arriving here in several
@@ -295,7 +295,7 @@ impl VuScmiBackend {
 
             self.event_descriptors.push(desc_chain);
         }
-        Ok(true)
+        Ok(())
     }
 
     fn process_event_queue(&mut self, vring: &VringRwLock) -> Result<()> {


### PR DESCRIPTION
Since everyone copied the first bits of code from the I2C crate, the same issue is present almost everywhere. The returned value isn't checked at all by the callers. Stop returning bool unnecessarily.
