### PR TITLE
ci: Allow different configs for the same directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
       vhost-device:
         patterns:
           - "*"
+  # Makes it possible to have another config for the same directory.
+  # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
+  target-branch: main
+
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:


### PR DESCRIPTION
### Summary of the PR

Currently `dependabot` does not allow different configurations for the same directories. This workaround [1] provides a way to bypass this restriction.

[1] https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
