### PR TITLE
scmi: make socket_path required

### DIFF
--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -189,7 +189,7 @@ pub fn available_devices() -> NameDeviceMapping {
     devices
 }
 
-fn devices_help() -> String {
+pub fn devices_help() -> String {
     let mut help = String::new();
     writeln!(help, "Available devices:").unwrap();
     for (name, specification) in available_devices().iter() {
@@ -214,11 +214,6 @@ fn devices_help() -> String {
     )
     .unwrap();
     help
-}
-
-pub fn print_devices_help() {
-    let help = devices_help();
-    println!("{}", help);
 }
 
 // Common sensor infrastructure


### PR DESCRIPTION
~~Depends on PR #571~~

### Summary of the PR

Use clap's derive attributes to print device help instead of doing it
manually with the parsed arguments.

#### Previous output

```text
Usage: vhost-device-scmi [OPTIONS]

Options:
  -s, --socket-path <SOCKET_PATH>  vhost-user socket to use (required)
  -d, --device <DEVICE>...         Devices to expose
      --help-devices               Print help on available devices
  -h, --help                       Print help
```

#### New output

```text
vhost-user SCMI backend device

Usage: vhost-device-scmi [OPTIONS] --socket-path <SOCKET_PATH>

Options:
  -s, --socket-path <SOCKET_PATH>  vhost-user socket to use
  -d, --device <DEVICE>...         Devices to expose
  -h, --help                       Print help
  -V, --version                    Print version

Available devices:

- iio: industrial I/O sensor
  Parameters:
  - path: path to the device directory (e.g. /sys/bus/iio/devices/iio:device0)
  - channel: prefix of the device type (e.g. in_accel)
  - name: an optional name of the sensor, max. 15 characters

- fake: fake accelerometer
  A simple 3-axes sensor providing fake pre-defined values.
  Parameters:
  - name: an optional name of the sensor, max. 15 characters

Device specification example:
--device iio,path=/sys/bus/iio/devices/iio:device0,channel=in_accel
```


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
