### PR TITLE
scmi: Prepare v0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "vhost-device-scmi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_matches",
  "clap",

--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 ### Deprecated
 
+## [0.2.0]
+
+## Changed
+
+- [[#571]](https://github.com/rust-vmm/vhost-device/pull/571) scmi: use PathBuf for socket path
+- [[#572]](https://github.com/rust-vmm/vhost-device/pull/572) scmi: make socket_path required
+- [[#575]](https://github.com/rust-vmm/vhost-device/pull/575) scmi: revert to previous --help-devices behavior
+- Update rust-vmm and local dependencies.
+
 ## [0.1.0]
 
 First release

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-device-scmi"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Milan Zamazal <mzamazal@redhat.com>"]
 description = "vhost-user SCMI backend device"
 repository = "https://github.com/rust-vmm/vhost-device"


### PR DESCRIPTION
Update CHANGELOG.md and Cargo.toml for v0.2.0 relase.
