### PR TITLE
vhost-device-sound: update pipewire dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
+ "yansi-term",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,10 +150,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
@@ -649,7 +660,7 @@ dependencies = [
 [[package]]
 name = "libspa"
 version = "0.7.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=5fe090b3ac8f6fed756c4871ac18f26edda3ac89#5fe090b3ac8f6fed756c4871ac18f26edda3ac89"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=675dab340015ba2cc9e8ad1cc99b3a1e5005a18a#675dab340015ba2cc9e8ad1cc99b3a1e5005a18a"
 dependencies = [
  "bitflags 2.4.1",
  "cc",
@@ -665,9 +676,9 @@ dependencies = [
 [[package]]
 name = "libspa-sys"
 version = "0.7.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=5fe090b3ac8f6fed756c4871ac18f26edda3ac89#5fe090b3ac8f6fed756c4871ac18f26edda3ac89"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=675dab340015ba2cc9e8ad1cc99b3a1e5005a18a#675dab340015ba2cc9e8ad1cc99b3a1e5005a18a"
 dependencies = [
- "bindgen 0.66.1",
+ "bindgen 0.68.1",
  "cc",
  "system-deps 6.2.0",
 ]
@@ -821,7 +832,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pipewire"
 version = "0.7.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=5fe090b3ac8f6fed756c4871ac18f26edda3ac89#5fe090b3ac8f6fed756c4871ac18f26edda3ac89"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=675dab340015ba2cc9e8ad1cc99b3a1e5005a18a#675dab340015ba2cc9e8ad1cc99b3a1e5005a18a"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -837,9 +848,9 @@ dependencies = [
 [[package]]
 name = "pipewire-sys"
 version = "0.7.2"
-source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=5fe090b3ac8f6fed756c4871ac18f26edda3ac89#5fe090b3ac8f6fed756c4871ac18f26edda3ac89"
+source = "git+https://gitlab.freedesktop.org/pipewire/pipewire-rs.git?rev=675dab340015ba2cc9e8ad1cc99b3a1e5005a18a#675dab340015ba2cc9e8ad1cc99b3a1e5005a18a"
 dependencies = [
- "bindgen 0.66.1",
+ "bindgen 0.68.1",
  "libspa-sys",
  "system-deps 6.2.0",
 ]
@@ -1278,6 +1289,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1770,4 +1787,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
 ]

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -31,7 +31,7 @@ vmm-sys-util = "0.12"
 # Make alsa and pipewire backends available only on gnu
 [target.'cfg(target_env = "gnu")'.dependencies]
 alsa = { version = "0.8", optional = true }
-pw = { package = "pipewire", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", rev = "5fe090b3ac8f6fed756c4871ac18f26edda3ac89", optional = true }
+pw = { package = "pipewire", git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git", rev = "675dab340015ba2cc9e8ad1cc99b3a1e5005a18a", optional = true }
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -10,7 +10,10 @@ use std::{
 };
 
 use log::debug;
-use pw::{properties, spa, sys::PW_ID_CORE, Context, Core, ThreadLoop};
+use pw::{
+    context::Context, core::Core, properties::properties, spa, sys::PW_ID_CORE,
+    thread_loop::ThreadLoop,
+};
 use spa::{
     param::{
         audio::{AudioFormat, AudioInfoRaw},
@@ -51,7 +54,7 @@ use crate::{
     Direction, Error, Result, Stream,
 };
 
-impl From<Direction> for spa::Direction {
+impl From<Direction> for spa::utils::Direction {
     fn from(val: Direction) -> Self {
         match val {
             Direction::Output => Self::Output,
@@ -89,7 +92,7 @@ impl PwBackend {
 
         let lock_guard = thread_loop.lock();
 
-        let context = pw::Context::new(&thread_loop).expect("failed to create context");
+        let context = Context::new(&thread_loop).expect("failed to create context");
         thread_loop.start();
         let core = context.connect(None).expect("Failed to connect to core");
 
@@ -336,10 +339,10 @@ impl AudioBackend for PwBackend {
 
             let listener_stream = stream
                 .add_local_listener()
-                .state_changed(|old, new| {
+                .state_changed(|_, _, old, new| {
                     debug!("State changed: {:?} -> {:?}", old, new);
                 })
-                .param_changed(move |stream, id, _data, param| {
+                .param_changed(move |stream, _data, id, param| {
                     let Some(_param) = param else {
                         return;
                     };


### PR DESCRIPTION
### Summary of the PR

Update pipewire dependencies after the MR -
https://gitlab.freedesktop.org/pipewire/pipewire-rs/-/merge_requests/210
in pipewire-rs that fixes the crash during vhost-device-sound
test execution

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
