### PR TITLE
gpio, sound: Use PathBuf for socket paths instead of Strings

### DIFF
--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -675,6 +675,7 @@ impl VhostUserBackend for VhostUserSoundBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use tempfile::tempdir;
     use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
     use virtio_queue::{mock::MockSplitQueue, Descriptor};
@@ -727,7 +728,7 @@ mod tests {
     #[test]
     fn test_sound_thread_success() {
         crate::init_logger();
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(PathBuf::from(SOCKET_PATH), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -822,7 +823,7 @@ mod tests {
     #[test]
     fn test_sound_thread_failure() {
         crate::init_logger();
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(PathBuf::from(SOCKET_PATH), false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -903,7 +904,7 @@ mod tests {
     fn test_sound_backend() {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
-        let socket_path = test_dir.path().join(SOCKET_PATH).display().to_string();
+        let socket_path = test_dir.path().join(SOCKET_PATH);
         let config = SoundConfig::new(socket_path, false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config).expect("Could not create backend.");
 
@@ -981,11 +982,8 @@ mod tests {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
 
-        let socket_path = test_dir
-            .path()
-            .join("sound_failures.socket")
-            .display()
-            .to_string();
+        let socket_path = test_dir.path().join("sound_failures.socket");
+
         let config = SoundConfig::new(socket_path, false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config);
 

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -46,6 +46,7 @@ use std::{
     convert::TryFrom,
     io::{Error as IoError, ErrorKind},
     mem::size_of,
+    path::PathBuf,
     sync::Arc,
 };
 
@@ -255,7 +256,7 @@ impl TryFrom<Le32> for ControlMessageKind {
 /// is allowed to configure the backend.
 pub struct SoundConfig {
     /// vhost-user Unix domain socket
-    socket: String,
+    socket: PathBuf,
     /// use multiple threads to hanlde the virtqueues
     multi_thread: bool,
     /// audio backend variant
@@ -265,7 +266,7 @@ pub struct SoundConfig {
 impl SoundConfig {
     /// Create a new instance of the SoundConfig struct, containing the
     /// parameters to be fed into the sound-backend server.
-    pub const fn new(socket: String, multi_thread: bool, audio_backend: BackendType) -> Self {
+    pub const fn new(socket: PathBuf, multi_thread: bool, audio_backend: BackendType) -> Self {
         Self {
             socket,
             multi_thread,
@@ -275,8 +276,8 @@ impl SoundConfig {
 
     /// Return the path of the unix domain socket which is listening to
     /// requests from the guest.
-    pub fn get_socket_path(&self) -> String {
-        String::from(&self.socket)
+    pub fn get_socket_path(&self) -> PathBuf {
+        self.socket.clone()
     }
 
     pub const fn get_audio_backend(&self) -> BackendType {
@@ -372,7 +373,7 @@ mod tests {
         const SOCKET_PATH: &str = "vsound.socket";
         crate::init_logger();
 
-        let config = SoundConfig::new(SOCKET_PATH.to_string(), false, BackendType::Null);
+        let config = SoundConfig::new(PathBuf::from(SOCKET_PATH), false, BackendType::Null);
 
         let backend = Arc::new(VhostUserSoundBackend::new(config).unwrap());
         let daemon = VhostUserDaemon::new(

--- a/vhost-device-sound/src/main.rs
+++ b/vhost-device-sound/src/main.rs
@@ -1,7 +1,7 @@
 // Manos Pitsidianakis <manos.pitsidianakis@linaro.org>
 // Stefano Garzarella <sgarzare@redhat.com>
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
-use std::convert::TryFrom;
+use std::{convert::TryFrom, path::PathBuf};
 
 use clap::Parser;
 use vhost_device_sound::{start_backend_server, BackendType, Error, Result, SoundConfig};
@@ -11,7 +11,7 @@ use vhost_device_sound::{start_backend_server, BackendType, Error, Result, Sound
 struct SoundArgs {
     /// vhost-user Unix domain socket path.
     #[clap(long)]
-    socket: String,
+    socket: PathBuf,
     /// audio backend to be used
     #[clap(long)]
     #[clap(value_enum)]
@@ -22,9 +22,7 @@ impl TryFrom<SoundArgs> for SoundConfig {
     type Error = Error;
 
     fn try_from(cmd_args: SoundArgs) -> Result<Self> {
-        let socket = cmd_args.socket.trim().to_string();
-
-        Ok(SoundConfig::new(socket, false, cmd_args.backend))
+        Ok(SoundConfig::new(cmd_args.socket, false, cmd_args.backend))
     }
 }
 
@@ -45,9 +43,9 @@ mod tests {
     use super::*;
 
     impl SoundArgs {
-        fn from_args(socket: &str) -> Self {
+        fn from_args(socket: PathBuf) -> Self {
             SoundArgs {
-                socket: socket.to_string(),
+                socket,
                 backend: BackendType::default(),
             }
         }
@@ -61,13 +59,16 @@ mod tests {
     #[test]
     fn test_sound_config_setup() {
         init_logger();
-        let args = SoundArgs::from_args("/tmp/vhost-sound.socket");
+        let args = SoundArgs::from_args(PathBuf::from("/tmp/vhost-sound.socket"));
 
         let config = SoundConfig::try_from(args);
         assert!(config.is_ok());
 
         let config = config.unwrap();
-        assert_eq!(config.get_socket_path(), "/tmp/vhost-sound.socket");
+        assert_eq!(
+            config.get_socket_path(),
+            PathBuf::from("/tmp/vhost-sound.socket")
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
### Summary of the PR

This PR changes socket paths type from String to PathBuf in vhost-user-gpio and vhost-user-sound.
This work was started in #446 and but never completed.

This PR along with #819 should complete the work.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [X] All added/changed functionality has a corresponding unit/integration
  test.
- [X] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [X] Any newly added `unsafe` code is properly documented.
