### PR TITLE
sound: use descriptor_utils.rs to manipulate requests

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 77.55,
+  "coverage_score": 77.63,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -811,7 +811,6 @@ mod tests {
         let request = VirtioSndPcmSetParams {
             hdr: VirtioSoundPcmHeader {
                 stream_id: 0.into(),
-                hdr: VirtioSoundHeader { code: 0.into() },
             },
             format: VIRTIO_SND_PCM_FMT_S16,
             rate: VIRTIO_SND_PCM_RATE_44100,
@@ -847,7 +846,6 @@ mod tests {
         let request = VirtioSndPcmSetParams {
             hdr: VirtioSoundPcmHeader {
                 stream_id: 3.into(),
-                hdr: VirtioSoundHeader { code: 0.into() },
             },
             format: VIRTIO_SND_PCM_FMT_S16,
             rate: VIRTIO_SND_PCM_RATE_44100,
@@ -882,7 +880,6 @@ mod tests {
         let request = VirtioSndPcmSetParams {
             hdr: VirtioSoundPcmHeader {
                 stream_id: 3.into(),
-                hdr: VirtioSoundHeader { code: 0.into() },
             },
             format: VIRTIO_SND_PCM_FMT_S16,
             rate: VIRTIO_SND_PCM_RATE_44100,
@@ -1122,7 +1119,6 @@ mod tests {
         let mut request = VirtioSndPcmSetParams {
             hdr: VirtioSoundPcmHeader {
                 stream_id: 0.into(),
-                hdr: VirtioSoundHeader { code: 0.into() },
             },
             format: VIRTIO_SND_PCM_FMT_S16,
             rate: VIRTIO_SND_PCM_RATE_44100,

--- a/vhost-device-sound/src/audio_backends/null.rs
+++ b/vhost-device-sound/src/audio_backends/null.rs
@@ -18,7 +18,7 @@ impl NullBackend {
 impl AudioBackend for NullBackend {
     fn write(&self, stream_id: u32) -> Result<()> {
         log::trace!("NullBackend write stream_id {}", stream_id);
-        _ = std::mem::take(&mut self.streams.write().unwrap()[stream_id as usize].buffers);
+        _ = std::mem::take(&mut self.streams.write().unwrap()[stream_id as usize].requests);
         Ok(())
     }
 
@@ -46,7 +46,7 @@ mod tests {
         null_backend.write(0).unwrap();
 
         let streams = streams.read().unwrap();
-        assert_eq!(streams[0].buffers.len(), 0);
+        assert_eq!(streams[0].requests.len(), 0);
     }
 
     #[test]
@@ -57,8 +57,8 @@ mod tests {
 
         null_backend.read(0).unwrap();
 
-        // buffer lengths should remain unchanged
+        // requests lengths should remain unchanged
         let streams = streams.read().unwrap();
-        assert_eq!(streams[0].buffers.len(), 0);
+        assert_eq!(streams[0].requests.len(), 0);
     }
 }

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -168,14 +168,8 @@ pub enum Error {
     NoMemoryConfigured,
     #[error("Invalid virtio_snd_hdr size, expected: {0}, found: {1}")]
     UnexpectedSoundHeaderSize(usize, u32),
-    #[error("Received unexpected write only descriptor at index {0}")]
-    UnexpectedWriteOnlyDescriptor(usize),
     #[error("Received unexpected readable descriptor at index {0}")]
-    UnexpectedReadableDescriptor(usize),
-    #[error("Invalid descriptor count {0}")]
     UnexpectedDescriptorCount(usize),
-    #[error("Invalid descriptor size, expected: {0}, found: {1}")]
-    UnexpectedDescriptorSize(usize, u32),
     #[error("Protocol or device error: {0}")]
     Stream(stream::Error),
     #[error("Stream with id {0} not found")]

--- a/vhost-device-sound/src/virtio_sound.rs
+++ b/vhost-device-sound/src/virtio_sound.rs
@@ -195,8 +195,6 @@ unsafe impl ByteValued for VirtioSoundEvent {}
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct VirtioSoundQueryInfo {
-    /// item request type (VIRTIO_SND_R_*_INFO)
-    pub hdr: VirtioSoundHeader,
     /// starting identifier for the item
     pub start_id: Le32,
     /// number of items for which information is requested
@@ -223,8 +221,6 @@ unsafe impl ByteValued for VirtioSoundInfo {}
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct VirtioSoundJackHeader {
-    /// jack request type (VIRTIO_SND_R_JACK_*)
-    pub hdr: VirtioSoundHeader,
     /// jack identifier
     pub jack_id: Le32,
 }
@@ -269,7 +265,6 @@ unsafe impl ByteValued for VirtioSoundJackRemap {}
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[repr(C)]
 pub struct VirtioSoundPcmHeader {
-    pub hdr: VirtioSoundHeader,
     pub stream_id: Le32,
 }
 // SAFETY: The layout of the structure is fixed and can be initialized by
@@ -373,11 +368,8 @@ mod tests {
         let val = VirtioSoundQueryInfo::default();
 
         let debug_output = format!("{:?}", val);
-        let expected_debug = format!(
-            "VirtioSoundQueryInfo {{ hdr: {:?}, start_id: Le32(0), count: Le32(0), size: Le32(0) \
-             }}",
-            val.hdr
-        );
+        let expected_debug =
+            "VirtioSoundQueryInfo { start_id: Le32(0), count: Le32(0), size: Le32(0) }".to_string();
         assert_eq!(debug_output, expected_debug);
 
         let val = VirtioSoundInfo::default();
@@ -389,10 +381,7 @@ mod tests {
         let val = VirtioSoundJackHeader::default();
 
         let debug_output = format!("{:?}", val);
-        let expected_debug = format!(
-            "VirtioSoundJackHeader {{ hdr: {:?}, jack_id: Le32(0) }}",
-            val.hdr
-        );
+        let expected_debug = "VirtioSoundJackHeader { jack_id: Le32(0) }".to_string();
         assert_eq!(debug_output, expected_debug);
 
         let val = VirtioSoundJackInfo::default();
@@ -417,10 +406,7 @@ mod tests {
         let val = VirtioSoundPcmHeader::default();
 
         let debug_output = format!("{:?}", val);
-        let expected_debug = format!(
-            "VirtioSoundPcmHeader {{ hdr: {:?}, stream_id: Le32(0) }}",
-            val.hdr
-        );
+        let expected_debug = "VirtioSoundPcmHeader { stream_id: Le32(0) }".to_string();
         assert_eq!(debug_output, expected_debug);
 
         let val = VirtioSoundPcmInfo::default();


### PR DESCRIPTION
### Summary of the PR

This commit makes `device.rs` to use `descriptor_utils.rs` API to read/write requests independent of the descriptor distribution. This is a draft PR in which I am still working on.

Thanks for the comments.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
