### PR TITLE
sound/pipewire: stop threadloop during drop

### DIFF
--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -129,6 +129,12 @@ impl PwBackend {
     }
 }
 
+impl Drop for PwBackend {
+    fn drop(&mut self) {
+        self.thread_loop.stop();
+    }
+}
+
 impl AudioBackend for PwBackend {
     fn write(&self, stream_id: u32) -> Result<()> {
         if !matches!(
@@ -528,7 +534,6 @@ impl AudioBackend for PwBackend {
         stream_hash.remove(&stream_id);
         stream_listener.remove(&stream_id);
         lock_guard.unlock();
-        self.thread_loop.stop();
         Ok(())
     }
 


### PR DESCRIPTION
## Summary of the PR
The threadloop has to be stopped only when the audio backend is dropped otherwise `release()` stops it and it is not started again. The threadloop must be active all alone the life of the audio backend. The fix proposed at #555 seems working only because, during the tests, the pw backend is instantiated each time after `release()` but if `start()` is issued after `release()`, the pw backend stops to work. This issue has been resolved with current commit.  

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
