### PR TITLE
Disable EPOLLOUT if triggered while txbuf is empty

### DIFF
--- a/vhost-device-vsock/CHANGELOG.md
+++ b/vhost-device-vsock/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 ### Fixed
+- [#800](https://github.com/rust-vmm/vhost-device/pull/800) Disable EPOLLOUT if triggered while txbuf is empty
 
 ### Deprecated
 


### PR DESCRIPTION
### Summary of the PR

Currently the vsock connection always triggers on EPOLLOUT. When a host applicationlistens to the UDS, it's almost always writable, and thus keeps triggering backend events with EPOLLOUT on the connection. As a result, vhost-device-vsock daemon consumes 100% CPU.

To make it more CPU efficient, it can instead unsubscribe EPOLLOUT whenever there is no more data to send. It can re-subscribe if the connection cannot write out all bytes. This change causes the CPU util to drop to negligible level.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
