### PR TITLE
dependabot: exclude rust-vmm crates from monthly task

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,14 @@ updates:
       vhost-device:
         patterns:
           - "*"
+        exclude-patterns:
+          - "vhost"
+          - "vhost-user-backend"
+          - "virtio-bindings"
+          - "virtio-queue"
+          - "virtio-vsock"
+          - "vm-memory"
+          - "vmm-sys-util"
   # Makes it possible to have another config for the same directory.
   # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
   target-branch: main


### PR DESCRIPTION
Without this, dependabot can open 2 PRs with same updates, see:
- https://github.com/rust-vmm/vhost-device/pull/762
- https://github.com/rust-vmm/vhost-device/pull/769]

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
