### PR TITLE
sound/alsa: fix conversion from one type to another

### DIFF
--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -160,9 +160,9 @@ fn update_pcm(
 
             // Finally, calculate the size of a period (in frames):
 
-            let period_frames = period_bytes / frame_size;
+            let period_frames = alsa::pcm::Frames::from((period_bytes / frame_size) as i32);
 
-            hwp.set_period_size(i64::from(period_frames), alsa::ValueOr::Less)?;
+            hwp.set_period_size(period_frames, alsa::ValueOr::Less)?;
 
             // Online ALSA driver recommendations seem to be that the buffer should be at
             // least 2 * period_size.
@@ -175,7 +175,7 @@ fn update_pcm(
             // > as well as the parameters set in the snd_pcm_hardware structure (in the driver).
             //
             // So, if the operation fails let's assume the ALSA runtime has set a better value.
-            if let Err(err) = hwp.set_buffer_size_near(2 * i64::from(period_frames)) {
+            if let Err(err) = hwp.set_buffer_size_near(2 * period_frames) {
                 log::error!("could not set buffer size {}: {}", 2 * period_frames, err);
             }
 


### PR DESCRIPTION
### Summary of the PR

Using i64, the code currently fails to compile on 32-bit architectures, the root cause seem to be that the functions set_period_size() and set_buffer_size_near() in alsa take differently sized arguments on different architectures. This fix allows compatibility with other architectures.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
