### PR TITLE
Cargo.lock: downgrade once_cell from 1.20.0 to 1.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "peeking_take_while"


### PR DESCRIPTION
`cargo audit` warned about a yanked version of once_cell we are using:
    Crate:     once_cell
    Version:   1.20.0
    Warning:   yanked
    Dependency tree:
    once_cell 1.20.0
    ├── which 4.4.2
    │   └── bindgen 0.63.0
    │       └── libgpiod-sys 0.1.1
    │           └── libgpiod 0.2.1
    │               └── vhost-device-gpio 0.1.0
    ├── tempfile 3.12.0
    │   ├── vhost-device-vsock 0.2.0
    │   ├── vhost-device-sound 0.2.0
    │   ├── vhost-device-scsi 0.1.0
    │   ├── vhost-device-rng 0.1.0
    │   └── vhost-device-input 0.1.0
    └── pipewire 0.8.0
        └── vhost-device-sound 0.2.0
