### PR TITLE
vhost-device-vsock: update serde_yaml dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.27"
+version = "0.9.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+checksum = "a15e0ef66bf939a7c890a0bf6d5a733c70202225f9888a89ed5c62298b019129"
 dependencies = [
  "indexmap",
  "itoa",
@@ -934,9 +934,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "utf8parse"


### PR DESCRIPTION
    $ cargo audit -q --deny warnings
    Crate:     unsafe-libyaml
    Version:   0.2.9
    Warning:   unsound
    Title:     Unaligned write of u64 on 32-bit and 16-bit platforms
    Date:      2023-12-20
    ID:        RUSTSEC-2023-0075
    URL:       https://rustsec.org/advisories/RUSTSEC-2023-0075
    Dependency tree:
    unsafe-libyaml 0.2.9
    └── serde_yaml 0.9.27
        └── vhost-device-vsock 0.1.0

    error: 1 denied warning found!
