### PR TITLE
sound: Put AlsaTestHarness static in a LazyLock

### DIFF
--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -654,7 +654,7 @@ impl AudioBackend for AlsaBackend {
             .write()
             .unwrap()
             .get_mut(id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(id))?
+            .ok_or(Error::StreamWithIdNotFound(id))?
             .state
             .stop()
         {

--- a/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/alsa/test_utils.rs
@@ -3,58 +3,31 @@
 
 use std::{
     path::PathBuf,
-    sync::{
-        atomic::{AtomicU8, Ordering},
-        Arc, Mutex, Once,
-    },
+    sync::{Arc, LazyLock, Mutex},
 };
 
 use tempfile::{tempdir, TempDir};
 
-static mut TEST_HARNESS: Option<AlsaTestHarness> = None;
-static INIT_ALSA_CONF: Once = Once::new();
+static TEST_HARNESS: LazyLock<AlsaTestHarness> = LazyLock::new(AlsaTestHarness::new);
 
 #[must_use]
-pub fn setup_alsa_conf() -> AlsaTestHarnessRef<'static> {
-    INIT_ALSA_CONF.call_once(||
-        // SAFETY:
-        // This is only called once, because of.. `Once`, so it's safe to
-        // access the static value mutably.
-        unsafe {
-            TEST_HARNESS = Some(AlsaTestHarness::new());
-        });
-    let retval = AlsaTestHarnessRef(
-        // SAFETY:
-        // The unsafe { } block is needed because TEST_HARNESS is a mutable static. The inner
-        // operations are protected by atomics.
-        unsafe { TEST_HARNESS.as_ref().unwrap() },
-    );
-    retval.0.inc_ref();
-    retval
+pub fn setup_alsa_conf() -> &'static AlsaTestHarness {
+    // Dereferencing is necessary to perform the LazyLock init fn
+    &TEST_HARNESS
 }
 
-/// The alsa test harness. It must only be constructed via
-/// `AlsaTestHarness::new()`.
-#[non_exhaustive]
+/// The alsa test harness.
+///
+/// It sets up the `ALSA_CONFIG_PATH` variable pointing to a configuration file
+/// inside a temporary directory. This way the tests won't mess with the host
+/// machine's devices.
 pub struct AlsaTestHarness {
-    pub tempdir: Arc<Mutex<Option<TempDir>>>,
-    pub conf_path: PathBuf,
-    pub ref_count: AtomicU8,
-}
-
-/// Ref counted alsa test harness ref.
-#[repr(transparent)]
-#[non_exhaustive]
-pub struct AlsaTestHarnessRef<'a>(&'a AlsaTestHarness);
-
-impl<'a> Drop for AlsaTestHarnessRef<'a> {
-    fn drop(&mut self) {
-        self.0.dec_ref();
-    }
+    tempdir: Arc<Mutex<Option<TempDir>>>,
+    conf_path: PathBuf,
 }
 
 impl AlsaTestHarness {
-    pub fn new() -> Self {
+    fn new() -> Self {
         let tempdir = tempdir().unwrap();
         let conf_path = tempdir.path().join("alsa.conf");
 
@@ -74,55 +47,20 @@ impl AlsaTestHarness {
         Self {
             tempdir: Arc::new(Mutex::new(Some(tempdir))),
             conf_path,
-            ref_count: 0.into(),
-        }
-    }
-
-    #[inline]
-    pub fn inc_ref(&self) {
-        let old_val = self.ref_count.fetch_add(1, Ordering::SeqCst);
-        assert!(
-            old_val != u8::MAX,
-            "ref_count overflowed on 8bits when increasing by 1"
-        );
-    }
-
-    #[inline]
-    pub fn dec_ref(&self) {
-        let old_val = self.ref_count.fetch_sub(1, Ordering::SeqCst);
-        if old_val == 1 {
-            let mut lck = self.tempdir.lock().unwrap();
-            println!(
-                "INFO: unsetting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
-                self.conf_path.display(),
-                std::process::id(),
-                std::thread::current().id()
-            );
-            std::env::remove_var("ALSA_CONFIG_PATH");
-            _ = lck.take();
         }
     }
 }
 
 impl Drop for AlsaTestHarness {
     fn drop(&mut self) {
-        let ref_count = self.ref_count.load(Ordering::SeqCst);
-        if ref_count != 0 {
-            println!(
-                "ERROR: ref_count is {ref_count} when dropping {}",
-                stringify!(AlsaTestHarness)
-            );
-        }
-        if self
-            .tempdir
-            .lock()
-            .map(|mut l| l.take().is_some())
-            .unwrap_or(false)
-        {
-            println!(
-                "ERROR: tempdir held a value when dropping {}",
-                stringify!(AlsaTestHarness)
-            );
-        }
+        let mut lck = self.tempdir.lock().unwrap();
+        println!(
+            "INFO: unsetting ALSA_CONFIG_PATH={} in PID {} and TID {:?}",
+            self.conf_path.display(),
+            std::process::id(),
+            std::thread::current().id()
+        );
+        std::env::remove_var("ALSA_CONFIG_PATH");
+        _ = lck.take();
     }
 }

--- a/vhost-device-sound/src/audio_backends/null.rs
+++ b/vhost-device-sound/src/audio_backends/null.rs
@@ -10,7 +10,7 @@ pub struct NullBackend {
 }
 
 impl NullBackend {
-    pub fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
+    pub const fn new(streams: Arc<RwLock<Vec<Stream>>>) -> Self {
         Self { streams }
     }
 }

--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -195,7 +195,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .prepare();
         if let Err(err) = prepare_result {
@@ -500,7 +500,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .release();
         if let Err(err) = release_result {
@@ -529,7 +529,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .start();
         if let Err(err) = start_result {
@@ -554,7 +554,7 @@ impl AudioBackend for PwBackend {
             .write()
             .unwrap()
             .get_mut(stream_id as usize)
-            .ok_or_else(|| Error::StreamWithIdNotFound(stream_id))?
+            .ok_or(Error::StreamWithIdNotFound(stream_id))?
             .state
             .stop();
         if let Err(err) = stop_result {

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -92,11 +92,11 @@ impl VhostUserSoundThread {
     ) -> IoResult<()> {
         let vring = &vrings
             .get(device_event as usize)
-            .ok_or_else(|| Error::HandleUnknownEvent(device_event))?;
+            .ok_or(Error::HandleUnknownEvent(device_event))?;
         let queue_idx = self
             .queue_indexes
             .get(device_event as usize)
-            .ok_or_else(|| Error::HandleUnknownEvent(device_event))?;
+            .ok_or(Error::HandleUnknownEvent(device_event))?;
         if self.event_idx {
             // vm-virtio's Queue implementation only checks avail_index
             // once, so to properly support EVENT_IDX we need to keep

--- a/vhost-device-sound/src/stream.rs
+++ b/vhost-device-sound/src/stream.rs
@@ -266,7 +266,7 @@ impl std::fmt::Debug for Request {
 }
 
 impl Request {
-    pub fn new(len: usize, message: Arc<IOMessage>, direction: Direction) -> Self {
+    pub const fn new(len: usize, message: Arc<IOMessage>, direction: Direction) -> Self {
         Self {
             pos: 0,
             len,


### PR DESCRIPTION
Instead of using unsafe {} and undefined behavior (mutable shared static
references) use LazyLock which initializes the harness on first
dereference and provides immutable access only (the harness type has
interior mutability).

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>