### PR TITLE
vhost-device-vsock: increase max queue size to 1024

### DIFF
--- a/vhost-device-vsock/README.md
+++ b/vhost-device-vsock/README.md
@@ -44,18 +44,19 @@ vhost-device-vsock --guest-cid=<CID assigned to the guest> \
   --socket=<path to the Unix socket to be created to communicate with the VMM via the vhost-user protocol> \
   --uds-path=<path to the Unix socket to communicate with the guest via the virtio-vsock device> \
   [--tx-buffer-size=<size of the buffer used for the TX virtqueue (guest->host packets)>] \
+  [--queue-size=<size of the vring queue>] \
   [--groups=<list of group names to which the device belongs concatenated with '+' delimiter>]
 ```
 or
 ```
-vhost-device-vsock --vm guest_cid=<CID assigned to the guest>,socket=<path to the Unix socket to be created to communicate with the VMM via the vhost-user protocol>,uds-path=<path to the Unix socket to communicate with the guest via the virtio-vsock device>[,tx-buffer-size=<size of the buffer used for the TX virtqueue (guest->host packets)>][,groups=<list of group names to which the device belongs concatenated with '+' delimiter>]
+vhost-device-vsock --vm guest_cid=<CID assigned to the guest>,socket=<path to the Unix socket to be created to communicate with the VMM via the vhost-user protocol>,uds-path=<path to the Unix socket to communicate with the guest via the virtio-vsock device>[,tx-buffer-size=<size of the buffer used for the TX virtqueue (guest->host packets)>][,queue-size=<size of the vring queue>][,groups=<list of group names to which the device belongs concatenated with '+' delimiter>]
 ```
 
 Specify the `--vm` argument multiple times to specify multiple devices like this:
 ```
 vhost-device-vsock \
 --vm guest-cid=3,socket=/tmp/vhost3.socket,uds-path=/tmp/vm3.vsock,groups=group1+groupA \
---vm guest-cid=4,socket=/tmp/vhost4.socket,uds-path=/tmp/vm4.vsock,tx-buffer-size=32768
+--vm guest-cid=4,socket=/tmp/vhost4.socket,uds-path=/tmp/vm4.vsock,tx-buffer-size=32768,queue-size=256
 ```
 
 Or use a configuration file:
@@ -70,11 +71,13 @@ vms:
       socket: /tmp/vhost3.socket
       uds_path: /tmp/vm3.sock
       tx_buffer_size: 65536
+      queue_size: 1024
       groups: group1+groupA
     - guest_cid: 4
       socket: /tmp/vhost4.socket
       uds_path: /tmp/vm4.sock
       tx_buffer_size: 32768
+      queue_size: 256
       groups: group2+groupB
 ```
 
@@ -94,9 +97,9 @@ qemu-system-x86_64 \
 ```sh
 shell1$ vhost-device-vsock --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/vhost4.socket
 ```
-or if you want to configure the TX buffer size
+or if you want to configure the TX buffer size and vring queue size
 ```sh
-shell1$ vhost-device-vsock --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/vhost4.socket,tx-buffer-size=65536
+shell1$ vhost-device-vsock --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/vhost4.socket,tx-buffer-size=65536,queue-size=1024
 ```
 
 ```sh

--- a/vhost-device-vsock/src/main.rs
+++ b/vhost-device-vsock/src/main.rs
@@ -27,7 +27,7 @@ use vm_memory::{GuestMemoryAtomic, GuestMemoryMmap};
 
 const DEFAULT_GUEST_CID: u64 = 3;
 const DEFAULT_TX_BUFFER_SIZE: u32 = 64 * 1024;
-const DEFAULT_QUEUE_SIZE: usize = 256;
+const DEFAULT_QUEUE_SIZE: usize = 1024;
 const DEFAULT_GROUP_NAME: &str = "default";
 
 #[derive(Debug, ThisError)]

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -356,6 +356,7 @@ mod tests {
 
     const DATA_LEN: usize = 16;
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
+    const QUEUE_SIZE: usize = 1024;
     const GROUP_NAME: &str = "default";
 
     #[test]
@@ -471,6 +472,7 @@ mod tests {
             sibling_vhost_socket_path,
             sibling_vsock_socket_path,
             CONN_TX_BUF_SIZE,
+            QUEUE_SIZE,
             vec!["group1", "group2", "group3"]
                 .into_iter()
                 .map(String::from)
@@ -482,6 +484,7 @@ mod tests {
             sibling2_vhost_socket_path,
             sibling2_vsock_socket_path,
             CONN_TX_BUF_SIZE,
+            QUEUE_SIZE,
             vec!["group1"].into_iter().map(String::from).collect(),
         );
 


### PR DESCRIPTION
### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

When running "vhost-device-vsock" against QEMU's "vhost-user-vsock-device" (i.e., mmio version, not the pci one) causes an error output on the vhost-device-vsock terminal:
```
[2024-06-30T10:57:54Z ERROR vhost_device_vsock] Fatal error: failed to handle request: invalid parameters 
```
And some errors on the QEMU terminal too like below:
```
qemu-system-x86_64: Failed to read msg header. Read -1 instead of 12.
Original request 1.
qemu-system-x86_64: Failed to write msg. Wrote -1 instead of 20.
qemu-system-x86_64: vhost VQ 1 ring restore failed: -22: Invalid argument (22)
qemu-system-x86_64: Failed to set msg fds.
qemu-system-x86_64: vhost VQ 0 ring restore failed: -22: Invalid argument (22)
qemu-system-x86_64: Error starting vhost: 71
qemu-system-x86_64: Failed to set msg fds.
qemu-system-x86_64: vhost_set_vring_call failed 22
qemu-system-x86_64: Failed to set msg fds.
qemu-system-x86_64: vhost_set_vring_call failed 22
```

I debugged this on the QEMU side and traced it back to trying to set the vring queue size to 1024  and I think the "InvalidParameter" error comes from the ["set_vring_num"](https://github.com/rust-vmm/vhost/blob/main/vhost-user-backend/src/handler.rs#L344C1-L346C10) function in vhost-device-vsock. The commands to reproduce this are below:

shell1: `./target/release/vhost-device-vsock --vm guest-cid=4,uds-path=/tmp/vm4.vsock,socket=/tmp/vhost4.socket`

shell2: `./qemu-system-x86_64 -M microvm,memory-backend=mem0 -kernel ./bzImage -nographic -append "console=ttyS0 nokaslr" -initrd ./initramfs.cpio.gz -m 4G --enable-kvm -cpu host -object memory-backend-memfd,id=mem0,size=4G -chardev socket,id=char0,reconnect=0,path=/tmp/vhost4.socket -device vhost-user-vsock-device,chardev=char0`

I built the bzImage from linux kernel 6.9.3. From what I understand, in the linux driver side in "drivers/virtio/virtio_mmio.c" the "vm_setup_vq" function first reads the max queue size (VIRTIO_MMIO_QUEUE_NUM_MAX) and then sets it to be the queue size (VIRTIO_MMIO_QUEUE_NUM). In the QEMU side, the max queue size is in "include/hw/virtio/virtio.h" "VIRTQUEUE_MAX_SIZE" which is 1024. I think it makes sense to just increase the max queue size in vhost-device-vsock too. The errors go away if I do so.

Edit: Per review comments, a new queue-size option is introduced and the default value of queue size has been changed to 1024

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
