### PR TITLE
dependabot: Group updates to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,30 +7,17 @@ updates:
   schedule:
     interval: weekly
   allow:
-  - dependency-type: direct
-  - dependency-type: indirect
+    - dependency-name: "vhost"
+    - dependency-name: "vhost-user-backend"
+    - dependency-name: "virtio-bindings"
+    - dependency-name: "virtio-queue"
+    - dependency-name: "virtio-vsock"
+    - dependency-name: "vm-memory"
+    - dependency-name: "vmm-sys-util"
   groups:
       rust-vmm:
         patterns:
-          - "vhost"
-          - "vhost-user-backend"
-          - "virtio-bindings"
-          - "virtio-queue"
-          - "virtio-vsock"
-          - "vm-memory"
-          - "vmm-sys-util"
-      non-rust-vmm:
-        applies-to: security-updates
-        patterns:
           - "*"
-        exclude-patterns:
-          - "vhost"
-          - "vhost-user-backend"
-          - "virtio-bindings"
-          - "virtio-queue"
-          - "virtio-vsock"
-          - "vm-memory"
-          - "vmm-sys-util"
 - package-ecosystem: cargo
   directories:
     - "/"
@@ -38,10 +25,17 @@ updates:
   schedule:
     interval: monthly
   allow:
-  - dependency-type: direct
-  - dependency-type: indirect
+    - dependency-type: all
+  ignore:
+    - dependency-name: "vhost"
+    - dependency-name: "vhost-user-backend"
+    - dependency-name: "virtio-bindings"
+    - dependency-name: "virtio-queue"
+    - dependency-name: "virtio-vsock"
+    - dependency-name: "vm-memory"
+    - dependency-name: "vmm-sys-util"
   groups:
-      vhost-device:
+      non-rust-vmm:
         patterns:
           - "*"
   # Makes it possible to have another config for the same directory.


### PR DESCRIPTION
### Summary of the PR

We have missused `exclude-patterns` and `applies-to` in previous setup, they are documented in [1]:

- `exclude-patterns`: Use to exclude certain dependencies from the group. If a dependency is excluded from a group, Dependabot will continue to **raise single pull requests** to update the dependency to its latest version.
- `applies-to`: Use to specify whether the rules in the group apply to version updates or security updates. applies-to can be version-updates or security-updates.

Options in `groups` section is a matter of grouping strategy of these detected udpates.

All in all, to effectively "group" these updates, we need to use `allow` and `ignore` to specify update "candidates" for dependabot, if the "candidates" were duplicated in the first place, no matter the grouping strategy, the PRs raised are bound to be overlaped/duplicated.

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
