### PR TITLE
Add xtask to generate manpages

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
 [target.aarch64-unknown-linux-musl]
 rustflags = [ "-C", "target-feature=+crt-static", "-C", "link-arg=-lgcc" ]
 
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "markdown"
+version = "1.0.0-alpha.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9047e0a37a596d4e15411a1ffbdabe71c328908cb90a721cb9bf8dcf3434e6d2"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +1751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-id"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2365,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_mangen",
+ "markdown",
  "toml 0.8.19",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "clap_mangen"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a"
+dependencies = [
+ "clap",
+ "roff",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,6 +1276,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
 name = "rstest"
@@ -2326,6 +2342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_mangen",
+ "toml 0.8.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ members = [
     "vhost-device-spi",
     "vhost-device-template",
     "vhost-device-vsock",
+    "xtask",
 ]

--- a/README.md
+++ b/README.md
@@ -115,3 +115,11 @@ Supporting Xen requires special handling while mapping the guest memory. The
 
 It was decided by the `rust-vmm` maintainers to keep the interface simple and
 build the crate for either standard Unix memory mapping or Xen, and not both.
+
+## Packaging and distribution
+
+The [`xtask`](./xtask/) workspace crate provides support for generating ROFF manual pages.
+
+If the binary you're interested in packaging does not have a manual page
+generated you are encouraged to file a bug or even contribute the necessary
+changes by filing a pull request.

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
   "coverage_score": 86.60,
-  "exclude_path": "",
+  "exclude_path": "xtask",
   "crate_features": ""
 }

--- a/vhost-device-scmi/README.md
+++ b/vhost-device-scmi/README.md
@@ -40,22 +40,21 @@ messages on the standard error output.
 
 The daemon should be started first:
 
-::
-
-  host# vhost-device-scmi --socket-path=scmi.sock --device fake,name=foo
+```shell
+host# vhost-device-scmi --socket-path=scmi.sock --device fake,name=foo
+```
 
 The QEMU invocation needs to create a chardev socket the device can
 use to communicate as well as share the guests memory over a memfd:
 
-::
-
-  host# qemu-system \
-      -chardev socket,path=scmi.sock,id=scmi \
-      -device vhost-user-scmi-pci,chardev=vscmi,id=scmi \
-      -machine YOUR-MACHINE-OPTIONS,memory-backend=mem \
-      -m 4096 \
-      -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on \
-      ...
+```shell
+host# qemu-system \
+    -chardev socket,path=scmi.sock,id=scmi \
+    -device vhost-user-scmi-pci,chardev=vscmi,id=scmi \
+    -machine YOUR-MACHINE-OPTIONS,memory-backend=mem \
+    -m 4096 \
+    -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on \
+```
 
 ## Supported SCMI protocols
 

--- a/vhost-device-scmi/src/args.rs
+++ b/vhost-device-scmi/src/args.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Red Hat, Inc.
+// SPDX-License-Identifier: Apache-2.0
+// Based on implementation of other devices here, Copyright by Linaro Ltd.
+//! An arguments type for the binary interface of this library.
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct ScmiArgs {
+    // Location of vhost-user Unix domain socket.
+    // Required, unless one of the --help options is used.
+    #[clap(
+        short,
+        long,
+        default_value_if(
+            "help_devices",
+            clap::builder::ArgPredicate::IsPresent,
+            "PathBuf::new()"
+        ),
+        help = "vhost-user socket to use"
+    )]
+    pub socket_path: PathBuf,
+    // Specification of SCMI devices to create.
+    #[clap(short, long, help = "Devices to expose")]
+    #[arg(num_args(1..))]
+    pub device: Vec<String>,
+    #[clap(long, exclusive = true, help = "Print help on available devices")]
+    pub help_devices: bool,
+}

--- a/vhost-device-sound/src/args.rs
+++ b/vhost-device-sound/src/args.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+//! An arguments type for the binary interface of this library.
+
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+
+#[derive(Parser, Debug)]
+#[clap(version, about, long_about = None)]
+pub struct SoundArgs {
+    /// vhost-user Unix domain socket path.
+    #[clap(long)]
+    pub socket: PathBuf,
+    /// audio backend to be used
+    #[clap(long)]
+    #[clap(value_enum)]
+    pub backend: BackendType,
+}
+
+#[derive(ValueEnum, Clone, Copy, Default, Debug, Eq, PartialEq)]
+pub enum BackendType {
+    #[default]
+    Null,
+    #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
+    Pipewire,
+    #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
+    Alsa,
+}

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -37,6 +37,7 @@ pub fn init_logger() {
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
+pub mod args;
 pub mod audio_backends;
 pub mod device;
 pub mod stream;
@@ -50,7 +51,7 @@ use std::{
     sync::Arc,
 };
 
-use clap::ValueEnum;
+pub use args::BackendType;
 pub use stream::Stream;
 use thiserror::Error as ThisError;
 use vhost_user_backend::{VhostUserDaemon, VringRwLock, VringT};
@@ -191,16 +192,6 @@ impl From<stream::Error> for Error {
     }
 }
 
-#[derive(ValueEnum, Clone, Copy, Default, Debug, Eq, PartialEq)]
-pub enum BackendType {
-    #[default]
-    Null,
-    #[cfg(all(feature = "pw-backend", target_env = "gnu"))]
-    Pipewire,
-    #[cfg(all(feature = "alsa-backend", target_env = "gnu"))]
-    Alsa,
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct InvalidControlMessage(u32);
 
@@ -261,6 +252,14 @@ pub struct SoundConfig {
     multi_thread: bool,
     /// audio backend variant
     audio_backend: BackendType,
+}
+
+impl From<args::SoundArgs> for SoundConfig {
+    fn from(cmd_args: args::SoundArgs) -> Self {
+        let args::SoundArgs { socket, backend } = cmd_args;
+
+        Self::new(socket, false, backend)
+    }
 }
 
 impl SoundConfig {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 clap = { version = "4.5", features = ["derive"], optional = true }
 clap_mangen = { version = "0.2.24", optional = true }
 toml = { version = "0.8.19", optional = true }
+markdown = { version = "=1.0.0-alpha.23", optional = true }
 
 [build-dependencies]
 
@@ -22,7 +23,7 @@ vhost-device-scmi = []
 vhost-device-sound = ["vhost-device-sound-alsa", "vhost-device-sound-pipewire"]
 vhost-device-sound-alsa = ["mangen"]
 vhost-device-sound-pipewire = ["mangen"]
-mangen = ["dep:clap_mangen", "dep:clap", "dep:toml"]
+mangen = ["dep:clap_mangen", "dep:clap", "dep:toml", "dep:markdown"]
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("alsa-backend", "pw-backend"))'] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -17,7 +17,8 @@ toml = { version = "0.8.19", optional = true }
 [build-dependencies]
 
 [features]
-default = ["vhost-device-sound"]
+default = ["vhost-device-sound", "vhost-device-scmi"]
+vhost-device-scmi = []
 vhost-device-sound = ["vhost-device-sound-alsa", "vhost-device-sound-pipewire"]
 vhost-device-sound-alsa = ["mangen"]
 vhost-device-sound-pipewire = ["mangen"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+authors = ["Manos Pitsidianakis <manos.pitsidianakis@linaro.org>"]
+description = "A helper binary crate following the cargo-xtask workflow recommended in <https://github.com/matklad/cargo-xtask>"
+repository = "https://github.com/rust-vmm/vhost-device"
+readme = "README.md"
+license = "EUPL-1.2 OR GPL-3.0-or-later"
+edition = "2021"
+publish = false
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"], optional = true }
+clap_mangen = { version = "0.2.24", optional = true }
+toml = { version = "0.8.19", optional = true }
+
+[build-dependencies]
+
+[features]
+default = ["vhost-device-sound"]
+vhost-device-sound = ["vhost-device-sound-alsa", "vhost-device-sound-pipewire"]
+vhost-device-sound-alsa = ["mangen"]
+vhost-device-sound-pipewire = ["mangen"]
+mangen = ["dep:clap_mangen", "dep:clap", "dep:toml"]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("alsa-backend", "pw-backend"))'] }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -6,6 +6,8 @@ This binary crate provides support for running useful tasks with `cargo xtask <.
 
 The `mangen` task which is enabled by the `mangen` cargo feature, builds ROFF manual pages for binary crates in this repository. It uses the [`clap_mangen`](https://crates.io/crates/clap_mangen) crate to generate ROFF from the crate's argument types which implement the `clap::CommandFactory` trait, through the `clap::Parser` derive macro.
 
+Furthmore, if the `README.md` of a crate contains an `Examples` heading, it includes it in the manual page.
+
 ```session
 $ cargo xtask mangen
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,22 @@
+# `xtask` - Run tasks with `cargo`
+
+This binary crate provides support for running useful tasks with `cargo xtask <..>`.
+
+## `mangen`
+
+The `mangen` task which is enabled by the `mangen` cargo feature, builds ROFF manual pages for binary crates in this repository. It uses the [`clap_mangen`](https://crates.io/crates/clap_mangen) crate to generate ROFF from the crate's argument types which implement the `clap::CommandFactory` trait, through the `clap::Parser` derive macro.
+
+```session
+$ cargo xtask mangen
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
+     Running `target/debug/xtask mangen`
+Generated the following manual pages:
+/path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-sound.1
+/path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-scmi.1
+```
+
+The following crates have manual pages built by default:
+
+- [`vhost-device-sound`](../vhost-device-sound), enabled by the default feature `vhost-device-sound`.
+  - It can further be fine-tuned with the features `vhost-device-sound-pipewire` and `vhost-device-sound-alsa`.
+- [`vhost-device-scmi`](../vhost-device-scmi), enabled by the default feature `vhost-device-scmi`.

--- a/xtask/build.rs
+++ b/xtask/build.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: EUPL-1.2 OR GPL-3.0-or-later
+// Copyright (c) 2024 Linaro Ltd.
+
+fn main() {
+    #[cfg(feature = "vhost-device-sound-pipewire")]
+    println!("cargo::rustc-cfg=feature=\"pw-backend\"");
+    #[cfg(feature = "vhost-device-sound-alsa")]
+    println!("cargo::rustc-cfg=feature=\"alsa-backend\"");
+    #[cfg(any(
+        feature = "vhost-device-sound-pipewire",
+        feature = "vhost-device-sound-alsa"
+    ))]
+    println!("cargo::rustc-cfg=target_env=\"gnu\"");
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: EUPL-1.2 OR GPL-3.0-or-later
+// Copyright (c) 2024 Linaro Ltd.
+
+// the `explicit_builtin_cfgs_in_flags` lint must be allowed because we might
+// emit `target_env = "gnu"` in build.rs in order to get some cfg checks to
+// compile; it does no harm because we're not using anything target_env specific
+// here. If we find out that it affects the xtask's crate dependencies (e.g.
+// when using this xtask under musl), we should figure out some other solution.
+#![allow(unknown_lints, explicit_builtin_cfgs_in_flags)]
+
+use std::error::Error;
+
+#[cfg(feature = "mangen")]
+use clap::CommandFactory;
+#[cfg(feature = "mangen")]
+use clap_mangen::Man;
+#[cfg(feature = "mangen")]
+use toml::value::Table;
+
+// Use vhost-device-sound's args module as our own using the #[path] attribute
+
+#[cfg(any(
+    feature = "vhost-device-sound-pipewire",
+    feature = "vhost-device-sound-alsa"
+))]
+#[path = "../../vhost-device-sound/src/args.rs"]
+mod vhost_device_sound;
+
+fn main() {
+    if let Err(err) = run_app() {
+        eprintln!("{}", err);
+        std::process::exit(-1);
+    }
+}
+
+fn run_app() -> Result<(), Box<dyn Error>> {
+    let task = std::env::args().nth(1);
+    match task.as_deref() {
+        #[cfg(feature = "mangen")]
+        Some("mangen") => mangen()?,
+        _ => print_help(),
+    }
+    Ok(())
+}
+
+fn print_help() {
+    eprintln!(
+        "Tasks:
+
+{mangen}",
+        mangen = if cfg!(feature = "mangen") {
+            "mangen            builds man pages using clap_mangen under target/dist/man"
+        } else {
+            ""
+        },
+    )
+}
+
+#[cfg(feature = "mangen")]
+fn mangen() -> Result<(), Box<dyn Error>> {
+    let workspace_dir = std::path::Path::new(&env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(1)
+        .unwrap()
+        .to_path_buf();
+    let dist_dir = workspace_dir.join("target/dist/man");
+    let _ = std::fs::remove_dir_all(&dist_dir);
+    std::fs::create_dir_all(&dist_dir)?;
+
+    let mut generated_artifacts = vec![];
+
+    #[cfg(any(
+        feature = "vhost-device-sound-pipewire",
+        feature = "vhost-device-sound-alsa"
+    ))]
+    {
+        use vhost_device_sound::SoundArgs;
+
+        let manifest =
+            std::fs::read_to_string(workspace_dir.join("vhost-device-sound/Cargo.toml"))?;
+        let manifest = manifest.as_str().parse::<Table>()?;
+
+        let name: &'static str = manifest["package"]["name"]
+            .as_str()
+            .unwrap()
+            .to_string()
+            .leak();
+        let version: &'static str = manifest["package"]["version"]
+            .as_str()
+            .unwrap()
+            .to_string()
+            .leak();
+        let repository: &'static str = manifest["package"]["repository"]
+            .as_str()
+            .unwrap()
+            .to_string()
+            .leak();
+        let description: &'static str = manifest["package"]["description"]
+            .as_str()
+            .unwrap()
+            .to_string()
+            .leak();
+        let cmd = <SoundArgs as CommandFactory>::command()
+            .name(name)
+            .display_name(name)
+            .bin_name(name)
+            .version(version)
+            .about(description);
+        let man = Man::new(cmd);
+        let mut buffer: Vec<u8> = Default::default();
+        man.render(&mut buffer)?;
+        clap_mangen::roff::Roff::new()
+            .control("SH", ["REPORTING BUGS"])
+            .text(vec![format!(
+                "Report bugs to the project's issue tracker: {repository}"
+            )
+            .into()])
+            .to_writer(&mut buffer)?;
+
+        let man_path = dist_dir.join("vhost-device-sound.1");
+        std::fs::write(&man_path, buffer)?;
+        generated_artifacts.push(man_path);
+    }
+    if generated_artifacts.is_empty() {
+        println!("No manpages were generated! Try using the correct xtask cargo features.");
+    } else {
+        println!("Generated the following manual pages:");
+        for art in generated_artifacts {
+            println!("{}", art.display());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
For information about the cargo xtask workflow pattern see: <https://github.com/matklad/cargo-xtask>

This PR adds an `xtask` crate with only one task, `mangen`, which generates a ROFF manual page under `target/dist/man` directory for the `vhost-device-sound` and `vhost-device-scmi` binaries.

The manual pages are placed in `target/dist/man/vhost-device-sound.1` and `target/dist/man/vhost-device-scmi.1`.

Future support for other crates in this repository is possible and provisioned for.

Fixes #687
Fixes #697 

## Demo: Rendered man pages as plain text

Generate the manpages:

```session
$ cargo xtask mangen
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/xtask mangen`
Generated the following manual pages:
/path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-sound.1
/path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-scmi.1
```
Plain text rendered with:

```sh
man -l /path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-sound.1 | xclip
```

<details>
<summary><code>vhost-device-sound(1)</code></summary>

```text
vhost-device-sound(1)                                                                                                        General Commands Manual                                                                                                        vhost-device-sound(1)

NAME
       vhost-device-sound - A virtio-sound device using the vhost-user protocol.

SYNOPSIS
       vhost-device-sound <--socket> <--backend> [-h|--help] [-V|--version]

DESCRIPTION
       A virtio-sound device using the vhost-user protocol.

OPTIONS
       --socket=SOCKET
              vhost-user Unix domain socket path

       --backend=BACKEND
              audio backend to be used

              [possible values: null, pipewire, alsa]

       -h, --help
              Print help

       -V, --version
              Print version

VERSION
       v0.2.0

EXAMPLES
       Launch the backend on the host machine:

       host# vhost-device-sound --socket /tmp/snd.sock --backend null

       With QEMU, you can add a  virtio  device that uses the backend's socket with the following flags:

       -chardev socket,id=vsnd,path=/tmp/snd.sock \ -device vhost-user-snd-pci,chardev=vsnd,id=snd

REPORTING BUGS
       Report bugs to the project's issue tracker: https://github.com/rust-vmm/vhost-device

                                                                                                                             vhost-device-sound 0.2.0                                                                                                       vhost-device-sound(1)
```

</details>

```sh
man -l /path/to/rust-vmm/vhost-device/target/dist/man/vhost-device-scmi.1 | xclip
```

<details>
<summary><code>vhost-device-scmi(1)</code></summary>

```text
vhost-device-scmi(1)                                                                                                         General Commands Manual                                                                                                         vhost-device-scmi(1)

NAME
       vhost-device-scmi - vhost-user SCMI backend device

SYNOPSIS
       vhost-device-scmi <-s|--socket-path> [-d|--device] [--help-devices] [-h|--help] [-V|--version]

DESCRIPTION
       vhost-user SCMI backend device

OPTIONS
       -s, --socket-path=SOCKET_PATH
              vhost-user socket to use

       -d, --device=DEVICE
              Devices to expose

       --help-devices
              Print help on available devices

       -h, --help
              Print help

       -V, --version
              Print version

VERSION
       v0.3.0

EXAMPLES
       The daemon should be started first:

       host# vhost-device-scmi --socket-path=scmi.sock --device fake,name=foo

       The QEMU invocation needs to create a chardev socket the device can use to communicate as well as share the guests memory over a memfd:

       host# qemu-system \
           -chardev socket,path=scmi.sock,id=scmi \
           -device vhost-user-scmi-pci,chardev=vscmi,id=scmi \
           -machine YOUR-MACHINE-OPTIONS,memory-backend=mem \
           -m 4096 \
           -object memory-backend-file,id=mem,size=4G,mem-path=/dev/shm,share=on \

REPORTING BUGS
       Report bugs to the project's issue tracker: https://github.com/rust-vmm/vhost-device

                                                                                                                             vhost-device-scmi 0.3.0                                                                                                         vhost-device-scmi(1)
```

</details>
