### PR TITLE
build(deps): bump shlex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"


### PR DESCRIPTION
$ cargo audit -q --deny warnings
Crate:     shlex
Version:   1.2.0
Title:     Multiple issues involving quote API
Date:      2024-01-21
ID:        RUSTSEC-2024-0006
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0006
Solution:  Upgrade to >=1.3.0
Dependency tree:
shlex 1.2.0
├── bindgen 0.66.1
│   ├── pipewire-sys 0.7.2
│   │   └── pipewire 0.7.2
│   │       └── vhost-device-sound 0.1.0
│   └── libspa-sys 0.7.2
│       ├── pipewire-sys 0.7.2
│       ├── pipewire 0.7.2
│       └── libspa 0.7.2
│           └── pipewire 0.7.2
└── bindgen 0.63.0
    └── libgpiod-sys 0.1.1
        └── libgpiod 0.2.1
            └── vhost-device-gpio 0.1.0