### PR TITLE
buildkite: add main-tests.json

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -6,8 +6,14 @@ If we add a new pipeline we need to enable it in
 https://buildkite.com/rust-vmm/vhost-device-ci/steps
 
 Custom pipelines currently defined are:
-- `staging-tests.json`
+- `main-tests.json`
   This is based on `rust-vmm-ci/.buildkite/test_description.json`.
+  We have an internal version, because we have several applications that have
+  dependencies that don't work very well on musl, so it's easier to manage CI
+  by having our own internal pipeline.
+
+- `staging-tests.json`
+  This is based on `main-tests.json`.
   We should keep `staging-tests.json` aligned with it as much as possible to
   make sure we don't notice any difference in CI when we move a crate from the
   staging to the main workspace.

--- a/.buildkite/main-tests.json
+++ b/.buildkite/main-tests.json
@@ -1,0 +1,113 @@
+{
+  "tests": [
+    {
+      "test_name": "build-gnu",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ]
+    },
+    {
+      "test_name": "build-musl",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo build --release --target {target_platform}-unknown-linux-musl",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
+      "test_name": "style",
+      "command": "cargo fmt --all -- --check --config format_code_in_doc_comments=true"
+    },
+    {
+      "test_name": "unittests-gnu",
+      "command": "cargo test --all-features --workspace",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-musl",
+      "command": "cargo test --all-features --workspace --target {target_platform}-unknown-linux-musl",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-gnu-release",
+      "command": "cargo test --release --all-features --workspace",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "unittests-musl-release",
+      "command": "cargo test --release --all-features --workspace --target {target_platform}-unknown-linux-musl",
+      "platform": [
+        "x86_64",
+        "aarch64"
+      ],
+      "docker_plugin": {
+        "privileged": true
+      }
+    },
+    {
+      "test_name": "clippy",
+      "command": "cargo clippy --workspace --bins --examples --benches --all-features --all-targets -- -D warnings -D clippy::undocumented_unsafe_blocks",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ]
+    },
+    {
+      "test_name": "check-warnings",
+      "command": "RUSTFLAGS=\"-D warnings\" cargo check --all-targets --all-features --workspace",
+      "platform": [
+        "x86_64",
+        "aarch64",
+        "riscv64"
+      ]
+    },
+    {
+      "test_name": "coverage",
+      "command": "pytest $(find . -type f -name \"test_coverage.py\")",
+      "docker_plugin": {
+        "privileged": true
+      },
+      "platform": [
+        "x86_64"
+      ]
+    },
+    {
+      "test_name": "commit-format",
+      "command": "pytest $(find . -type f -name \"test_commit_format.py\")",
+      "docker_plugin": {
+        "propagate-environment": true
+      }
+    },
+    {
+      "test_name": "cargo-audit",
+      "command": "[ -e Cargo.lock ] || cargo generate-lockfile; cargo audit -q --deny warnings",
+      "platform": [
+        "x86_64"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`vhost-device-gpu` has dependencies that do not work well on musl. Also `vhost-device-gpio` has the same problem, but we merged workarounds.

Instead of continuing to make hacks to compile empty main for these applications. Better to have our own pipeline also for the main workspace. In that way we can easily exclude applications (e.g. that do not support musl) as discussed in
  https://github.com/rust-vmm/vhost-device/pull/801

The new `.buildkite/main-tests.json` file is copied from rust-vmm-ci/.buildkite/test_description.json from commit 09aef99 ("chore: update container version to v48")
