### PR TITLE
vhost-device-sound: Add controls field in VirtioSoundConfig

### DIFF
--- a/vhost-device-sound/CHANGELOG.md
+++ b/vhost-device-sound/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 
+- [[#806]](https://github.com/rust-vmm/vhost-device/pull/806) Add controls field in VirtioSoundConfig
 - [[#746]](https://github.com/rust-vmm/vhost-device/pull/746) Add new sampling rates 12000Hz and 24000Hz
 
 ### Changed

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -573,6 +573,7 @@ impl VhostUserSoundBackend {
                 jacks: 0.into(),
                 streams: Le32::from(streams_no as u32),
                 chmaps: 1.into(),
+                controls: 0.into(),
             },
             exit_event: EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?,
             audio_backend: RwLock::new(audio_backend),

--- a/vhost-device-sound/src/virtio_sound.rs
+++ b/vhost-device-sound/src/virtio_sound.rs
@@ -163,6 +163,8 @@ pub struct VirtioSoundConfig {
     pub streams: Le32,
     /// total number of all available channel maps
     pub chmaps: Le32,
+    /// total number of all available control elements
+    pub controls: Le32,
 }
 
 // SAFETY: The layout of the structure is fixed and can be initialized by
@@ -350,8 +352,9 @@ mod tests {
         let val = VirtioSoundConfig::default();
 
         let debug_output = format!("{:?}", val);
-        let expected_debug =
-            "VirtioSoundConfig { jacks: Le32(0), streams: Le32(0), chmaps: Le32(0) }".to_string();
+        let expected_debug = "VirtioSoundConfig { jacks: Le32(0), streams: Le32(0), chmaps: \
+                              Le32(0), controls: Le32(0) }"
+            .to_string();
         assert_eq!(debug_output, expected_debug);
 
         let val = VirtioSoundHeader::default();


### PR DESCRIPTION

### Summary of the PR

This commit introduces a new controls field in VirtioSoundConfig to represent the total number of available control elements. It's based on the recent changes to the virtio-snd header file in QEMU. Fixes this issue:
https://gitlab.com/qemu-project/qemu/-/issues/2805

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
