### PR TITLE
staging/tests: make the build blocking for CI

### DIFF
--- a/.buildkite/staging-tests.json
+++ b/.buildkite/staging-tests.json
@@ -3,7 +3,7 @@
     {
       "test_name": "staging: build-gnu",
       "command": "cd staging && RUSTFLAGS=\"-D warnings\" cargo build --release",
-      "soft_fail": "true",
+      "soft_fail": "false",
       "platform": [
         "x86_64",
         "aarch64"


### PR DESCRIPTION
In some cases, we don't realize that changes can break crates in `staging` because CI is not blocking.

Let's make sure that at least the build of crates in `staging` is blocking, while the rest (clippy, coverage, musl, etc.) remain non-blocking for CI.

Suggested-by: Erik Schilling <erik.schilling@linaro.org>
