### PR TITLE
scmi: extended sensor attributes support

### DIFF
--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- [[#798]](https://github.com/rust-vmm/vhost-device/pull/798) scmi: extended sensor attributes support
+
 ### Changed
 
 ### Fixed

--- a/vhost-device-scmi/CHANGELOG.md
+++ b/vhost-device-scmi/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixed
 
+- [[#798]](https://github.com/rust-vmm/vhost-device/pull/798) Fix the wrong value number of remaining sensor axis descriptor.
+
 ### Deprecated
 
 ## v0.3.0

--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -450,11 +450,11 @@ pub trait SensorT: Send {
                 if axis_desc_index >= n_sensor_axes {
                     return Result::Err(ScmiDeviceError::InvalidParameters);
                 }
-                let mut values = vec![MessageValue::Unsigned(n_sensor_axes - axis_desc_index)];
-                for i in axis_desc_index..n_sensor_axes {
-                    let mut description = self.axis_description(i);
-                    values.append(&mut description);
-                }
+                // Report only a single axis, in order to not exceed the descriptor size.
+                let num_axis_flags = 1 | ((n_sensor_axes - axis_desc_index - 1) << 26);
+                let mut values = vec![MessageValue::Unsigned(num_axis_flags)];
+                let mut description = self.axis_description(axis_desc_index);
+                values.append(&mut description);
                 Ok(values)
             }
             SENSOR_CONFIG_GET => self.config_get(),

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -1377,17 +1377,18 @@ mod tests {
             MessageValue::Unsigned(0),
             MessageValue::Unsigned(axis_index),
         ];
-        let mut result = vec![MessageValue::Unsigned(n_axes - axis_index)];
-        for i in axis_index..n_axes {
-            let name = format!("acc_{}", char::from_u32('X' as u32 + i).unwrap()).to_string();
-            let mut description = vec![
-                MessageValue::Unsigned(i),
-                MessageValue::Unsigned(0),
-                MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
-                MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
-            ];
-            result.append(&mut description);
-        }
+        // Each call will return only one descriptor to avoid exceeding the maximum length of the message
+        // and to inform about the number of the remaining sensor axis descriptions.
+        let num_axis_flags = 1 | (n_axes - axis_index - 1) << 26;
+        let mut result = vec![MessageValue::Unsigned(num_axis_flags)];
+        let name = format!("acc_{}", char::from_u32('X' as u32 + axis_index).unwrap()).to_string();
+        let mut description = vec![
+            MessageValue::Unsigned(axis_index),
+            MessageValue::Unsigned(0),
+            MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
+            MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+        ];
+        result.append(&mut description);
         test_message(
             SENSOR_PROTOCOL_ID,
             SENSOR_AXIS_DESCRIPTION_GET,

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -1384,9 +1384,15 @@ mod tests {
         let name = format!("acc_{}", char::from_u32('X' as u32 + axis_index).unwrap()).to_string();
         let mut description = vec![
             MessageValue::Unsigned(axis_index),
-            MessageValue::Unsigned(0),
+            MessageValue::Unsigned(1 << 8),
             MessageValue::Unsigned(u32::from(SENSOR_UNIT_METERS_PER_SECOND_SQUARED)),
             MessageValue::String(name, MAX_SIMPLE_STRING_LENGTH),
+            // Add extended attributes
+            MessageValue::Unsigned(0),
+            MessageValue::Signed(0),
+            MessageValue::Signed(i32::MIN),
+            MessageValue::Signed(-1i32),
+            MessageValue::Signed(i32::MAX),
         ];
         result.append(&mut description);
         test_message(


### PR DESCRIPTION
For Android requirment, virtio-scmi axis descriptor should support extended attributes. This patch does this things.

We get axis's resolution during reading "scale" and store. When agent wants to get axis description,
it will add to extend attribute field.
At the same time, max and min range have also been configured.

And because of supporting extended attributes, in flow of handle command SENSOR_ AXIS_DESCRIPTION_GET, it should report frontend the axis info one by one instead of together, for reason that it will exceed the size of descriptor buffer size.

Change-Id: Idc1984c6e23846cb877644a4459dbf6b6fbd63fa

### Summary of the PR

This patch extends the attributes of scmi sensor which is required by Android Trout.
