### PR TITLE
Set @mz-pdm as the code owner of vhost-device-scmi

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Add the list of code owners here (using their GitHub username)
 * @stsquad @vireshk @stefano-garzarella @epilys
+/vhost-device-scmi/ @mz-pdm


### PR DESCRIPTION
### Summary of the PR

Making @mz-pdm a code owner of vhost-device-scmi.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
