### PR TITLE
Vhost device scmi notification implement

### DIFF
--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -224,7 +224,7 @@ pub fn devices_help() -> String {
 #[derive(Debug)]
 pub struct Sensor {
     /// The sensor name (possibly truncated) as reported to the guest.
-    pub name: String,
+    pub name: Option<String>,
     /// Whether the sensor is enabled.
     ///
     /// Sensors can be enabled and disabled using SCMI.  [Sensor]s created
@@ -233,10 +233,9 @@ pub struct Sensor {
 }
 
 impl Sensor {
-    pub fn new(properties: &DeviceProperties, default_name: &str) -> Self {
-        let name = properties.get("name").unwrap_or(default_name);
+    pub fn new(properties: &DeviceProperties) -> Self {
         Self {
-            name: name.to_owned(),
+            name: properties.get("name").map(|s| (*s).to_owned()),
             enabled: false,
         }
     }
@@ -323,7 +322,8 @@ pub trait SensorT: Send {
         } else {
             self.format_unit(0)
         };
-        let name = self.sensor().name.clone();
+        // During initialization, sensor name has be set.
+        let name = self.sensor().name.clone().unwrap();
         let values: MessageValues = vec![
             // attributes low
             MessageValue::Unsigned(low),

--- a/vhost-device-scmi/src/devices/fake.rs
+++ b/vhost-device-scmi/src/devices/fake.rs
@@ -59,7 +59,7 @@ impl SensorT for FakeSensor {
 impl FakeSensor {
     pub fn new_device(properties: &DeviceProperties) -> MaybeDevice {
         properties.check(&[], &["name"])?;
-        let sensor = Sensor::new(properties, "fake");
+        let sensor = Sensor::new(properties);
         let fake_sensor = Self { sensor, value: 0 };
         let sensor_device = SensorDevice(Box::new(fake_sensor));
         Ok(Box::new(sensor_device))

--- a/vhost-device-scmi/src/devices/fake.rs
+++ b/vhost-device-scmi/src/devices/fake.rs
@@ -9,9 +9,9 @@
 //! arranging SCMI virtualization setup without the need to bind real host
 //! devices.
 
-use crate::scmi::{self, DeviceResult, MessageValue};
-
 use super::common::{DeviceProperties, MaybeDevice, Sensor, SensorDevice, SensorT};
+use crate::scmi::{self, DeviceResult, MessageValue};
+use std::os::unix::io::RawFd;
 
 pub struct FakeSensor {
     sensor: Sensor,
@@ -51,6 +51,25 @@ impl SensorT for FakeSensor {
             result.push(MessageValue::Unsigned(0));
             result.push(MessageValue::Unsigned(0));
             result.push(MessageValue::Unsigned(0));
+        }
+        Ok(result)
+    }
+
+    fn get_notify_fd(&self) -> Option<RawFd> {
+        Some(1)
+    }
+
+    fn reading_update(&mut self, device_index: u32) -> DeviceResult {
+        let value = self.value;
+        self.value = self.value.overflowing_add(1).0;
+        let mut result = vec![];
+        result.push(MessageValue::Unsigned(0));
+        result.push(MessageValue::Unsigned(device_index));
+        for i in 0..3 {
+            result.push(MessageValue::Signed(i32::from(value) + 100 * i));
+            result.push(MessageValue::Signed(0));
+            result.push(MessageValue::Signed(0));
+            result.push(MessageValue::Signed(0));
         }
         Ok(result)
     }

--- a/vhost-device-scmi/src/devices/iio.rs
+++ b/vhost-device-scmi/src/devices/iio.rs
@@ -280,8 +280,8 @@ impl SensorT for IIOSensor {
         let mut result = vec![];
         for axis in &self.axes {
             let value = self.read_axis(axis)?;
-            result.push(MessageValue::Unsigned((value & 0xFFFFFFFF) as u32));
-            result.push(MessageValue::Unsigned((value >> 32) as u32));
+            result.push(MessageValue::Signed((value & 0xFFFFFFFF) as i32));
+            result.push(MessageValue::Signed((value >> 32) as i32));
             result.push(MessageValue::Unsigned(0));
             result.push(MessageValue::Unsigned(0));
         }
@@ -784,8 +784,8 @@ mod tests {
         // custom exponent = 2
         // applied and rounded: 45037037598 = 0xA7C6AA81E
         assert_eq!(result.len(), 4);
-        assert_eq!(result.first().unwrap(), &MessageValue::Unsigned(0x7C6AA81E));
-        assert_eq!(result.get(1).unwrap(), &MessageValue::Unsigned(0xA));
+        assert_eq!(result.first().unwrap(), &MessageValue::Signed(0x7C6AA81E));
+        assert_eq!(result.get(1).unwrap(), &MessageValue::Signed(0xA));
         assert_eq!(result.get(2).unwrap(), &MessageValue::Unsigned(0));
         assert_eq!(result.get(3).unwrap(), &MessageValue::Unsigned(0));
     }
@@ -801,8 +801,8 @@ mod tests {
         sensor.initialize().unwrap();
         let result = sensor.reading_get().unwrap();
         assert_eq!(result.len(), 4);
-        assert_eq!(result.first().unwrap(), &MessageValue::Unsigned(0x5A));
-        assert_eq!(result.get(1).unwrap(), &MessageValue::Unsigned(0));
+        assert_eq!(result.first().unwrap(), &MessageValue::Signed(0x5A));
+        assert_eq!(result.get(1).unwrap(), &MessageValue::Signed(0));
         assert_eq!(result.get(2).unwrap(), &MessageValue::Unsigned(0));
         assert_eq!(result.get(3).unwrap(), &MessageValue::Unsigned(0));
     }
@@ -823,12 +823,15 @@ mod tests {
         sensor.initialize().unwrap();
         let result = sensor.reading_get().unwrap();
         assert_eq!(result.len(), 12);
-        assert_eq!(result.first().unwrap(), &MessageValue::Unsigned(22));
-        assert_eq!(result.get(4).unwrap(), &MessageValue::Unsigned(60));
-        assert_eq!(result.get(8).unwrap(), &MessageValue::Unsigned(150));
+        assert_eq!(result.first().unwrap(), &MessageValue::Signed(22));
+        assert_eq!(result.get(4).unwrap(), &MessageValue::Signed(60));
+        assert_eq!(result.get(8).unwrap(), &MessageValue::Signed(150));
         for i in 0..12 {
-            if i % 4 != 0 {
+            if i % 4 == 2 || i % 4 == 3 {
                 assert_eq!(result.get(i).unwrap(), &MessageValue::Unsigned(0));
+            }
+            if i % 4 == 1 {
+                assert_eq!(result.get(i).unwrap(), &MessageValue::Signed(0));
             }
         }
     }

--- a/vhost-device-scmi/src/devices/iio.rs
+++ b/vhost-device-scmi/src/devices/iio.rs
@@ -453,8 +453,12 @@ impl IIOSensor {
 
     fn read_axis(&self, axis: &Axis) -> Result<i64, ScmiDeviceError> {
         let path_result = axis.path.clone().into_string();
-        let mut value: i64 =
+        let value: i64 =
             read_number_from_file(Path::new(&(path_result.unwrap() + "_raw")))?.unwrap();
+        self.deal_axis_raw_data(value, axis)
+    }
+
+    fn deal_axis_raw_data(&self, mut value: i64, axis: &Axis) -> Result<i64, ScmiDeviceError> {
         let offset: Option<i64> = self.read_axis_offset(&axis.path)?;
         if let Some(offset_value) = offset {
             match value.checked_add(offset_value) {

--- a/vhost-device-scmi/src/devices/iio.rs
+++ b/vhost-device-scmi/src/devices/iio.rs
@@ -58,7 +58,7 @@ const UNIT_MAPPING: &[UnitMapping] = &[
         unit_exponent: 0,
     },
     UnitMapping {
-        channel: "in_anglevel",
+        channel: "in_anglvel",
         unit: scmi::SENSOR_UNIT_RADIANS_PER_SECOND,
         unit_exponent: 0,
     },

--- a/vhost-device-scmi/src/main.rs
+++ b/vhost-device-scmi/src/main.rs
@@ -126,6 +126,11 @@ fn start_backend(config: VuScmiConfig) -> Result<()> {
         )
         .unwrap();
 
+        // Register devices such as "/dev/iio:deviceX" which can actively notify the frontend to epoll the handler.
+        // Then once there is data coming from these devices, an event will be created. (device_event=3)
+        let handlers = daemon.get_epoll_handlers();
+        backend.read().unwrap().register_device_event_fd(handlers);
+
         daemon
             .serve(&config.socket_path)
             .map_err(|e| format!("{e}"))?;


### PR DESCRIPTION
### Summary of the PR

This is Samsung Team. We want to contribute scmi notification implement.
In virtio-spec, if feature VIRTIO_SCMI_F_P2A_CHANNELS was negotiated, device should implement SCMI notification.

In our embeded environment, we enable iio sensor with notification feature, and configure this feature.
