### PR TITLE
vhost-device-console: Fix a typo in README

### DIFF
--- a/vhost-device-console/README.md
+++ b/vhost-device-console/README.md
@@ -94,7 +94,7 @@ host# qemu-system                                               \
     <normal QEMU options>                                       \
     -machine <machine options>,memory-backend=mem0              \
     -object memory-backend-memfd,id=mem0,size=<Guest RAM size>  \ # size == -m size
-    -chardev socket,path=/tmp/console.sock0,id=con              \
+    -chardev socket,path=/tmp/console.sock0,id=con0             \
     -device vhost-user-console-pci,chardev=con0,id=console      \
     ...
 ```


### PR DESCRIPTION
### Summary of the PR

In the example of using `vhost-user-console-pci`, the id should be
`con0` instead of `con`.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
