### PR TITLE
vsock/README: simplify the examples using memfd

### DIFF
--- a/vhost-device-vsock/README.md
+++ b/vhost-device-vsock/README.md
@@ -83,7 +83,7 @@ Run VMM (e.g. QEMU):
 ```
 qemu-system-x86_64 \
   <normal QEMU options> \
-  -object memory-backend-file,share=on,id=mem0,size=<Guest RAM size>,mem-path=<Guest RAM file path> \ # size == -m size
+  -object memory-backend-memfd,id=mem0,size=<Guest RAM size> \ # size == -m size
   -machine <machine options>,memory-backend=mem0 \
   -chardev socket,id=char0,reconnect=0,path=<vhost-user socket path> \
   -device vhost-user-vsock-pci,chardev=char0
@@ -101,8 +101,8 @@ shell1$ vhost-device-vsock --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/
 
 ```sh
 shell2$ qemu-system-x86_64 \
-          -drive file=vm.qcow2,format=qcow2,if=virtio -smp 2 -m 512M -mem-prealloc \
-          -object memory-backend-file,share=on,id=mem0,size=512M,mem-path="/dev/hugepages" \
+          -drive file=vm.qcow2,format=qcow2,if=virtio -smp 2 \
+          -object memory-backend-memfd,id=mem0,size=512M \
           -machine q35,accel=kvm,memory-backend=mem0 \
           -chardev socket,id=char0,reconnect=0,path=/tmp/vhost4.socket \
           -device vhost-user-vsock-pci,chardev=char0
@@ -159,14 +159,14 @@ For example, if you have two VMs with CID 3 and 4, you can run the following com
 shell1$ vhost-device-vsock --vm guest-cid=3,uds-path=/tmp/vm3.vsock,socket=/tmp/vhost3.socket,groups=group1+group2 \
           --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/vhost4.socket,groups=group1
 shell2$ qemu-system-x86_64 \
-          -drive file=vm1.qcow2,format=qcow2,if=virtio -smp 2 -m 512M -mem-prealloc \
-          -object memory-backend-file,share=on,id=mem0,size=512M,mem-path="/dev/hugepages" \
+          -drive file=vm1.qcow2,format=qcow2,if=virtio -smp 2 \
+          -object memory-backend-memfd,id=mem0,size=512M \
           -machine q35,accel=kvm,memory-backend=mem0 \
           -chardev socket,id=char0,reconnect=0,path=/tmp/vhost3.socket \
           -device vhost-user-vsock-pci,chardev=char0
 shell3$ qemu-system-x86_64 \
-          -drive file=vm2.qcow2,format=qcow2,if=virtio -smp 2 -m 512M -mem-prealloc \
-          -object memory-backend-file,share=on,id=mem0,size=512M,mem-path="/dev/hugepages2" \
+          -drive file=vm2.qcow2,format=qcow2,if=virtio -smp 2 \
+          -object memory-backend-memfd,id=mem0,size=512M \
           -machine q35,accel=kvm,memory-backend=mem0 \
           -chardev socket,id=char0,reconnect=0,path=/tmp/vhost4.socket \
           -device vhost-user-vsock-pci,chardev=char0


### PR DESCRIPTION
### Summary of the PR

In the examples we used hugepages, which could be useful in special cases where the performance matters, but this requires specific configuration and permissions to allocate them.

Let's simplify the examples by using memfd, removing `--mem-prealloc`, and the superfluous `-m 512M`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
