### PR TITLE
sound: remove ctrl msg param

### DIFF
--- a/staging/vhost-device-sound/src/audio_backends.rs
+++ b/staging/vhost-device-sound/src/audio_backends.rs
@@ -15,7 +15,7 @@ use self::alsa::AlsaBackend;
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{stream::Stream, BackendType, ControlMessage, Result, VirtioSndPcmSetParams};
+use crate::{stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
 
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
@@ -30,7 +30,7 @@ pub trait AudioBackend {
         Ok(())
     }
 
-    fn release(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+    fn release(&self, _stream_id: u32) -> Result<()> {
         Ok(())
     }
 

--- a/staging/vhost-device-sound/src/audio_backends.rs
+++ b/staging/vhost-device-sound/src/audio_backends.rs
@@ -15,14 +15,14 @@ use self::alsa::AlsaBackend;
 use self::null::NullBackend;
 #[cfg(feature = "pw-backend")]
 use self::pipewire::PwBackend;
-use crate::{stream::Stream, BackendType, ControlMessage, Result};
+use crate::{stream::Stream, BackendType, ControlMessage, Result, VirtioSndPcmSetParams};
 
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
 
     fn read(&self, stream_id: u32) -> Result<()>;
 
-    fn set_parameters(&self, _stream_id: u32, _: ControlMessage) -> Result<()> {
+    fn set_parameters(&self, _stream_id: u32, _: VirtioSndPcmSetParams) -> Result<()> {
         Ok(())
     }
 

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -15,13 +15,11 @@ use alsa::{
     pcm::{Access, Format, HwParams, State, PCM},
     PollDescriptors, ValueOr,
 };
-use virtio_queue::Descriptor;
-use vm_memory::Bytes;
 
 use super::AudioBackend;
 use crate::{
     stream::{PCMState, Stream},
-    virtio_sound::{self, VirtioSndPcmSetParams, VIRTIO_SND_S_BAD_MSG, VIRTIO_SND_S_NOT_SUPP},
+    virtio_sound::{self, VirtioSndPcmSetParams, VIRTIO_SND_S_BAD_MSG},
     ControlMessage, Direction, Error, Result as CrateResult,
 };
 
@@ -659,32 +657,22 @@ impl AudioBackend for AlsaBackend {
         Ok(())
     }
 
-    fn set_parameters(&self, stream_id: u32, mut msg: ControlMessage) -> CrateResult<()> {
+    fn set_parameters(&self, stream_id: u32, request: VirtioSndPcmSetParams) -> CrateResult<()> {
         if stream_id >= self.streams.read().unwrap().len() as u32 {
             log::error!(
                 "Received SetParameters action for stream id {} but there are only {} PCM streams.",
                 stream_id,
                 self.streams.read().unwrap().len() as u32
             );
-            msg.code = VIRTIO_SND_S_BAD_MSG;
             return Err(Error::StreamWithIdNotFound(stream_id));
         }
-        let descriptors: Vec<Descriptor> = msg.desc_chain.clone().collect();
-        let desc_request = &descriptors[0];
-        let request = msg
-            .desc_chain
-            .memory()
-            .read_obj::<VirtioSndPcmSetParams>(desc_request.addr())
-            .unwrap();
         {
             let mut streams = self.streams.write().unwrap();
             let st = &mut streams[stream_id as usize];
             if let Err(err) = st.state.set_parameters() {
                 log::error!("Stream {} set_parameters {}", stream_id, err);
-                msg.code = VIRTIO_SND_S_BAD_MSG;
                 return Err(Error::Stream(err));
             } else if !st.supports_format(request.format) || !st.supports_rate(request.rate) {
-                msg.code = VIRTIO_SND_S_NOT_SUPP;
                 return Err(Error::UnexpectedAudioBackendConfiguration);
             } else {
                 st.params.buffer_bytes = request.buffer_bytes;
@@ -694,8 +682,6 @@ impl AudioBackend for AlsaBackend {
                 st.params.format = request.format;
                 st.params.rate = request.rate;
             }
-            // Manually drop msg for faster response: the kernel has a timeout.
-            drop(msg);
         }
         update_pcm(
             &self.pcms[stream_id as usize],

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -19,8 +19,8 @@ use alsa::{
 use super::AudioBackend;
 use crate::{
     stream::{PCMState, Stream},
-    virtio_sound::{self, VirtioSndPcmSetParams, VIRTIO_SND_S_BAD_MSG},
-    ControlMessage, Direction, Error, Result as CrateResult,
+    virtio_sound::{self, VirtioSndPcmSetParams},
+    Direction, Error, Result as CrateResult,
 };
 
 impl From<Direction> for alsa::Direction {
@@ -692,21 +692,18 @@ impl AudioBackend for AlsaBackend {
         Ok(())
     }
 
-    fn release(&self, stream_id: u32, mut msg: ControlMessage) -> CrateResult<()> {
+    fn release(&self, stream_id: u32) -> CrateResult<()> {
         if stream_id >= self.streams.read().unwrap().len() as u32 {
             log::error!(
                 "Received Release action for stream id {} but there are only {} PCM streams.",
                 stream_id,
                 self.streams.read().unwrap().len() as u32
             );
-            msg.code = VIRTIO_SND_S_BAD_MSG;
             return Err(Error::StreamWithIdNotFound(stream_id));
         }
         let mut streams = self.streams.write().unwrap();
         if let Err(err) = streams[stream_id as usize].state.release() {
             log::error!("Stream {}: {}", stream_id, err);
-            msg.code = VIRTIO_SND_S_BAD_MSG;
-            drop(msg);
             return Err(Error::Stream(err));
         }
         // Stop worker thread


### PR DESCRIPTION
### Summary of the PR

This PR is the result of splitting https://github.com/rust-vmm/vhost-device/pull/556. This PR addresses the required changes to remove the `ControlMessage` parameter from the `set_param()` and `release()` functions. In particular in `set_param()`, this PR replaces it with the `VirtioSndPcmSetParams` structure that is parsed in the device thus preventing the audio backend to manipulate descriptors. 

Thanks for reviewing!

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
