### PR TITLE
scmi: use PathBuf for socket path

### DIFF
--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -587,7 +587,7 @@ mod tests {
 
     fn make_backend() -> VuScmiBackend {
         let config = VuScmiConfig {
-            socket_path: "/foo/scmi.sock".to_owned(),
+            socket_path: "/foo/scmi.sock".into(),
             devices: vec![],
         };
         VuScmiBackend::new(&config).unwrap()


### PR DESCRIPTION
clap can parse a PathBuf directly from the command line arguments, and paths are not always UTF-8. Use PathBuf instead of a String to allow for all valid filesystem paths.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
