### PR TITLE
Fix clippy::empty_line_after_doc_comments

### DIFF
--- a/staging/vhost-device-video/src/vhu_video.rs
+++ b/staging/vhost-device-video/src/vhu_video.rs
@@ -27,9 +27,9 @@ use crate::{vhu_video_thread::VhostUserVideoThread, video_backends};
 
 /// Virtio Video Feature bits
 const VIRTIO_VIDEO_F_RESOURCE_GUEST_PAGES: u16 = 0;
-/// Unsupported
-/// const VIRTIO_VIDEO_F_RESOURCE_NON_CONTIG: u16 = 1;
-/// const VIRTIO_VIDEO_F_RESOURCE_VIRTIO_OBJECT: u16 = 2;
+// Unsupported
+// const VIRTIO_VIDEO_F_RESOURCE_NON_CONTIG: u16 = 1;
+// const VIRTIO_VIDEO_F_RESOURCE_VIRTIO_OBJECT: u16 = 2;
 
 const COMMAND_Q: u16 = 0;
 const EVENT_Q: u16 = 1;

--- a/vhost-device-gpio/src/virtio_gpio.rs
+++ b/vhost-device-gpio/src/virtio_gpio.rs
@@ -5,8 +5,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
-/// Virtio specification definitions
-/// Virtio GPIO request types
+//! Virtio specification definitions
+
+// Virtio GPIO request types
 
 pub const VIRTIO_GPIO_MSG_GET_LINE_NAMES: u16 = 0x0001;
 pub const VIRTIO_GPIO_MSG_GET_DIRECTION: u16 = 0x0002;
@@ -15,12 +16,14 @@ pub const VIRTIO_GPIO_MSG_GET_VALUE: u16 = 0x0004;
 pub const VIRTIO_GPIO_MSG_SET_VALUE: u16 = 0x0005;
 pub const VIRTIO_GPIO_MSG_IRQ_TYPE: u16 = 0x0006;
 
-/// Direction types
+// Direction types
+
 pub const VIRTIO_GPIO_DIRECTION_NONE: u8 = 0x00;
 pub const VIRTIO_GPIO_DIRECTION_OUT: u8 = 0x01;
 pub const VIRTIO_GPIO_DIRECTION_IN: u8 = 0x02;
 
-/// Virtio GPIO IRQ types
+// Virtio GPIO IRQ types
+
 pub const VIRTIO_GPIO_IRQ_TYPE_NONE: u16 = 0x00;
 pub const VIRTIO_GPIO_IRQ_TYPE_EDGE_RISING: u16 = 0x01;
 pub const VIRTIO_GPIO_IRQ_TYPE_EDGE_FALLING: u16 = 0x02;

--- a/vhost-device-i2c/src/i2c.rs
+++ b/vhost-device-i2c/src/i2c.rs
@@ -56,8 +56,9 @@ pub(crate) enum Error {
     ParseFailure,
 }
 
-/// Linux I2C/SMBUS definitions
-/// IOCTL commands, refer Linux's Documentation/i2c/dev-interface.rst for further details.
+// Linux I2C/SMBUS definitions
+
+// IOCTL commands, refer Linux's Documentation/i2c/dev-interface.rst for further details.
 
 /// NOTE: Slave address is 7 or 10 bits, but 10-bit addresses are NOT supported!
 /// (due to code brokenness)
@@ -114,7 +115,6 @@ pub(crate) const I2C_M_RD: u16 = 0x0001; // read data, from slave to master
 /// and ACKed.  If this is the last message in a group, it is followed by
 /// a STOP.  Otherwise it is followed by the next @I2cMsg transaction
 /// segment, beginning with a (repeated) START.
-
 #[repr(C)]
 struct I2cMsg {
     addr: u16,

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -71,7 +71,7 @@ impl convert::From<Error> for io::Error {
     }
 }
 
-/// I2C definitions from Virtio Spec
+// I2C definitions from Virtio Spec
 
 /// The final status written by the device
 const VIRTIO_I2C_MSG_OK: u8 = 0;

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -49,28 +49,24 @@ pub(crate) const VSOCK_HOST_CID: u64 = 2;
 /// Connection oriented packet
 pub(crate) const VSOCK_TYPE_STREAM: u16 = 1;
 
-/// Vsock packet operation ID
-
-/// Connection request
+/// Vsock packet operation ID - Connection request
 pub(crate) const VSOCK_OP_REQUEST: u16 = 1;
-/// Connection response
+/// Vsock packet operation ID - Connection response
 pub(crate) const VSOCK_OP_RESPONSE: u16 = 2;
-/// Connection reset
+/// Vsock packet operation ID - Connection reset
 pub(crate) const VSOCK_OP_RST: u16 = 3;
-/// Shutdown connection
+/// Vsock packet operation ID - Shutdown connection
 pub(crate) const VSOCK_OP_SHUTDOWN: u16 = 4;
-/// Data read/write
+/// Vsock packet operation ID - Data read/write
 pub(crate) const VSOCK_OP_RW: u16 = 5;
-/// Flow control credit update
+/// Vsock packet operation ID - Flow control credit update
 pub(crate) const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
-/// Flow control credit request
+/// Vsock packet operation ID - Flow control credit request
 pub(crate) const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
 
-/// Vsock packet flags
-
-/// VSOCK_OP_SHUTDOWN: Packet sender will receive no more data
+/// Vsock packet flags - `VSOCK_OP_SHUTDOWN`: Packet sender will receive no more data
 pub(crate) const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
-/// VSOCK_OP_SHUTDOWN: Packet sender will send no more data
+/// Vsock packet flags - `VSOCK_OP_SHUTDOWN`: Packet sender will send no more data
 pub(crate) const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
 
 // Queue mask to select vrings.


### PR DESCRIPTION

### Summary of the PR


Fix new warn by default clippy lint, empty_line_after_doc_comments, by removing empty lines after doc comments.


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
