### PR TITLE
sound/alsa: Handle Error instead of unwrapping

### DIFF
--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -500,9 +500,15 @@ impl AlsaBackend {
             let (sender, receiver) = channel();
             // Initialize with a dummy value, which will be updated every time we call
             // `update_pcm`.
-            let pcm = Arc::new(Mutex::new(
-                PCM::new("default", Direction::Output.into(), false).unwrap(),
-            ));
+            let pcm_result = PCM::new("default", Direction::Output.into(), false);
+            let pcm = match pcm_result {
+                Ok(pcm) => pcm,
+                Err(err) => {
+                    log::error!("Failed to initialize PCM device: {}", err);
+                    continue;
+                }
+            };
+            let pcm = Arc::new(Mutex::new(pcm));
 
             let mtx = Arc::clone(&pcm);
             let streams = Arc::clone(&streams);


### PR DESCRIPTION

### Summary of the PR

Instead of unwrapping the result of PCM::new(),
which could potentially lead to a runtime panic
if PCM::new() returns an error, use a match
statement to handle the error gracefully.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
