### PR TITLE
Remove runner thread in alsa

### DIFF
--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -36,19 +36,20 @@ impl From<Direction> for alsa::Direction {
 
 type AResult<T> = std::result::Result<T, alsa::Error>;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct AlsaBackend {
-    sender: Arc<Mutex<Sender<AlsaAction>>>,
+    senders: Vec<Sender<bool>>,
     streams: Arc<RwLock<Vec<Stream>>>,
+    pcms: Vec<Arc<Mutex<PCM>>>,
 }
 
-#[derive(Debug)]
-enum AlsaAction {
-    SetParameters(usize, ControlMessage),
-    Prepare(usize),
-    Release(usize, ControlMessage),
-    Start(usize),
-    DoWork(usize),
+impl std::fmt::Debug for AlsaBackend {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct(stringify!(AlsaBackend))
+            .field("senders_no", &self.senders.len())
+            .field("pcm_no", &self.pcms.len())
+            .finish_non_exhaustive()
+    }
 }
 
 fn update_pcm(
@@ -492,245 +493,140 @@ fn alsa_worker(
 
 impl AlsaBackend {
     pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
-        let (sender, receiver) = channel();
-        let sender = Arc::new(Mutex::new(sender));
-        let streams2 = Arc::clone(&streams);
+        let streams_no = streams.read().unwrap().len();
 
-        thread::spawn(move || {
-            if let Err(err) = Self::run(streams2, receiver) {
-                log::error!("Main thread exited with error: {}", err);
-            }
-        });
+        let mut vec = Vec::with_capacity(streams_no);
+        let mut senders = Vec::with_capacity(streams_no);
 
-        Self { sender, streams }
-    }
+        for i in 0..streams_no {
+            let (sender, receiver) = channel();
+            // Initialize with a dummy value, which will be updated every time we call
+            // `update_pcm`.
+            let pcm = Arc::new(Mutex::new(
+                PCM::new("default", Direction::Output.into(), false).unwrap(),
+            ));
 
-    #[allow(clippy::cognitive_complexity)]
-    fn run(
-        streams: Arc<RwLock<Vec<Stream>>>,
-        receiver: Receiver<AlsaAction>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let streams_no: usize;
+            let mtx = Arc::clone(&pcm);
+            let streams = Arc::clone(&streams);
+            // create worker
+            thread::spawn(move || {
+                while let Err(err) = alsa_worker(mtx.clone(), streams.clone(), &receiver, i) {
+                    log::error!(
+                        "Worker thread exited with error: {}, sleeping for 500ms",
+                        err
+                    );
+                    sleep(Duration::from_millis(500));
+                }
+            });
 
-        let (mut pcms, senders) = {
-            streams_no = streams.read().unwrap().len();
-            let mut vec = Vec::with_capacity(streams_no);
-            let mut senders = Vec::with_capacity(streams_no);
-            for i in 0..streams_no {
-                let (sender, receiver) = channel();
-
-                // Initialize with a dummy value, which will be updated every time we call
-                // `update_pcm`.
-                let pcm = Arc::new(Mutex::new(PCM::new(
-                    "default",
-                    Direction::Output.into(),
-                    false,
-                )?));
-
-                let mtx = Arc::clone(&pcm);
-                let streams = Arc::clone(&streams);
-                thread::spawn(move || {
-                    // TODO: exponential backoff? send fatal error to daemon?
-                    while let Err(err) = alsa_worker(mtx.clone(), streams.clone(), &receiver, i) {
-                        log::error!(
-                            "Worker thread exited with error: {}, sleeping for 500ms",
-                            err
-                        );
-                        sleep(Duration::from_millis(500));
-                    }
-                });
-
-                senders.push(sender);
-                vec.push(pcm);
-            }
-            (vec, senders)
-        };
-        for (i, pcm) in pcms.iter_mut().enumerate() {
-            update_pcm(pcm, i, &streams)?;
+            vec.push(pcm);
+            senders.push(sender);
         }
 
-        while let Ok(action) = receiver.recv() {
-            match action {
-                AlsaAction::DoWork(stream_id) => {
-                    if stream_id >= streams_no {
-                        log::error!(
-                            "Received DoWork action for stream id {} but there are only {} PCM \
-                             streams.",
-                            stream_id,
-                            pcms.len()
-                        );
-                        continue;
-                    };
-                    if matches!(
-                        streams.write().unwrap()[stream_id].state,
-                        PCMState::Start | PCMState::Prepare
-                    ) {
-                        senders[stream_id].send(true).unwrap();
-                    }
-                }
-                AlsaAction::Start(stream_id) => {
-                    if stream_id >= streams_no {
-                        log::error!(
-                            "Received Start action for stream id {} but there are only {} PCM \
-                             streams.",
-                            stream_id,
-                            pcms.len()
-                        );
-                        continue;
-                    };
-                    if let Err(err) = streams.write().unwrap()[stream_id].state.start() {
-                        log::error!("Stream {}: {}", stream_id, err);
-                        continue;
-                    }
-                    let pcm = &pcms[stream_id];
-                    let lck = pcm.lock().unwrap();
-                    if !matches!(lck.state(), State::Running) {
-                        // Fail gracefully if Start does not succeed.
-                        if let Err(err) = lck.start() {
-                            log::error!(
-                                "Could not start stream {}; ALSA returned: {}",
-                                stream_id,
-                                err
-                            );
-                        }
-                    }
-                    senders[stream_id].send(true).unwrap();
-                }
-                AlsaAction::Prepare(stream_id) => {
-                    if stream_id >= streams_no {
-                        log::error!(
-                            "Received Prepare action for stream id {} but there are only {} PCM \
-                             streams.",
-                            stream_id,
-                            pcms.len()
-                        );
-                        continue;
-                    };
-                    if let Err(err) = streams.write().unwrap()[stream_id].state.prepare() {
-                        log::error!("Stream {}: {}", stream_id, err);
-                        continue;
-                    }
-                    let pcm = &pcms[stream_id];
-                    let lck = pcm.lock().unwrap();
-                    if !matches!(lck.state(), State::Running) {
-                        // Fail gracefully if Prepare does not succeed.
-                        if let Err(err) = lck.prepare() {
-                            log::error!(
-                                "Could not prepare stream {}; ALSA returned: {}",
-                                stream_id,
-                                err
-                            );
-                        }
-                    }
-                }
-                AlsaAction::Release(stream_id, mut msg) => {
-                    if stream_id >= streams_no {
-                        log::error!(
-                            "Received Release action for stream id {} but there are only {} PCM \
-                             streams.",
-                            stream_id,
-                            pcms.len()
-                        );
-                        msg.code = VIRTIO_SND_S_BAD_MSG;
-                        continue;
-                    };
-                    // Stop worker thread
-                    senders[stream_id].send(false).unwrap();
-                    let mut streams = streams.write().unwrap();
-                    if let Err(err) = streams[stream_id].state.release() {
-                        log::error!("Stream {}: {}", stream_id, err);
-                        msg.code = VIRTIO_SND_S_BAD_MSG;
-                    }
-                    // Drop pending stream buffers to complete pending I/O messages
-                    //
-                    // This will release buffers even if state transition is invalid. If it is
-                    // invalid, we won't be in a valid device state anyway so better to get rid of
-                    // them and free the virt queue.
-                    std::mem::take(&mut streams[stream_id].buffers);
-                }
-                AlsaAction::SetParameters(stream_id, mut msg) => {
-                    if stream_id >= streams_no {
-                        log::error!(
-                            "Received SetParameters action for stream id {} but there are only {} \
-                             PCM streams.",
-                            stream_id,
-                            pcms.len()
-                        );
-                        msg.code = VIRTIO_SND_S_BAD_MSG;
-                        continue;
-                    };
-                    let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
-                    let desc_request = &descriptors[0];
-                    let request = msg
-                        .desc_chain
-                        .memory()
-                        .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
-                        .unwrap();
-                    {
-                        let mut streams = streams.write().unwrap();
-                        let st = &mut streams[stream_id];
-                        if let Err(err) = st.state.set_parameters() {
-                            log::error!("Stream {} set_parameters {}", stream_id, err);
-                            msg.code = VIRTIO_SND_S_BAD_MSG;
-                            continue;
-                        } else if !st.supports_format(request.format)
-                            || !st.supports_rate(request.rate)
-                        {
-                            msg.code = VIRTIO_SND_S_NOT_SUPP;
-                            continue;
-                        } else {
-                            st.params.buffer_bytes = request.buffer_bytes;
-                            st.params.period_bytes = request.period_bytes;
-                            st.params.features = request.features;
-                            st.params.channels = request.channels;
-                            st.params.format = request.format;
-                            st.params.rate = request.rate;
-                        }
-                        // Manually drop msg for faster response: the kernel has a timeout.
-                        drop(msg);
-                    }
-                    update_pcm(&pcms[stream_id], stream_id, &streams)?;
-                }
-            }
+        for (i, pcm) in vec.iter_mut().enumerate() {
+            update_pcm(pcm, i, &streams).unwrap();
         }
 
-        Ok(())
-    }
-}
-
-macro_rules! send_action {
-    ($($fn_name:ident $action:tt),+$(,)?) => {
-        $(
-            fn $fn_name(&self, id: u32) -> CrateResult<()> {
-                self.sender
-                    .lock()
-                    .unwrap()
-                    .send(AlsaAction::$action(id as usize))
-                    .unwrap();
-                Ok(())
-            }
-        )*
-    };
-    ($(ctrl $fn_name:ident $action:tt),+$(,)?) => {
-        $(
-            fn $fn_name(&self, id: u32, msg: ControlMessage) -> CrateResult<()> {
-                self.sender
-                    .lock()
-                    .unwrap()
-                    .send(AlsaAction::$action(id as usize, msg))
-                    .unwrap();
-                Ok(())
-            }
-        )*
+        Self {
+            senders,
+            streams,
+            pcms: vec,
+        }
     }
 }
 
 impl AudioBackend for AlsaBackend {
-    send_action! {
-        write DoWork,
-        read DoWork,
-        prepare Prepare,
-        start Start,
+    fn read(&self, stream_id: u32) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received DoWork action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len()
+            );
+        }
+        if matches!(
+            self.streams.write().unwrap()[stream_id as usize].state,
+            PCMState::Start | PCMState::Prepare
+        ) {
+            self.senders[stream_id as usize].send(true).unwrap();
+        }
+        Ok(())
+    }
+
+    fn write(&self, stream_id: u32) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received DoWork action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len()
+            );
+        }
+        if matches!(
+            self.streams.write().unwrap()[stream_id as usize].state,
+            PCMState::Start | PCMState::Prepare
+        ) {
+            self.senders[stream_id as usize].send(true).unwrap();
+        }
+        Ok(())
+    }
+
+    fn start(&self, stream_id: u32) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received Start action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len()
+            );
+        }
+        if let Err(err) = self.streams.write().unwrap()[stream_id as usize]
+            .state
+            .start()
+        {
+            log::error!("Stream {}: {}", stream_id, err);
+        }
+        let pcm = &self.pcms[stream_id as usize];
+        let lck = pcm.lock().unwrap();
+        if !matches!(lck.state(), State::Running) {
+            // Fail gracefully if Start does not succeed.
+            if let Err(err) = lck.start() {
+                log::error!(
+                    "Could not start stream {}; ALSA returned: {}",
+                    stream_id,
+                    err
+                );
+            }
+        }
+        self.senders[stream_id as usize].send(true).unwrap();
+        Ok(())
+    }
+
+    fn prepare(&self, stream_id: u32) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received Prepare action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len() as u32
+            );
+        }
+        if let Err(err) = self.streams.write().unwrap()[stream_id as usize]
+            .state
+            .prepare()
+        {
+            log::error!("Stream {}: {}", stream_id, err);
+        }
+        let pcm = &self.pcms[stream_id as usize];
+        let lck = pcm.lock().unwrap();
+        if !matches!(lck.state(), State::Running) {
+            // Fail gracefully if Prepare does not succeed.
+            if let Err(err) = lck.prepare() {
+                log::error!(
+                    "Could not prepare stream {}; ALSA returned: {}",
+                    stream_id,
+                    err
+                );
+            }
+        }
+        Ok(())
     }
 
     fn stop(&self, id: u32) -> CrateResult<()> {
@@ -746,8 +642,72 @@ impl AudioBackend for AlsaBackend {
         Ok(())
     }
 
-    send_action! {
-        ctrl set_parameters SetParameters,
-        ctrl release Release,
+    fn set_parameters(&self, stream_id: u32, mut msg: ControlMessage) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received SetParameters action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len() as u32
+            );
+            msg.code = VIRTIO_SND_S_BAD_MSG;
+        }
+        let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
+        let desc_request = &descriptors[0];
+        let request = msg
+            .desc_chain
+            .memory()
+            .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
+            .unwrap();
+        {
+            let mut streams = self.streams.write().unwrap();
+            let st = &mut streams[stream_id as usize];
+            if let Err(err) = st.state.set_parameters() {
+                log::error!("Stream {} set_parameters {}", stream_id, err);
+                msg.code = VIRTIO_SND_S_BAD_MSG;
+            } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
+                msg.code = VIRTIO_SND_S_NOT_SUPP;
+            } else {
+                st.params.buffer_bytes = request.buffer_bytes;
+                st.params.period_bytes = request.period_bytes;
+                st.params.features = request.features;
+                st.params.channels = request.channels;
+                st.params.format = request.format;
+                st.params.rate = request.rate;
+            }
+            // Manually drop msg for faster response: the kernel has a timeout.
+            drop(msg);
+        }
+        update_pcm(
+            &self.pcms[stream_id as usize],
+            stream_id as usize,
+            &self.streams,
+        )
+        .unwrap();
+        Ok(())
+    }
+
+    fn release(&self, stream_id: u32, mut msg: ControlMessage) -> CrateResult<()> {
+        if stream_id >= self.streams.read().unwrap().len() as u32 {
+            log::error!(
+                "Received Release action for stream id {} but there are only {} PCM streams.",
+                stream_id,
+                self.streams.read().unwrap().len() as u32
+            );
+            msg.code = VIRTIO_SND_S_BAD_MSG;
+        }
+        // Stop worker thread
+        self.senders[stream_id as usize].send(false).unwrap();
+        let mut streams = self.streams.write().unwrap();
+        if let Err(err) = streams[stream_id as usize].state.release() {
+            log::error!("Stream {}: {}", stream_id, err);
+            msg.code = VIRTIO_SND_S_BAD_MSG;
+        }
+        // Drop pending stream buffers to complete pending I/O messages
+        //
+        // This will release buffers even if state transition is invalid. If it is
+        // invalid, we won't be in a valid device state anyway so better to get rid of
+        // them and free the virt queue.
+        std::mem::take(&mut streams[stream_id as usize].buffers);
+        Ok(())
     }
 }

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -22,7 +22,7 @@ use super::AudioBackend;
 use crate::{
     stream::{PCMState, Stream},
     virtio_sound::{self, VirtioSndPcmSetParams, VIRTIO_SND_S_BAD_MSG, VIRTIO_SND_S_NOT_SUPP},
-    ControlMessage, Direction, Result as CrateResult,
+    ControlMessage, Direction, Error, Result as CrateResult,
 };
 
 impl From<Direction> for alsa::Direction {
@@ -543,12 +543,18 @@ impl AudioBackend for AlsaBackend {
                 stream_id,
                 self.streams.read().unwrap().len()
             );
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
         if matches!(
-            self.streams.write().unwrap()[stream_id as usize].state,
+            self.streams.read().unwrap()[stream_id as usize].state,
             PCMState::Start | PCMState::Prepare
         ) {
             self.senders[stream_id as usize].send(true).unwrap();
+        } else {
+            return Err(Error::Stream(crate::stream::Error::InvalidState(
+                "read",
+                self.streams.read().unwrap()[stream_id as usize].state,
+            )));
         }
         Ok(())
     }
@@ -560,12 +566,18 @@ impl AudioBackend for AlsaBackend {
                 stream_id,
                 self.streams.read().unwrap().len()
             );
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
         if matches!(
-            self.streams.write().unwrap()[stream_id as usize].state,
+            self.streams.read().unwrap()[stream_id as usize].state,
             PCMState::Start | PCMState::Prepare
         ) {
             self.senders[stream_id as usize].send(true).unwrap();
+        } else {
+            return Err(Error::Stream(crate::stream::Error::InvalidState(
+                "write",
+                self.streams.read().unwrap()[stream_id as usize].state,
+            )));
         }
         Ok(())
     }
@@ -577,12 +589,13 @@ impl AudioBackend for AlsaBackend {
                 stream_id,
                 self.streams.read().unwrap().len()
             );
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
         if let Err(err) = self.streams.write().unwrap()[stream_id as usize]
             .state
             .start()
         {
-            log::error!("Stream {}: {}", stream_id, err);
+            return Err(Error::Stream(err));
         }
         let pcm = &self.pcms[stream_id as usize];
         let lck = pcm.lock().unwrap();
@@ -594,6 +607,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
+                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
             }
         }
         self.senders[stream_id as usize].send(true).unwrap();
@@ -607,12 +621,14 @@ impl AudioBackend for AlsaBackend {
                 stream_id,
                 self.streams.read().unwrap().len() as u32
             );
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
         if let Err(err) = self.streams.write().unwrap()[stream_id as usize]
             .state
             .prepare()
         {
             log::error!("Stream {}: {}", stream_id, err);
+            return Err(Error::Stream(err));
         }
         let pcm = &self.pcms[stream_id as usize];
         let lck = pcm.lock().unwrap();
@@ -624,6 +640,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
+                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
             }
         }
         Ok(())
@@ -650,6 +667,7 @@ impl AudioBackend for AlsaBackend {
                 self.streams.read().unwrap().len() as u32
             );
             msg.code = VIRTIO_SND_S_BAD_MSG;
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
         let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
         let desc_request = &descriptors[0];
@@ -664,8 +682,10 @@ impl AudioBackend for AlsaBackend {
             if let Err(err) = st.state.set_parameters() {
                 log::error!("Stream {} set_parameters {}", stream_id, err);
                 msg.code = VIRTIO_SND_S_BAD_MSG;
+                return Err(Error::Stream(err));
             } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
                 msg.code = VIRTIO_SND_S_NOT_SUPP;
+                return Err(Error::UnexpectedAudioBackendConfiguration);
             } else {
                 st.params.buffer_bytes = request.buffer_bytes;
                 st.params.period_bytes = request.period_bytes;
@@ -694,14 +714,17 @@ impl AudioBackend for AlsaBackend {
                 self.streams.read().unwrap().len() as u32
             );
             msg.code = VIRTIO_SND_S_BAD_MSG;
+            return Err(Error::StreamWithIdNotFound(stream_id));
         }
-        // Stop worker thread
-        self.senders[stream_id as usize].send(false).unwrap();
         let mut streams = self.streams.write().unwrap();
         if let Err(err) = streams[stream_id as usize].state.release() {
             log::error!("Stream {}: {}", stream_id, err);
             msg.code = VIRTIO_SND_S_BAD_MSG;
+            drop(msg);
+            return Err(Error::Stream(err));
         }
+        // Stop worker thread
+        self.senders[stream_id as usize].send(false).unwrap();
         // Drop pending stream buffers to complete pending I/O messages
         //
         // This will release buffers even if state transition is invalid. If it is

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -118,6 +118,10 @@ pub enum Error {
     SoundReqMissingData,
     #[error("Audio backend not supported")]
     AudioBackendNotSupported,
+    #[error("Audio backend unexpected error: {0}")]
+    UnexpectedAudioBackendError(String),
+    #[error("Audio backend configuration not supported")]
+    UnexpectedAudioBackendConfiguration,
     #[error("No memory configured")]
     NoMemoryConfigured,
     #[error("Invalid virtio_snd_hdr size, expected: {0}, found: {1}")]

--- a/staging/vhost-device-sound/src/stream.rs
+++ b/staging/vhost-device-sound/src/stream.rs
@@ -11,6 +11,8 @@ use crate::{virtio_sound::*, Direction, IOMessage, SUPPORTED_FORMATS, SUPPORTED_
 /// Stream errors.
 #[derive(Debug, ThisError, PartialEq, Eq)]
 pub enum Error {
+    #[error("Guest driver request {0} in an invalid stream state {1}")]
+    InvalidState(&'static str, PCMState),
     #[error("Guest driver request an invalid stream state transition from {0} to {1}.")]
     InvalidStateTransition(PCMState, PCMState),
     #[error("Guest requested an invalid stream id: {0}")]


### PR DESCRIPTION
### Summary of the PR

This PR is the result of splitting https://github.com/rust-vmm/vhost-device/pull/556. This PR addresses the required changes to remove the runner thread in the ALSA backend. Also, it propagates the errors from the audio backed  to the device. Finally, this PR prepares the ALSA backend to get rid of the Control Message in a following PR.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
