### PR TITLE
i2c: Support for both bus name and bus number

### DIFF
--- a/vhost-device-i2c/README.md
+++ b/vhost-device-i2c/README.md
@@ -33,13 +33,25 @@ Examples section below.
 
 .. option:: -l, --device-list=I2C-DEVICES
 
-  I2c device list at the host OS in the format:
-      <bus-name>:<client_addr>[:<client_addr>],[<bus-name>:<client_addr>[:<client_addr>]]
+  I2c device list at the host OS can be in two different format, name and number:
 
+- format by name:
+      \<bus-name>:<client_addr>[:<client_addr>],[\<bus-name>:<client_addr>[:<client_addr>]]
+```
       Example: --device-list "i915 gmbus dpd:32:21,DPDDC-D:10:23"
-
+```
   Here,
       bus-name: is adatper's name. e.g. value of /sys/bus/i2c/devices/i2c-0/name.
+      client_addr (decimal): address for client device, 32 == 0x20.
+
+- format by number:
+    \<bus>:<client_addr>[:<client_addr>],[\<bus>:<client_addr>[:<client_addr>]]
+
+```
+      Example: --device-list "2:32:21,3:10:23"
+```
+  Here,
+      bus (decimal): adatper bus number. e.g. 2 for /dev/i2c-2, 3 for /dev/i2c-3.
       client_addr (decimal): address for client device, 32 == 0x20.
 
 ## Examples
@@ -49,6 +61,8 @@ The daemon should be started first:
 ::
 
   host# vhost-device-i2c --socket-path=vi2c.sock --socket-count=1 --device-list "i915 gmbus dpd:32"
+
+  host# vhost-device-i2c --socket-path=vi2c.sock --socket-count=1 --device-list "0:32"
 
 The QEMU invocation needs to create a chardev socket the device can
 use to communicate as well as share the guests memory over a memfd.


### PR DESCRIPTION
When the adapter name is used as a parameter, some adapters share the same name. For instance, both /dev/i2c-0 and /dev/i2c-1 have the bus name "xxxx". This leads to only the first found I2C adapter being opened.

To increase flexibility, accept both the I2C master's name and number as parameters and parse accordingly.

### Summary of the PR

In some scenarios, serveral i2c adapters share the same bus-name, which results in only the first founded i2c adapter being
opened.

To address this issue, introduced support for identification by names or numbers, providing users with a choice.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
