### PR TITLE
sound/pipewire: destroy multiple pipewire streams that are not destroyed

### DIFF
--- a/vhost-device-sound/src/stream.rs
+++ b/vhost-device-sound/src/stream.rs
@@ -21,6 +21,8 @@ pub enum Error {
     DescriptorReadFailed,
     #[error("Descriptor write failed")]
     DescriptorWriteFailed,
+    #[error("Could not disconnect stream")]
+    CouldNotDisconnectStream,
 }
 
 type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION

### Summary of the PR

The PCM command transition prepare->prepare or set_param->prepare is allowed by the specification. however this type of transition in pipewire lead to multiple creation of pipewire streams that are not destroyed. This PR ensures that in a case like this, when the prepare fn() in the pipewire backend is called multiple times without the release fn(), there should be only one pipewire stream.

Close #490

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
