### PR TITLE
scmi: fix new clippy/rustc warnings

### DIFF
--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -66,12 +66,12 @@ impl DeviceProperties {
         self.0.iter().map(|(n, _)| -> &str { n.as_str() }).collect()
     }
 
-    fn extra<'a>(&'a self, allowed: &[&'a str]) -> HashSet<&str> {
+    fn extra<'a>(&'a self, allowed: &[&'a str]) -> HashSet<&'a str> {
         let allowed_set: HashSet<&str> = HashSet::from_iter(allowed.iter().copied());
         self.names().difference(&allowed_set).copied().collect()
     }
 
-    fn missing<'a>(&'a self, required: &[&'a str]) -> HashSet<&str> {
+    fn missing<'a>(&'a self, required: &[&'a str]) -> HashSet<&'a str> {
         let required_set: HashSet<&str> = HashSet::from_iter(required.iter().copied());
         required_set.difference(&self.names()).copied().collect()
     }

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -468,11 +468,7 @@ impl HandlerMap {
                 let max_sensors_to_return = 256;
                 let sensors_to_return = min(n_sensors - first_index, max_sensors_to_return);
                 let last_non_returned_sensor = first_index + sensors_to_return;
-                let remaining_sensors = if n_sensors > last_non_returned_sensor {
-                    n_sensors - last_non_returned_sensor
-                } else {
-                    0
-                };
+                let remaining_sensors = n_sensors.saturating_sub(last_non_returned_sensor);
                 let mut values = vec![MessageValue::Unsigned(
                     sensors_to_return as u32 | (remaining_sensors as u32) << 16,
                 )];


### PR DESCRIPTION
### Summary of the PR

clippy 0.1.83 (90b35a6 2024-11-26) emits a new warning about manual arithmetic check and rustc 1.83.0 (90b35a623 2024-11-26) emits 2 new warnings about elided lifetime has a name.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
