### PR TITLE
sound: fix clippy::unnecessary_map_or lint

### DIFF
--- a/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
@@ -207,7 +207,7 @@ pub fn try_backoff<T, E: std::fmt::Display>(
     let distribution = Uniform::new(0.0_f32, 1.0_f32);
 
     loop {
-        if max_retries.map_or(false, |max| iterations >= max) {
+        if max_retries.is_some_and(|max| iterations >= max) {
             return Err(());
         }
 


### PR DESCRIPTION
clippy warns:

```
  error: this `map_or` is redundant
     --> vhost-device-sound/src/audio_backends/pipewire/test_utils.rs:210:12
      |
  210 |         if max_retries.map_or(false, |max| iterations >= max) {
      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use is_some_and instead: `max_retries.is_some_and(|max| iterations >= max)`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
```

Signed-off-by: Manos Pitsidianakis <manos.pitsidianakis@linaro.org>