### PR TITLE
sound: skip musl builds

### DIFF
--- a/staging/vhost-device-sound/Cargo.toml
+++ b/staging/vhost-device-sound/Cargo.toml
@@ -17,11 +17,9 @@ alsa-backend = ["dep:alsa"]
 pw-backend = ["pw"]
 
 [dependencies]
-alsa = { version = "0.8", optional = true }
 clap = { version = "4.4", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"
-pw = { package = "pipewire", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", rev = "5fe090b3ac8f6fed756c4871ac18f26edda3ac89", optional = true }
 thiserror = "1.0"
 vhost = { version = "0.9", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.11"
@@ -29,6 +27,11 @@ virtio-bindings = "0.2.1"
 virtio-queue = "0.10"
 vm-memory = "0.13.1"
 vmm-sys-util = "0.11"
+
+# Make alsa and pipewire backends available only on gnu
+[target.'cfg(target_env = "gnu")'.dependencies]
+alsa = { version = "0.8", optional = true }
+pw = { package = "pipewire", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", rev = "5fe090b3ac8f6fed756c4871ac18f26edda3ac89", optional = true }
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/staging/vhost-device-sound/src/audio_backends.rs
+++ b/staging/vhost-device-sound/src/audio_backends.rs
@@ -1,19 +1,19 @@
 // Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-#[cfg(feature = "alsa-backend")]
+#[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
 mod alsa;
 mod null;
 
-#[cfg(feature = "pw-backend")]
+#[cfg(all(feature = "pw-backend", target_env = "gnu"))]
 mod pipewire;
 
 use std::sync::{Arc, RwLock};
 
-#[cfg(feature = "alsa-backend")]
+#[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
 use self::alsa::AlsaBackend;
 use self::null::NullBackend;
-#[cfg(feature = "pw-backend")]
+#[cfg(all(feature = "pw-backend", target_env = "gnu"))]
 use self::pipewire::PwBackend;
 use crate::{stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
 
@@ -53,9 +53,9 @@ pub fn alloc_audio_backend(
     log::trace!("allocating audio backend {:?}", backend);
     match backend {
         BackendType::Null => Ok(Box::new(NullBackend::new(streams))),
-        #[cfg(feature = "pw-backend")]
+        #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
         BackendType::Pipewire => Ok(Box::new(PwBackend::new(streams))),
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
         BackendType::Alsa => Ok(Box::new(AlsaBackend::new(streams))),
     }
 }
@@ -74,7 +74,7 @@ mod tests {
             let value = alloc_audio_backend(v, Default::default()).unwrap();
             assert_eq!(TypeId::of::<NullBackend>(), value.as_any().type_id());
         }
-        #[cfg(feature = "pw-backend")]
+        #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
         {
             use pipewire::{test_utils::PipewireTestHarness, *};
 
@@ -83,7 +83,7 @@ mod tests {
             let value = alloc_audio_backend(v, Default::default()).unwrap();
             assert_eq!(TypeId::of::<PwBackend>(), value.as_any().type_id());
         }
-        #[cfg(feature = "alsa-backend")]
+        #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
         {
             let v = BackendType::Alsa;
             let value = alloc_audio_backend(v, Default::default()).unwrap();

--- a/staging/vhost-device-sound/src/lib.rs
+++ b/staging/vhost-device-sound/src/lib.rs
@@ -201,9 +201,9 @@ impl From<stream::Error> for Error {
 pub enum BackendType {
     #[default]
     Null,
-    #[cfg(feature = "pw-backend")]
+    #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
     Pipewire,
-    #[cfg(feature = "alsa-backend")]
+    #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
     Alsa,
 }
 

--- a/staging/vhost-device-sound/src/main.rs
+++ b/staging/vhost-device-sound/src/main.rs
@@ -73,10 +73,13 @@ mod tests {
     #[rstest]
     #[case::null_backend("null", BackendType::Null)]
     #[cfg_attr(
-        feature = "pw-backend",
+        all(feature = "pw-backend", target_env = "gnu"),
         case::pipewire("pipewire", BackendType::Pipewire)
     )]
-    #[cfg_attr(feature = "alsa-backend", case::alsa("alsa", BackendType::Alsa))]
+    #[cfg_attr(
+        all(feature = "alsa-backend", target_env = "gnu"),
+        case::alsa("alsa", BackendType::Alsa)
+    )]
     fn test_cli_backend_arg(#[case] backend_name: &str, #[case] backend: BackendType) {
         let args: SoundArgs = Parser::parse_from([
             "",


### PR DESCRIPTION
### Summary of the PR
Disable builds for musl, where alsa-sys and pipewire build fail on rust-vmm-container due to missing tools and headers.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
