### PR TITLE
sound/pipewire: specify audio channel position

### DIFF
--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -299,6 +299,7 @@ impl AudioBackend for PwBackend {
             audio_info.set_format(AudioFormat::S16LE);
             audio_info.set_rate(info.rate);
             audio_info.set_channels(info.channels);
+            audio_info.set_position(pos);
 
             let values: Vec<u8> = PodSerializer::serialize(
                 std::io::Cursor::new(Vec::new()),


### PR DESCRIPTION

### Summary of the PR

*add set_position() callback to specify audio channels position*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
