### PR TITLE
vhost-device-input: prepare release v0.1.0

### DIFF
--- a/vhost-device-input/CHANGELOG.md
+++ b/vhost-device-input/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 ## Unreleased
 
-- First initial vhost-device-input daemon implementation.
-
 ### Added
 
 ### Changed
@@ -10,4 +8,8 @@
 ### Fixed
 
 ### Deprecated
+
+## v0.1.0
+
+First release
 


### PR DESCRIPTION
It seems that we haven't tagged a release since vhost-device-input PR was merged.

Let's now release the first version: v0.1.0

Closes: #780
