### PR TITLE
vhost-device-console: Being able to specify max queue size

### DIFF
--- a/vhost-device-console/CHANGELOG.md
+++ b/vhost-device-console/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- [#811](https://github.com/rust-vmm/vhost-device/pull/811) Being able to specify max queue size
+
 ### Changed
 
 ### Fixed

--- a/vhost-device-console/README.md
+++ b/vhost-device-console/README.md
@@ -47,6 +47,11 @@ vhost-device-console --socket-path=<SOCKET_PATH>
   Note: The nested backend is selected by default and can be used only when
         socket_count equals 1.
 
+.. option:: -q, --max-queue-size=SIZE
+
+  The maximum size of virtqueues. It is optional, and the default value is
+  128. The size must be greater than 0 and a power of 2.
+
 ## Limitations
 
 This device is still work-in-progress (WIP). The current version has been tested

--- a/vhost-device-console/src/main.rs
+++ b/vhost-device-console/src/main.rs
@@ -44,6 +44,8 @@ use crate::console::BackendType;
 pub type Result<T> = std::result::Result<T, Error>;
 use crate::backend::{start_backend, Error, VuConsoleConfig};
 
+const DEFAULT_QUEUE_SIZE: usize = 128;
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct ConsoleArgs {
@@ -65,6 +67,10 @@ struct ConsoleArgs {
     /// `tcp_port + 1`, ... , `tcp_port + (N - 1)`.
     #[clap(short = 'p', long, value_name = "PORT", default_value = "12345")]
     tcp_port: String,
+
+    /// Specify the maximum size of virtqueue, the default is 128.
+    #[clap(short = 'q', long, default_value_t = DEFAULT_QUEUE_SIZE)]
+    max_queue_size: usize,
 }
 
 impl TryFrom<ConsoleArgs> for VuConsoleConfig {
@@ -84,6 +90,7 @@ impl TryFrom<ConsoleArgs> for VuConsoleConfig {
             backend,
             tcp_port,
             socket_count,
+            max_queue_size,
         } = args;
 
         Ok(Self {
@@ -91,6 +98,7 @@ impl TryFrom<ConsoleArgs> for VuConsoleConfig {
             backend,
             tcp_port,
             socket_count,
+            max_queue_size,
         })
     }
 }


### PR DESCRIPTION
### Summary of the PR

Some hypervisors, e.g. UML (User-Mode Linux), negotiate a queue size larger 
than `QUEUE_SIZE` (128), which results in failures (see below). This patch 
allows users to specify it using `--max-queue-size <size>`.

```
[2025-02-11T10:21:51Z ERROR vhost_device_console] Fatal error: failed to handle request: invalid parameters
```

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
