### PR TITLE
vsock: Fix CPU util 100% in vhost-device-vsock

### DIFF
--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -264,14 +264,14 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                 if VhostUserVsockThread::epoll_modify(
                     self.epoll_fd,
                     self.stream.as_raw_fd(),
-                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT | epoll::Events::EPOLLET,
                 )
                 .is_err()
                 {
                     if let Err(e) = VhostUserVsockThread::epoll_register(
                         self.epoll_fd,
                         self.stream.as_raw_fd(),
-                        epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                        epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT | epoll::Events::EPOLLET,
                     ) {
                         // TODO: let's move this logic out of this func, and handle it properly
                         error!("epoll_register failed: {:?}, but proceed further.", e);


### PR DESCRIPTION
When communicating with kata-agent (and other sample code) using vhost-device-vsock, the default EPOLLLT mode causes the process to continuously attempt to read from the socket. This results in the vhost-device-vsock process
reaching a CPU utilization of 100%.

Signed-off-by: SU Hang <darcy.sh@antgroup.com>