### PR TITLE
scmi: Prepare v0.3.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "vhost-device-scmi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_matches",
  "clap",

--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -7,9 +7,17 @@
 
 ### Fixed
 
-- [[#696]](https://github.com/rust-vmm/vhost-device/pull/696) scmi: Remove an unused piece of code
-
 ### Deprecated
+
+## v0.3.0
+
+### Added
+
+- [[#710]](https://github.com/rust-vmm/vhost-device/pull/710) Implement SCMI notifications
+
+### Fixed
+
+- [[#696]](https://github.com/rust-vmm/vhost-device/pull/696) scmi: Remove an unused piece of code
 
 ## v0.2.0
 

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vhost-device-scmi"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Milan Zamazal <mzamazal@redhat.com>"]
 description = "vhost-user SCMI backend device"
 repository = "https://github.com/rust-vmm/vhost-device"


### PR DESCRIPTION
Update CHANGELOG.md and Cargo.toml for v0.3.0 release. This release adds SCMI notification support.

### Summary of the PR

Let's make with a new release of vhost-device-scmi, with SCMI notification support.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ x] All added/changed functionality has a corresponding unit/integration
  test.
- [ x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ x] Any newly added `unsafe` code is properly documented.
