### PR TITLE
vsock: Set VhostUserProtocolFeatures::MQ

### DIFF
--- a/vhost-device-vsock/CHANGELOG.md
+++ b/vhost-device-vsock/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 ### Added
+- [#755](https://github.com/rust-vmm/vhost-device/pull/755) Advertise `VhostUserProtocolFeatures::MQ` protocol feature
 - [#698](https://github.com/rust-vmm/vhost-device/pull/698) vsock: add mdoc page
 - [#706](https://github.com/rust-vmm/vhost-device/pull/706) Support proxying using vsock
 

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -306,7 +306,7 @@ impl VhostUserBackend for VhostUserVsockBackend {
     }
 
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
-        VhostUserProtocolFeatures::CONFIG
+        VhostUserProtocolFeatures::MQ | VhostUserProtocolFeatures::CONFIG
     }
 
     fn set_event_idx(&self, enabled: bool) {


### PR DESCRIPTION
As per the vhost-user specification:

"Back-ends should always implement the VHOST_USER_PROTOCOL_F_MQ protocol feature, even for devices with a fixed number of virtqueues, since it is simple to implement and offers a degree of introspection."

Vsock backend support three virtqueues and hence this should be set.

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
