### PR TITLE
sound: add tests to Alsa and other test stuff

### DIFF
--- a/staging/coverage_config_x86_64.json
+++ b/staging/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 67.98,
+  "coverage_score": 71.65,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -718,4 +718,9 @@ impl AudioBackend for AlsaBackend {
         std::mem::take(&mut streams[stream_id as usize].buffers);
         Ok(())
     }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -724,3 +724,512 @@ impl AudioBackend for AlsaBackend {
         self
     }
 }
+
+#[cfg(test)]
+/// Utilities for temporarily setting a test-specific alsa config.
+pub mod test_utils;
+
+#[cfg(test)]
+mod tests {
+    use super::{test_utils::setup_alsa_conf, *};
+    use crate::{stream::PcmParams, virtio_sound::*};
+
+    const RATES: [u8; _VIRTIO_SND_PCM_RATE_MAX as usize] = [
+        virtio_sound::VIRTIO_SND_PCM_RATE_5512,
+        virtio_sound::VIRTIO_SND_PCM_RATE_8000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_11025,
+        virtio_sound::VIRTIO_SND_PCM_RATE_16000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_22050,
+        virtio_sound::VIRTIO_SND_PCM_RATE_32000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_44100,
+        virtio_sound::VIRTIO_SND_PCM_RATE_48000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_64000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_88200,
+        virtio_sound::VIRTIO_SND_PCM_RATE_96000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_176400,
+        virtio_sound::VIRTIO_SND_PCM_RATE_192000,
+        virtio_sound::VIRTIO_SND_PCM_RATE_384000,
+    ];
+
+    const FORMATS: [u8; _VIRTIO_SND_PCM_FMT_MAX as usize] = [
+        virtio_sound::VIRTIO_SND_PCM_FMT_IMA_ADPCM,
+        virtio_sound::VIRTIO_SND_PCM_FMT_MU_LAW,
+        virtio_sound::VIRTIO_SND_PCM_FMT_A_LAW,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S8,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U8,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S16,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U16,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S18_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U18_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S20_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U20_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S24_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U24_3,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S20,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U20,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S24,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U24,
+        virtio_sound::VIRTIO_SND_PCM_FMT_S32,
+        virtio_sound::VIRTIO_SND_PCM_FMT_U32,
+        virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT,
+        virtio_sound::VIRTIO_SND_PCM_FMT_FLOAT64,
+        virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U8,
+        virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U16,
+        virtio_sound::VIRTIO_SND_PCM_FMT_DSD_U32,
+        virtio_sound::VIRTIO_SND_PCM_FMT_IEC958_SUBFRAME,
+    ];
+
+    #[test]
+    fn test_alsa_trait_impls() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let _: alsa::Direction = Direction::Output.into();
+        let _: alsa::Direction = Direction::Input.into();
+
+        let backend = AlsaBackend::new(Default::default());
+        #[allow(clippy::redundant_clone)]
+        let _ = backend.clone();
+
+        _ = format!("{:?}", backend);
+    }
+
+    #[test]
+    fn test_alsa_ops() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![
+            Stream::default(),
+            Stream {
+                id: 1,
+                direction: Direction::Input,
+                ..Stream::default()
+            },
+        ]));
+        let backend = AlsaBackend::new(streams);
+        let request = VirtioSndPcmSetParams {
+            hdr: VirtioSoundPcmHeader {
+                stream_id: 0.into(),
+                hdr: VirtioSoundHeader { code: 0.into() },
+            },
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_44100,
+            channels: 2,
+            features: 0.into(),
+            buffer_bytes: 8192.into(),
+            period_bytes: 4096.into(),
+            padding: 0,
+        };
+        backend.set_parameters(0, request).unwrap();
+        backend.prepare(0).unwrap();
+        backend.start(0).unwrap();
+        backend.write(0).unwrap();
+        backend.read(0).unwrap();
+        backend.stop(0).unwrap();
+        backend.release(0).unwrap();
+    }
+
+    #[test]
+    fn test_alsa_invalid_stream_id() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![
+            Stream::default(),
+            Stream {
+                id: 1,
+                direction: Direction::Input,
+                ..Stream::default()
+            },
+        ]));
+        let backend = AlsaBackend::new(streams);
+        let request = VirtioSndPcmSetParams {
+            hdr: VirtioSoundPcmHeader {
+                stream_id: 3.into(),
+                hdr: VirtioSoundHeader { code: 0.into() },
+            },
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_44100,
+            channels: 2,
+            features: 0.into(),
+            buffer_bytes: 8192.into(),
+            period_bytes: 4096.into(),
+            padding: 0,
+        };
+        backend.set_parameters(3, request).unwrap_err();
+        backend.prepare(3).unwrap_err();
+        backend.start(3).unwrap_err();
+        backend.write(3).unwrap_err();
+        backend.read(3).unwrap_err();
+        backend.stop(3).unwrap_err();
+        backend.release(3).unwrap_err();
+    }
+
+    #[test]
+    fn test_alsa_invalid_state_transitions() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![
+            Stream::default(),
+            Stream {
+                id: 1,
+                direction: Direction::Input,
+                ..Stream::default()
+            },
+        ]));
+        let request = VirtioSndPcmSetParams {
+            hdr: VirtioSoundPcmHeader {
+                stream_id: 3.into(),
+                hdr: VirtioSoundHeader { code: 0.into() },
+            },
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_44100,
+            channels: 2,
+            features: 0.into(),
+            buffer_bytes: 8192.into(),
+            period_bytes: 4096.into(),
+            padding: 0,
+        };
+        {
+            let backend = AlsaBackend::new(streams.clone());
+
+            // Invalid, but we allow it.
+            backend.stop(0).unwrap();
+            // Invalid, but we don't allow it.
+            backend.release(0).unwrap_err();
+            backend.start(0).unwrap_err();
+            backend.release(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+
+            // set_parameters -> set_parameters | VALID
+            backend.set_parameters(0, request).unwrap();
+
+            // set_parameters -> prepare | VALID
+            backend.prepare(0).unwrap();
+
+            // Invalid, but we allow it.
+            // prepare -> stop | INVALID
+            backend.stop(0).unwrap();
+            // prepare -> release | VALID
+            backend.release(0).unwrap();
+
+            // release -> start | INVALID
+            backend.start(0).unwrap_err();
+            // release -> stop | VALID
+            backend.stop(0).unwrap();
+            // release -> prepare | VALID
+            backend.prepare(0).unwrap();
+
+            // prepare -> start | VALID
+            backend.start(0).unwrap();
+
+            // start -> start | INVALID
+            backend.start(0).unwrap_err();
+            // start -> set_parameters | INVALID
+            backend.set_parameters(0, request).unwrap_err();
+            // start -> prepare | INVALID
+            backend.prepare(0).unwrap_err();
+            // start -> release | INVALID
+            backend.release(0).unwrap_err();
+            // start -> stop | VALID
+            backend.stop(0).unwrap();
+            // stop -> start | VALID
+            backend.start(0).unwrap();
+            // start -> stop | VALID
+            backend.stop(0).unwrap();
+            // stop -> prepare | INVALID
+            backend.prepare(0).unwrap_err();
+            // stop -> set_parameters | INVALID
+            backend.set_parameters(0, request).unwrap_err();
+            // stop -> release | VALID
+            backend.release(0).unwrap();
+        }
+
+        // Redundant checks? Oh well.
+        //
+        // Generated with:
+        //
+        // ```python
+        // import itertools
+        // states = ["SetParameters", "Prepare", "Release", "Start", "Stop"]
+        // combs = set(itertools.product(states, repeat=2))
+        // ```
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap();
+            backend.prepare(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.prepare(0).unwrap();
+            backend.stop(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.start(0).unwrap();
+            backend.start(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.prepare(0).unwrap_err();
+            backend.start(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.stop(0).unwrap();
+            backend.release(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.stop(0).unwrap();
+            backend.prepare(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.release(0).unwrap();
+            backend.set_parameters(0, request).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.start(0).unwrap_err();
+            backend.set_parameters(0, request).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.prepare(0).unwrap();
+            backend.set_parameters(0, request).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.release(0).unwrap_err();
+            backend.read(0).unwrap_err();
+            backend.write(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap();
+            backend.stop(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.release(0).unwrap_err();
+            backend.prepare(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap();
+            backend.start(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.start(0).unwrap_err();
+            backend.release(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.prepare(0).unwrap();
+            backend.release(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.start(0).unwrap_err();
+            backend.prepare(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.stop(0).unwrap();
+            backend.stop(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.prepare(0).unwrap();
+            backend.prepare(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.stop(0).unwrap();
+            backend.start(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap_err();
+            backend.release(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.release(0).unwrap_err();
+            backend.stop(0).unwrap();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.stop(0).unwrap();
+            backend.set_parameters(0, request).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams.clone());
+            backend.release(0).unwrap();
+            backend.start(0).unwrap_err();
+        }
+        {
+            let backend = AlsaBackend::new(streams);
+            backend.start(0).unwrap_err();
+            backend.stop(0).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_alsa_worker() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![
+            Stream::default(),
+            Stream {
+                id: 1,
+                direction: Direction::Input,
+                ..Stream::default()
+            },
+        ]));
+        let (sender, receiver) = channel();
+        let pcm = Arc::new(Mutex::new(
+            PCM::new("null", Direction::Output.into(), false).unwrap(),
+        ));
+
+        let mtx = Arc::clone(&pcm);
+        let streams = Arc::clone(&streams);
+        let _handle =
+            thread::spawn(move || alsa_worker(mtx.clone(), streams.clone(), &receiver, 0));
+        sender.send(false).unwrap();
+    }
+
+    #[test]
+    fn test_alsa_valid_parameters() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![
+            Stream::default(),
+            Stream {
+                id: 1,
+                direction: Direction::Input,
+                ..Stream::default()
+            },
+        ]));
+        let mut request = VirtioSndPcmSetParams {
+            hdr: VirtioSoundPcmHeader {
+                stream_id: 0.into(),
+                hdr: VirtioSoundHeader { code: 0.into() },
+            },
+            format: VIRTIO_SND_PCM_FMT_S16,
+            rate: VIRTIO_SND_PCM_RATE_44100,
+            channels: 2,
+            features: 0.into(),
+            buffer_bytes: 8192.into(),
+            period_bytes: 4096.into(),
+            padding: 0,
+        };
+
+        for rate in RATES
+            .iter()
+            .cloned()
+            .filter(|rt| ((1 << *rt) & crate::SUPPORTED_RATES) > 0)
+        {
+            request.rate = rate;
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap();
+        }
+
+        for rate in RATES
+            .iter()
+            .cloned()
+            .filter(|rt| ((1 << *rt) & crate::SUPPORTED_RATES) == 0)
+        {
+            request.rate = rate;
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap_err();
+        }
+        request.rate = VIRTIO_SND_PCM_RATE_44100;
+
+        for format in FORMATS
+            .iter()
+            .cloned()
+            .filter(|fmt| ((1 << *fmt) & crate::SUPPORTED_FORMATS) > 0)
+        {
+            request.format = format;
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap();
+        }
+
+        for format in FORMATS
+            .iter()
+            .cloned()
+            .filter(|fmt| ((1 << *fmt) & crate::SUPPORTED_FORMATS) == 0)
+        {
+            request.format = format;
+            let backend = AlsaBackend::new(streams.clone());
+            backend.set_parameters(0, request).unwrap_err();
+        }
+
+        {
+            for format in FORMATS
+                .iter()
+                .cloned()
+                .filter(|fmt| ((1 << *fmt) & crate::SUPPORTED_FORMATS) > 0)
+            {
+                let streams = Arc::new(RwLock::new(vec![Stream {
+                    params: PcmParams {
+                        format,
+                        ..PcmParams::default()
+                    },
+                    ..Stream::default()
+                }]));
+                let pcm = Arc::new(Mutex::new(
+                    PCM::new("null", Direction::Output.into(), false).unwrap(),
+                ));
+                update_pcm(&pcm, 0, &streams).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unreachable")]
+    fn test_alsa_invalid_rate() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![Stream {
+            params: PcmParams {
+                rate: _VIRTIO_SND_PCM_RATE_MAX,
+                ..PcmParams::default()
+            },
+            ..Stream::default()
+        }]));
+        let pcm = Arc::new(Mutex::new(
+            PCM::new("null", Direction::Output.into(), false).unwrap(),
+        ));
+        update_pcm(&pcm, 0, &streams).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "unreachable")]
+    fn test_alsa_invalid_fmt() {
+        crate::init_logger();
+        let _harness = setup_alsa_conf();
+
+        let streams = Arc::new(RwLock::new(vec![Stream {
+            params: PcmParams {
+                format: _VIRTIO_SND_PCM_FMT_MAX,
+                ..PcmParams::default()
+            },
+            ..Stream::default()
+        }]));
+        let pcm = Arc::new(Mutex::new(
+            PCM::new("null", Direction::Output.into(), false).unwrap(),
+        ));
+        update_pcm(&pcm, 0, &streams).unwrap();
+    }
+}

--- a/staging/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa.rs
@@ -645,12 +645,14 @@ impl AudioBackend for AlsaBackend {
     }
 
     fn stop(&self, id: u32) -> CrateResult<()> {
-        if let Some(Err(err)) = self
+        if let Err(err) = self
             .streams
             .write()
             .unwrap()
             .get_mut(id as usize)
-            .map(|s| s.state.stop())
+            .ok_or_else(|| Error::StreamWithIdNotFound(id))?
+            .state
+            .stop()
         {
             log::error!("Stream {} stop {}", id, err);
         }

--- a/staging/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
+++ b/staging/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
@@ -1,0 +1,128 @@
+// Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use std::{
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc, Mutex, Once,
+    },
+};
+
+use tempfile::{tempdir, TempDir};
+
+static mut TEST_HARNESS: Option<AlsaTestHarness> = None;
+static INIT_ALSA_CONF: Once = Once::new();
+
+#[must_use]
+pub fn setup_alsa_conf() -> AlsaTestHarnessRef<'static> {
+    INIT_ALSA_CONF.call_once(||
+        // SAFETY:
+        // This is only called once, because of.. `Once`, so it's safe to
+        // access the static value mutably.
+        unsafe {
+            TEST_HARNESS = Some(AlsaTestHarness::new());
+        });
+    let retval = AlsaTestHarnessRef(
+        // SAFETY:
+        // The unsafe { } block is needed because TEST_HARNESS is a mutable static. The inner
+        // operations are protected by atomics.
+        unsafe { TEST_HARNESS.as_ref().unwrap() },
+    );
+    retval.0.inc_ref();
+    retval
+}
+
+/// The alsa test harness. It must only be constructed via
+/// `AlsaTestHarness::new()`.
+#[non_exhaustive]
+pub struct AlsaTestHarness {
+    pub tempdir: Arc<Mutex<Option<TempDir>>>,
+    pub conf_path: PathBuf,
+    pub ref_count: AtomicU8,
+}
+
+/// Ref counted alsa test harness ref.
+#[repr(transparent)]
+#[non_exhaustive]
+pub struct AlsaTestHarnessRef<'a>(&'a AlsaTestHarness);
+
+impl<'a> Drop for AlsaTestHarnessRef<'a> {
+    fn drop(&mut self) {
+        self.0.dec_ref();
+    }
+}
+
+impl AlsaTestHarness {
+    pub fn new() -> Self {
+        let tempdir = tempdir().unwrap();
+        let conf_path = tempdir.path().join("alsa.conf");
+
+        std::fs::write(
+            &conf_path,
+            b"pcm.!default {\n type null \n }\n\nctl.!default {\n type null\n }\n\npcm.null {\n type null \n }\n\nctl.null {\n type null\n }\n",
+        ).unwrap();
+
+        std::env::set_var("ALSA_CONFIG_PATH", &conf_path);
+        println!(
+            "INFO: setting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
+            conf_path.display(),
+            std::process::id(),
+            std::thread::current().id()
+        );
+
+        Self {
+            tempdir: Arc::new(Mutex::new(Some(tempdir))),
+            conf_path,
+            ref_count: 0.into(),
+        }
+    }
+
+    #[inline]
+    pub fn inc_ref(&self) {
+        let old_val = self.ref_count.fetch_add(1, Ordering::SeqCst);
+        assert!(
+            old_val != u8::MAX,
+            "ref_count overflowed on 8bits when increasing by 1"
+        );
+    }
+
+    #[inline]
+    pub fn dec_ref(&self) {
+        let old_val = self.ref_count.fetch_sub(1, Ordering::SeqCst);
+        if old_val == 1 {
+            let mut lck = self.tempdir.lock().unwrap();
+            println!(
+                "INFO: unsetting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
+                self.conf_path.display(),
+                std::process::id(),
+                std::thread::current().id()
+            );
+            std::env::remove_var("ALSA_CONFIG_PATH");
+            _ = lck.take();
+        }
+    }
+}
+
+impl Drop for AlsaTestHarness {
+    fn drop(&mut self) {
+        let ref_count = self.ref_count.load(Ordering::SeqCst);
+        if ref_count != 0 {
+            println!(
+                "ERROR: ref_count is {ref_count} when dropping {}",
+                stringify!(AlsaTestHarness)
+            );
+        }
+        if self
+            .tempdir
+            .lock()
+            .map(|mut l| l.take().is_some())
+            .unwrap_or(false)
+        {
+            println!(
+                "ERROR: tempdir held a value when dropping {}",
+                stringify!(AlsaTestHarness)
+            );
+        }
+    }
+}

--- a/staging/vhost-device-sound/src/audio_backends/null.rs
+++ b/staging/vhost-device-sound/src/audio_backends/null.rs
@@ -34,6 +34,7 @@ mod tests {
 
     #[test]
     fn test_null_backend_write() {
+        crate::init_logger();
         let streams = Arc::new(RwLock::new(vec![Stream::default()]));
         let null_backend = NullBackend::new(streams.clone());
 
@@ -45,6 +46,7 @@ mod tests {
 
     #[test]
     fn test_null_backend_read() {
+        crate::init_logger();
         let streams = Arc::new(RwLock::new(vec![Stream::default()]));
         let null_backend = NullBackend::new(streams.clone());
 

--- a/staging/vhost-device-sound/src/audio_backends/null.rs
+++ b/staging/vhost-device-sound/src/audio_backends/null.rs
@@ -26,6 +26,11 @@ impl AudioBackend for NullBackend {
         log::trace!("NullBackend read stream_id {}", _id);
         Ok(())
     }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -562,12 +562,17 @@ impl AudioBackend for PwBackend {
         lock_guard.unlock();
         Ok(())
     }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 #[cfg(test)]
 /// Utilities for building a temporary Dbus session and a pipewire instance for
 /// testing.
-mod test_utils;
+pub mod test_utils;
 
 #[cfg(test)]
 mod tests {

--- a/staging/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/staging/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -575,6 +575,7 @@ mod tests {
 
     #[test]
     fn test_pipewire_backend_success() {
+        crate::init_logger();
         let streams = Arc::new(RwLock::new(vec![Stream::default()]));
         let stream_params = streams.clone();
 
@@ -603,6 +604,7 @@ mod tests {
 
     #[test]
     fn test_pipewire_backend_invalid_stream() {
+        crate::init_logger();
         let stream_params = Arc::new(RwLock::new(vec![]));
 
         let _test_harness = PipewireTestHarness::new();

--- a/staging/vhost-device-sound/src/device.rs
+++ b/staging/vhost-device-sound/src/device.rs
@@ -827,6 +827,7 @@ mod tests {
 
     #[test]
     fn test_sound_thread_success() {
+        crate::init_logger();
         let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
@@ -921,6 +922,7 @@ mod tests {
 
     #[test]
     fn test_sound_thread_failure() {
+        crate::init_logger();
         let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
@@ -995,6 +997,7 @@ mod tests {
 
     #[test]
     fn test_sound_backend() {
+        crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
         let socket_path = test_dir.path().join(SOCKET_PATH).display().to_string();
         let config = SoundConfig::new(socket_path, false, BackendType::Null);
@@ -1069,6 +1072,7 @@ mod tests {
 
     #[test]
     fn test_sound_backend_failures() {
+        crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
 
         let socket_path = test_dir

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -106,8 +106,8 @@ pub enum Error {
     DescriptorWriteFailed,
     #[error("Failed to handle event other than EPOLLIN event")]
     HandleEventNotEpollIn,
-    #[error("Failed to handle unknown event")]
-    HandleUnknownEvent,
+    #[error("Failed to handle unknown event with id {0}")]
+    HandleUnknownEvent(u16),
     #[error("Invalid control message code {0}")]
     InvalidControlMessage(u32),
     #[error("Invalid value in {0}: {1}")]

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -30,6 +30,12 @@
     clippy::significant_drop_tightening
 )]
 
+#[cfg(test)]
+pub fn init_logger() {
+    std::env::set_var("RUST_LOG", "trace");
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
 pub mod audio_backends;
 pub mod device;
 pub mod stream;
@@ -319,6 +325,7 @@ mod tests {
     #[test]
     fn test_sound_server() {
         const SOCKET_PATH: &str = "vsound.socket";
+        crate::init_logger();
 
         let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
 
@@ -341,6 +348,7 @@ mod tests {
 
     #[test]
     fn test_control_message_kind_try_from() {
+        crate::init_logger();
         assert_eq!(
             ControlMessageKind::try_from(<u32 as Into<Le32>>::into(VIRTIO_SND_R_JACK_INFO)),
             Ok(ControlMessageKind::JackInfo)
@@ -361,6 +369,7 @@ mod tests {
 
     #[test]
     fn test_control_message_kind_try_from_invalid() {
+        crate::init_logger();
         // Test an invalid value that should result in an InvalidControlMessage error
         let invalid_value: u32 = 0x1101;
         assert_eq!(
@@ -371,6 +380,7 @@ mod tests {
 
     #[test]
     fn test_try_from_valid_output() {
+        crate::init_logger();
         let val = virtio_sound::VIRTIO_SND_D_OUTPUT;
         assert_eq!(Direction::try_from(val).unwrap(), Direction::Output);
 
@@ -383,6 +393,7 @@ mod tests {
 
     #[test]
     fn test_display() {
+        crate::init_logger();
         let error = InvalidControlMessage(42);
         let formatted_error = format!("{}", error);
         assert_eq!(formatted_error, "Invalid control message code 42");
@@ -390,6 +401,7 @@ mod tests {
 
     #[test]
     fn test_into_error() {
+        crate::init_logger();
         let error = InvalidControlMessage(42);
         let _error: Error = error.into();
 

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 //
 #![deny(
+    clippy::undocumented_unsafe_blocks,
     /* groups */
     clippy::correctness,
     clippy::suspicious,

--- a/staging/vhost-device-sound/src/main.rs
+++ b/staging/vhost-device-sound/src/main.rs
@@ -53,8 +53,14 @@ mod tests {
         }
     }
 
+    fn init_logger() {
+        std::env::set_var("RUST_LOG", "trace");
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
     #[test]
     fn test_sound_config_setup() {
+        init_logger();
         let args = SoundArgs::from_args("/tmp/vhost-sound.socket");
 
         let config = SoundConfig::try_from(args);

--- a/staging/vhost-device-sound/src/virtio_sound.rs
+++ b/staging/vhost-device-sound/src/virtio_sound.rs
@@ -89,6 +89,7 @@ pub const VIRTIO_SND_PCM_FMT_DSD_U8: u8 = 21;
 pub const VIRTIO_SND_PCM_FMT_DSD_U16: u8 = 22;
 pub const VIRTIO_SND_PCM_FMT_DSD_U32: u8 = 23;
 pub const VIRTIO_SND_PCM_FMT_IEC958_SUBFRAME: u8 = 24;
+pub(crate) const _VIRTIO_SND_PCM_FMT_MAX: u8 = 25;
 
 // supported PCM frame rates
 
@@ -106,6 +107,7 @@ pub const VIRTIO_SND_PCM_RATE_96000: u8 = 10;
 pub const VIRTIO_SND_PCM_RATE_176400: u8 = 11;
 pub const VIRTIO_SND_PCM_RATE_192000: u8 = 12;
 pub const VIRTIO_SND_PCM_RATE_384000: u8 = 13;
+pub(crate) const _VIRTIO_SND_PCM_RATE_MAX: u8 = 14;
 
 // standard channel position definition
 


### PR DESCRIPTION
### Summary of the PR

add tests to Alsa and other test stuff

#### Before

<table><tbody><tr><td class="column-entry-bold">Filename</td><td class="column-entry-bold">Function Coverage</td><td class="column-entry-bold">Line Coverage</td><td class="column-entry-bold">Region Coverage</td><td class="column-entry-bold">Branch Coverage</td></tr><tr class="light-row"><td><span><a >audio_backends.rs</a></span></td><td class="column-entry-green"><span> 100.00% (6/6)</span></td><td class="column-entry-yellow"><span>  92.00% (23/25)</span></td><td class="column-entry-red"><span>  75.00% (9/12)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/alsa.rs</a></span></td><td class="column-entry-red"><span>   0.00% (0/21)</span></td><td class="column-entry-red"><span>   0.00% (0/519)</span></td><td class="column-entry-red"><span>   0.00% (0/375)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/null.rs</a></span></td><td class="column-entry-green"><span> 100.00% (7/7)</span></td><td class="column-entry-green"><span> 100.00% (33/33)</span></td><td class="column-entry-yellow"><span>  84.62% (11/13)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/pipewire.rs</a></span></td><td class="column-entry-yellow"><span>  95.45% (21/22)</span></td><td class="column-entry-red"><span>  63.49% (313/493)</span></td><td class="column-entry-red"><span>  48.20% (107/222)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/pipewire/test_utils.rs</a></span></td><td class="column-entry-green"><span> 100.00% (6/6)</span></td><td class="column-entry-yellow"><span>  91.11% (82/90)</span></td><td class="column-entry-red"><span>  76.47% (26/34)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >device.rs</a></span></td><td class="column-entry-red"><span>  61.22% (30/49)</span></td><td class="column-entry-red"><span>  74.59% (690/925)</span></td><td class="column-entry-red"><span>  53.11% (205/386)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >lib.rs</a></span></td><td class="column-entry-red"><span>  75.61% (31/41)</span></td><td class="column-entry-yellow"><span>  84.18% (149/177)</span></td><td class="column-entry-red"><span>  70.21% (66/94)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >main.rs</a></span></td><td class="column-entry-red"><span>  60.00% (6/10)</span></td><td class="column-entry-red"><span>  68.75% (22/32)</span></td><td class="column-entry-red"><span>  70.59% (12/17)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >stream.rs</a></span></td><td class="column-entry-yellow"><span>  81.82% (36/44)</span></td><td class="column-entry-yellow"><span>  96.53% (362/375)</span></td><td class="column-entry-yellow"><span>  82.73% (91/110)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >virtio_sound.rs</a></span></td><td class="column-entry-green"><span> 100.00% (60/60)</span></td><td class="column-entry-green"><span> 100.00% (191/191)</span></td><td class="column-entry-green"><span> 100.00% (99/99)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row-bold"><td><span>Totals</span></td><td class="column-entry-red"><b>  76.32% (203/266)</b></td><td class="column-entry-red"><b>  65.21% (1865/2860)</b></td><td class="column-entry-red"><b>  45.96% (626/1362)</b></td><td class="column-entry-red"><b>- (0/0)</b></td></tr></tbody></table>


#### After

<table><tbody><tr><td class="column-entry-bold">Filename</td><td class="column-entry-bold">Function Coverage</td><td class="column-entry-bold">Line Coverage</td><td class="column-entry-bold">Region Coverage</td><td class="column-entry-bold">Branch Coverage</td></tr><tr class="light-row"><td><span><a >audio_backends.rs</a></span></td><td class="column-entry-green"><span> 100.00% (8/8)</span></td><td class="column-entry-green"><span> 100.00% (39/39)</span></td><td class="column-entry-green"><span> 100.00% (17/17)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/alsa.rs</a></span></td><td class="column-entry-yellow"><span>  88.64% (39/44)</span></td><td class="column-entry-red"><span>  73.56% (704/957)</span></td><td class="column-entry-red"><span>  48.94% (208/425)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/null.rs</a></span></td><td class="column-entry-green"><span> 100.00% (8/8)</span></td><td class="column-entry-green"><span> 100.00% (38/38)</span></td><td class="column-entry-green"><span> 100.00% (14/14)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/pipewire.rs</a></span></td><td class="column-entry-yellow"><span>  95.65% (22/23)</span></td><td class="column-entry-red"><span>  63.86% (318/498)</span></td><td class="column-entry-red"><span>  51.57% (115/223)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >audio_backends/pipewire/test_utils.rs</a></span></td><td class="column-entry-green"><span> 100.00% (6/6)</span></td><td class="column-entry-yellow"><span>  91.11% (82/90)</span></td><td class="column-entry-red"><span>  76.47% (26/34)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >device.rs</a></span></td><td class="column-entry-red"><span>  61.54% (32/52)</span></td><td class="column-entry-red"><span>  76.67% (723/943)</span></td><td class="column-entry-red"><span>  60.35% (242/401)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >lib.rs</a></span></td><td class="column-entry-red"><span>  78.72% (37/47)</span></td><td class="column-entry-yellow"><span>  87.39% (194/222)</span></td><td class="column-entry-red"><span>  76.58% (85/111)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >main.rs</a></span></td><td class="column-entry-red"><span>  63.64% (7/11)</span></td><td class="column-entry-red"><span>  72.97% (27/37)</span></td><td class="column-entry-red"><span>  72.22% (13/18)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >stream.rs</a></span></td><td class="column-entry-yellow"><span>  84.09% (37/44)</span></td><td class="column-entry-yellow"><span>  97.87% (367/375)</span></td><td class="column-entry-yellow"><span>  89.09% (98/110)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row"><td><span><a >virtio_sound.rs</a></span></td><td class="column-entry-green"><span> 100.00% (60/60)</span></td><td class="column-entry-green"><span> 100.00% (191/191)</span></td><td class="column-entry-green"><span> 100.00% (99/99)</span></td><td class="column-entry-red"><span>- (0/0)</span></td></tr><tr class="light-row-bold"><td><span>Totals</span></td><td class="column-entry-yellow"><b>  84.49% (256/303)</b></td><td class="column-entry-red"><b>  79.14% (2683/3390)</b></td><td class="column-entry-red"><b>  63.15% (917/1452)</b></td><td class="column-entry-red"><b>- (0/0)</b></td></tr></tbody></table>


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
