### PR TITLE
sound/pipewire: add truncated exp backoff to tests and fork them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1475abae4f8ad4998590fe3acfe20104f0a5d48fc420c817cd2c09c3f56151f0"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1236,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1800,6 +1824,7 @@ dependencies = [
  "pipewire",
  "rand",
  "rstest",
+ "rusty-fork",
  "tempfile",
  "thiserror 2.0.3",
  "vhost",
@@ -1948,6 +1973,15 @@ checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
 dependencies = [
  "libc",
  "nix 0.29.0",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,6 +1798,7 @@ dependencies = [
  "env_logger",
  "log",
  "pipewire",
+ "rand",
  "rstest",
  "tempfile",
  "thiserror 2.0.3",

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -41,3 +41,4 @@ vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] 
 
 [target.'cfg(target_env = "gnu")'.dev-dependencies]
 rand = { version = "0.8.5" }
+rusty-fork = { version = "0.3.0" }

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -38,3 +38,6 @@ rstest = "0.23.0"
 tempfile = "3.14"
 virtio-queue = { version = "0.14", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
+
+[target.'cfg(target_env = "gnu")'.dev-dependencies]
+rand = { version = "0.8.5" }

--- a/vhost-device-sound/src/audio_backends.rs
+++ b/vhost-device-sound/src/audio_backends.rs
@@ -54,7 +54,11 @@ pub fn alloc_audio_backend(
     match backend {
         BackendType::Null => Ok(Box::new(NullBackend::new(streams))),
         #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
-        BackendType::Pipewire => Ok(Box::new(PwBackend::new(streams))),
+        BackendType::Pipewire => {
+            Ok(Box::new(PwBackend::new(streams).map_err(|err| {
+                crate::Error::UnexpectedAudioBackendError(err.into())
+            })?))
+        }
         #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
         BackendType::Alsa => Ok(Box::new(AlsaBackend::new(streams))),
     }

--- a/vhost-device-sound/src/audio_backends.rs
+++ b/vhost-device-sound/src/audio_backends.rs
@@ -80,11 +80,14 @@ mod tests {
         }
         #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
         {
-            use pipewire::{test_utils::PipewireTestHarness, *};
+            use pipewire::{
+                test_utils::{try_backoff, PipewireTestHarness},
+                *,
+            };
 
             let _test_harness = PipewireTestHarness::new();
             let v = BackendType::Pipewire;
-            let value = alloc_audio_backend(v, Default::default()).unwrap();
+            let value = try_backoff(|| alloc_audio_backend(v, Default::default()), std::num::NonZeroU32::new(3)).expect("reached maximum retry count");
             assert_eq!(TypeId::of::<PwBackend>(), value.as_any().type_id());
         }
         #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]

--- a/vhost-device-sound/src/audio_backends/alsa.rs
+++ b/vhost-device-sound/src/audio_backends/alsa.rs
@@ -609,7 +609,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
-                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
+                return Err(Error::UnexpectedAudioBackendError(err.into()));
             }
         }
         self.senders[stream_id as usize].send(true).unwrap();
@@ -642,7 +642,7 @@ impl AudioBackend for AlsaBackend {
                     stream_id,
                     err
                 );
-                return Err(Error::UnexpectedAudioBackendError(err.to_string()));
+                return Err(Error::UnexpectedAudioBackendError(err.into()));
             }
         }
         Ok(())

--- a/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 use std::{
+    convert::TryFrom,
     io::Read,
     path::Path,
     process::{Child, Command, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
 };
 
+use rand::distributions::Uniform;
 use tempfile::{tempdir, TempDir};
 
 /// Temporary Dbus session which is killed in drop().
@@ -80,13 +84,13 @@ impl PipewireTestHarness {
         println!("INFO: dbus_session_bus_address={}", dbus_session.address);
 
         println!("INFO: Wait for dbus to setup...");
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        sleep(Duration::from_secs(1));
 
         println!("INFO: Launch pipewire.");
         let pipewire_child = launch_pipewire(tempdir.path(), Path::new(&dbus_session.address))
             .expect("ERROR: Could not launch pipewire");
         println!("INFO: Wait for pipewire to setup...");
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        sleep(Duration::from_secs(1));
 
         std::env::set_var("DBUS_SESSION_BUS_ADDRESS", &dbus_session.address);
         std::env::set_var("XDG_RUNTIME_DIR", tempdir.path());
@@ -131,4 +135,69 @@ fn print_output(child: &mut Child, id: &'static str) -> Option<()> {
     }
 
     None
+}
+
+pub fn truncated_wait_delay<D: rand::distributions::Distribution<f32>, R: rand::Rng>(
+    slot_time: &Duration,
+    attempts_so_far: u32,
+    exponent_max: u32,
+    rng: &mut R,
+    distribution: &D,
+) -> Duration {
+    let attempts_so_far =
+        i32::try_from(attempts_so_far.clamp(0_u32, exponent_max)).unwrap_or(i32::MAX);
+    let position = distribution.sample(rng);
+    let max = 2_f32.powi(attempts_so_far) - 1.0_f32;
+    slot_time.mul_f32(position * max)
+}
+
+pub fn try_backoff<T, E: std::fmt::Display>(
+    closure: impl Fn() -> Result<T, E>,
+    max_retries: Option<std::num::NonZeroU32>,
+) -> Result<T, ()> {
+    const NO_DELAY: Duration = Duration::new(0, 0);
+
+    let max_retries: Option<u32> = max_retries.map(Into::into);
+    let mut iterations: u32 = 0;
+    let mut dur: Option<Duration> = None;
+    let mut rng = rand::thread_rng();
+
+    let distribution = Uniform::new(0.0_f32, 1.0_f32);
+
+    loop {
+        if max_retries.map_or(false, |max| iterations >= max) {
+            return Err(());
+        }
+
+        let start: Instant = Instant::now();
+        let result: Result<T, E> = closure();
+        let elapsed: Duration = start.elapsed();
+
+        iterations += 1;
+
+        match result {
+            Ok(v) => return Ok(v),
+            Err(err) => {
+                log::debug!("try_backoff: closured failed with {err}, will retry");
+            }
+        }
+
+        if let Some(dur_val) = &dur {
+            dur = Some((*dur_val * (iterations - 1) + elapsed) / iterations);
+        } else {
+            dur = Some(elapsed);
+        }
+
+        let delay: Duration = truncated_wait_delay(
+            dur.as_ref().unwrap_or(&NO_DELAY),
+            iterations,
+            10_u32,
+            &mut rng,
+            &distribution,
+        );
+
+        log::debug!("Sleeping for {}s", delay.as_secs_f64());
+
+        sleep(delay);
+    }
 }

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -161,7 +161,7 @@ pub enum Error {
     #[error("Audio backend not supported")]
     AudioBackendNotSupported,
     #[error("Audio backend unexpected error: {0}")]
-    UnexpectedAudioBackendError(String),
+    UnexpectedAudioBackendError(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Audio backend configuration not supported")]
     UnexpectedAudioBackendConfiguration,
     #[error("No memory configured")]


### PR DESCRIPTION
Sometimes pw backend creation on CI fails with errors like for example:

    thread 'audio_backends::pipewire::tests::test_pipewire_backend_invalid_stream' panicked at vhost-device-sound/src/audio_backends/pipewire.rs:98:42:
    Failed to connect to core: CreationFailed

Add a simple kind of truncated exponential backoff retry wrapper to
PwBackend::new().

Also, run all tests that modify their process environment under a fork using the `rusty_fork` crate.

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>

Depends on #788 which fixes lint warnings