### PR TITLE
sound/pipewire: remove duplicate increment

### DIFF
--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -379,10 +379,9 @@ impl AudioBackend for PwBackend {
                                         return;
                                     };
 
-                                    let mut buf_pos = buffer.pos;
                                     let avail = usize::try_from(buffer.desc_len())
                                         .unwrap()
-                                        .saturating_sub(buf_pos);
+                                        .saturating_sub(buffer.pos);
                                     let n_bytes = n_samples.min(avail);
                                     let p = &slice[start..start + n_bytes];
 
@@ -394,12 +393,10 @@ impl AudioBackend for PwBackend {
                                         break;
                                     }
 
-                                    buf_pos += n_bytes;
-                                    buffer.pos = buf_pos;
                                     n_samples -= n_bytes;
                                     start += n_bytes;
 
-                                    if buf_pos >= buffer.desc_len() as usize {
+                                    if buffer.pos >= buffer.desc_len() as usize {
                                         stream.buffers.pop_front();
                                     }
                                 }


### PR DESCRIPTION
### Summary of the PR

For capturing, pipewire backend is incrementing the position in the buffer, however, this is already done by write_input() thus resulting in incrementing two times the position. This commit removes the incrementation that happens in pipewire.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
