### PR TITLE
Revert "vsock: Skip tests causing CI failure"

### DIFF
--- a/vhost-device-vsock/src/main.rs
+++ b/vhost-device-vsock/src/main.rs
@@ -483,8 +483,6 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;
-    #[cfg(feature = "backend_vsock")]
-    use vsock::VsockListener;
 
     impl VsockArgs {
         fn from_args_unix(
@@ -1047,12 +1045,6 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_server_vsock() {
-        if VsockListener::bind_with_cid_port(libc::VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).is_err()
-        {
-            println!("  SKIPPED: AF_VSOCK is not available.");
-            return;
-        }
-
         const CID: u64 = 3;
         const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
         const QUEUE_SIZE: usize = 1024;

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -604,12 +604,6 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_thread_backend_vsock() {
-        if VsockListener::bind_with_cid_port(libc::VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).is_err()
-        {
-            println!("  SKIPPED: AF_VSOCK is not available.");
-            return;
-        }
-
         let _listener = VsockListener::bind_with_cid_port(VMADDR_CID_ANY, VSOCK_PEER_PORT).unwrap();
         let backend_info = BackendType::Vsock(VsockProxyInfo {
             forward_cid: 1,

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -404,8 +404,6 @@ mod tests {
     use tempfile::tempdir;
     use vhost_user_backend::VringT;
     use vm_memory::GuestAddress;
-    #[cfg(feature = "backend_vsock")]
-    use vsock::VsockListener;
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
     const QUEUE_SIZE: usize = 1024;
@@ -503,12 +501,6 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_backend_vsock() {
-        if VsockListener::bind_with_cid_port(libc::VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).is_err()
-        {
-            println!("  SKIPPED: AF_VSOCK is not available.");
-            return;
-        }
-
         const CID: u64 = 3;
 
         let groups_list: Vec<String> = vec![String::from("default")];

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -1041,12 +1041,6 @@ mod tests {
     #[cfg(feature = "backend_vsock")]
     #[test]
     fn test_vsock_thread_vsock_backend() {
-        if VsockListener::bind_with_cid_port(libc::VMADDR_CID_LOCAL, libc::VMADDR_PORT_ANY).is_err()
-        {
-            println!("  SKIPPED: AF_VSOCK is not available.");
-            return;
-        }
-
         let groups: Vec<String> = vec![String::from("default")];
         let cid_map: Arc<RwLock<CidMap>> = Arc::new(RwLock::new(HashMap::new()));
 


### PR DESCRIPTION
This reverts commit cec57c943354e938cde08ba984f8b1efb6cfa99a.

Thanks to https://github.com/rust-vmm/rust-vmm-ci/pull/165 our CI is now able to use AF_VSOCK, so let's force the tests to run to discover any problems in the future.

Thanks to @roypat for the help on debugging and finding the solution :-)