### PR TITLE
gpu: guard gfxstream dependency with a feature

### DIFF
--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -10,9 +10,14 @@ categories = ["multimedia::video", "virtualization"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2021"
 publish = false
+# "Features enabled on platform-specific dependencies for target architectures not currently being built are ignored."
+# See <https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2>
+resolver = "2"
 
 [features]
+default = ["gfxstream"]
 xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
+gfxstream = ["rutabaga_gfx/gfxstream"]
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }
@@ -21,7 +26,7 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(not(target_env = "musl"))'.dependencies]
-rutabaga_gfx = { version = "0.1.4", features = ["gfxstream", "virgl_renderer"] }
+rutabaga_gfx = { version = "0.1.4", features = ["virgl_renderer"] }
 thiserror = "2.0.3"
 vhost = { version = "0.13.0", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.17"

--- a/staging/vhost-device-gpu/Cargo.toml
+++ b/staging/vhost-device-gpu/Cargo.toml
@@ -32,8 +32,8 @@ vmm-sys-util = "0.12.1"
 
 [dev-dependencies]
 assert_matches = "1.5"
+mockall = "0.13.0"
+rusty-fork = "0.3.0"
 tempfile = "3.13"
 virtio-queue = { version = "0.14", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
-mockall = "0.13.0"
-rusty-fork = "0.3.0"

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -1,36 +1,34 @@
 # vhost-device-gpu - GPU emulation backend daemon
 
 ## Synopsis
+
 ```shell
-vhost-device-gpu --socket-path <SOCKET>
+vhost-device-gpu --socket-path <SOCKET> --gpu-mode <GPU_MODE>
 ```
 
 ## Description
+
 A virtio-gpu device using the vhost-user protocol.
 
 ## Options
 
 ```text
-       -s, --socket-path <SOCKET>
-              vhost-user Unix domain socket path
-
-       -h, --help
-              Print help
-
-       -V, --version
-              Print version
+  -s, --socket-path <SOCKET>  vhost-user Unix domain socket
+  -g, --gpu-mode <GPU_MODE>   [possible values: virgl-renderer, gfxstream]
+  -h, --help                  Print help
+  -V, --version               Print version
 ```
 
 ## Limitations
 
 We are currently only supporting sharing the display output to QEMU through a
 socket using the transfer_read operation triggered by
-VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D to transfer data from and to virtio-gpu 3d
+`VIRTIO_GPU_CMD_TRANSFER_FROM_HOST_3D` to transfer data from and to virtio-gpu 3D
 resources. It'll be nice to have support for directly sharing display output
 resource using dmabuf.
 
-This device does not yet support the VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB,
-VIRTIO_GPU_CMD_SET_SCANOUT_BLOB and VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID features.
+This device does not yet support the `VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB`,
+`VIRTIO_GPU_CMD_SET_SCANOUT_BLOB` and `VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID` features.
 
 Currently this crate requires some necessary bits in order to move the crate out of staging:
 
@@ -40,18 +38,21 @@ Currently this crate requires some necessary bits in order to move the crate out
 
 ## Features
 
-The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx) crate
-to provide virglrenderer and gfxstream rendering. With Virglrenderer, Rutabaga
-translates OpenGL API and Vulkan calls to an intermediate representation and allows
-for OpenGL acceleration on the host. With the gfxstream rendering mode, GLES and
-Vulkan calls are forwarded to the host with minimal modification.
+The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx)
+crate to provide rendering with virglrenderer and gfxstream.
+
+With Virglrenderer, Rutabaga translates OpenGL API and Vulkan calls to an
+intermediate representation and allows for OpenGL acceleration on the host.
+
+With the gfxstream rendering mode, GLES and Vulkan calls are forwarded to the
+host with minimal modification.
 
 ## Examples
 
 First start the daemon on the host machine using either of the 2 gpu modes:
 
-1) virgl-renderer
-2) gfxstream
+1) `virgl-renderer`
+2) `gfxstream`
 
 ```shell
 host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virgl-renderer

--- a/staging/vhost-device-gpu/README.md
+++ b/staging/vhost-device-gpu/README.md
@@ -19,6 +19,9 @@ A virtio-gpu device using the vhost-user protocol.
   -V, --version               Print version
 ```
 
+_NOTE_: Option `-g, --gpu-mode` can only accept the `gfxstream` value if the
+crate has been built with the `gfxstream` feature, which is the default.
+
 ## Limitations
 
 We are currently only supporting sharing the display output to QEMU through a
@@ -41,6 +44,12 @@ Currently this crate requires some necessary bits in order to move the crate out
 The device leverages the [rutabaga_gfx](https://crates.io/crates/rutabaga_gfx)
 crate to provide rendering with virglrenderer and gfxstream.
 
+gfxstream support is compiled by default, it can be disabled by not building with the `gfxstream` feature flag, for example:
+
+```session
+$ cargo build --no-default-features
+```
+
 With Virglrenderer, Rutabaga translates OpenGL API and Vulkan calls to an
 intermediate representation and allows for OpenGL acceleration on the host.
 
@@ -52,7 +61,7 @@ host with minimal modification.
 First start the daemon on the host machine using either of the 2 gpu modes:
 
 1) `virgl-renderer`
-2) `gfxstream`
+2) `gfxstream` (if the crate has been compiled with the feature `gfxstream`)
 
 ```shell
 host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virgl-renderer

--- a/staging/vhost-device-gpu/src/lib.rs
+++ b/staging/vhost-device-gpu/src/lib.rs
@@ -49,6 +49,7 @@ use clap::ValueEnum;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum GpuMode {
     VirglRenderer,
+    #[cfg(feature = "gfxstream")]
     Gfxstream,
 }
 

--- a/staging/vhost-device-gpu/src/protocol.rs
+++ b/staging/vhost-device-gpu/src/protocol.rs
@@ -481,6 +481,7 @@ unsafe impl ByteValued for virtio_gpu_cmd_submit {}
 
 pub const VIRTIO_GPU_CAPSET_VIRGL: u32 = 1;
 pub const VIRTIO_GPU_CAPSET_VIRGL2: u32 = 2;
+#[cfg(feature = "gfxstream")]
 pub const VIRTIO_GPU_CAPSET_GFXSTREAM: u32 = 3;
 pub const VIRTIO_GPU_CAPSET_VENUS: u32 = 4;
 pub const VIRTIO_GPU_CAPSET_CROSS_DOMAIN: u32 = 5;

--- a/staging/vhost-device-gpu/src/virtio_gpu.rs
+++ b/staging/vhost-device-gpu/src/virtio_gpu.rs
@@ -390,6 +390,7 @@ impl RutabagaVirtioGpu {
     fn configure_rutabaga_builder(gpu_mode: GpuMode) -> RutabagaBuilder {
         let component = match gpu_mode {
             GpuMode::VirglRenderer => RutabagaComponentType::VirglRenderer,
+            #[cfg(feature = "gfxstream")]
             GpuMode::Gfxstream => RutabagaComponentType::Gfxstream,
         };
         RutabagaBuilder::new(component, 0)


### PR DESCRIPTION
Add a new compile-time feature, `gfxstream`, which is included in the
default features. The only thing that changes is that we can now build
without requiring `gfxstream_backend` on compilation time, which helps
in cases it is not packaged in a distro, or is not available at a user's
build machine.

Also update `README.md` with information about the build-time feature,
and do a light reformatting while at it.

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>

CC @dorindabassey @mtjhrc if you want to take a look