### PR TITLE
clippy: Fix clippy warnings found in rust toolchain v1.85.0

### DIFF
--- a/vhost-device-can/src/main.rs
+++ b/vhost-device-can/src/main.rs
@@ -74,10 +74,7 @@ impl TryFrom<CanArgs> for VuCanConfig {
             return Err(Self::Error::SocketCountInvalid(0));
         }
 
-        let can_devices = match parse_can_devices(&args) {
-            Ok(can_devs) => can_devs,
-            Err(e) => return Err(e),
-        };
+        let can_devices = parse_can_devices(&args)?;
 
         Ok(VuCanConfig {
             socket_path: args.socket_path,

--- a/vhost-device-can/src/vhu_can.rs
+++ b/vhost-device-can/src/vhu_can.rs
@@ -603,12 +603,12 @@ impl VhostUserBackendMut for VhostUserCanBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_CAN_F_CAN_CLASSIC
-            | 1 << VIRTIO_CAN_F_CAN_FD
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_CAN_F_CAN_CLASSIC)
+            | (1 << VIRTIO_CAN_F_CAN_FD)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -703,11 +703,11 @@ impl VhostUserBackendMut for VhostUserConsoleBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_CONSOLE_F_MULTIPORT
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_CONSOLE_F_MULTIPORT)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-gpio/src/vhu_gpio.rs
+++ b/vhost-device-gpio/src/vhu_gpio.rs
@@ -394,11 +394,11 @@ impl<D: 'static + GpioDevice + Sync + Send> VhostUserBackendMut for VhostUserGpi
 
     fn features(&self) -> u64 {
         // this matches the current libvhost defaults except VHOST_F_LOG_ALL
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_GPIO_F_IRQ
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_GPIO_F_IRQ)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-gpu/src/device.rs
+++ b/vhost-device-gpu/src/device.rs
@@ -624,15 +624,15 @@ impl VhostUserBackend for VhostUserGpuBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_RING_RESET
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_GPU_F_VIRGL
-            | 1 << VIRTIO_GPU_F_EDID
-            | 1 << VIRTIO_GPU_F_RESOURCE_BLOB
-            | 1 << VIRTIO_GPU_F_CONTEXT_INIT
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_RING_RESET)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_GPU_F_VIRGL)
+            | (1 << VIRTIO_GPU_F_EDID)
+            | (1 << VIRTIO_GPU_F_RESOURCE_BLOB)
+            | (1 << VIRTIO_GPU_F_CONTEXT_INIT)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -291,11 +291,11 @@ impl<D: 'static + I2cDevice + Sync + Send> VhostUserBackendMut for VhostUserI2cB
 
     fn features(&self) -> u64 {
         // this matches the current libvhost defaults except VHOST_F_LOG_ALL
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_I2C_F_ZERO_LENGTH_REQUEST
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_I2C_F_ZERO_LENGTH_REQUEST)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -332,9 +332,9 @@ impl<T: 'static + InputDevice + Sync + Send> VhostUserBackendMut for VuInputBack
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -216,10 +216,10 @@ impl<T: 'static + ReadVolatile + Sync + Send> VhostUserBackendMut for VuRngBacke
 
     fn features(&self) -> u64 {
         // this matches the current libvhost defaults except VHOST_F_LOG_ALL
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-scmi/src/devices/common.rs
+++ b/vhost-device-scmi/src/devices/common.rs
@@ -321,7 +321,7 @@ pub trait SensorT: Send {
     ///
     /// Usually no need to redefine this.
     fn format_unit(&self, axis: u32) -> u32 {
-        (self.unit_exponent(axis) as u32 & 0x1F) << 11 | u32::from(self.unit())
+        ((self.unit_exponent(axis) as u32 & 0x1F) << 11) | u32::from(self.unit())
     }
 
     /// Returns SCMI description of the sensor.
@@ -332,7 +332,7 @@ pub trait SensorT: Send {
         let low = 1 << 30;
         let n_axes = self.number_of_axes();
         let high = if n_axes > 0 {
-            n_axes << 16 | 1 << 8
+            (n_axes << 16) | (1 << 8)
         } else {
             self.format_unit(0)
         };

--- a/vhost-device-scmi/src/scmi.rs
+++ b/vhost-device-scmi/src/scmi.rs
@@ -470,7 +470,7 @@ impl HandlerMap {
                 let last_non_returned_sensor = first_index + sensors_to_return;
                 let remaining_sensors = n_sensors.saturating_sub(last_non_returned_sensor);
                 let mut values = vec![MessageValue::Unsigned(
-                    sensors_to_return as u32 | (remaining_sensors as u32) << 16,
+                    sensors_to_return as u32 | ((remaining_sensors as u32) << 16),
                 )];
                 for index in first_index..last_non_returned_sensor {
                     values.push(MessageValue::Unsigned(index as u32));
@@ -1339,7 +1339,7 @@ mod tests {
             let mut description = vec![
                 MessageValue::Unsigned(i),
                 MessageValue::Unsigned(1 << 30),
-                MessageValue::Unsigned(3 << 16 | 1 << 8),
+                MessageValue::Unsigned((3 << 16) | (1 << 8)),
                 MessageValue::String(format!("fake{i}"), MAX_SIMPLE_STRING_LENGTH),
             ];
             result.append(&mut description);
@@ -1379,7 +1379,7 @@ mod tests {
         ];
         // Each call will return only one descriptor to avoid exceeding the maximum length of the message
         // and to inform about the number of the remaining sensor axis descriptions.
-        let num_axis_flags = 1 | (n_axes - axis_index - 1) << 26;
+        let num_axis_flags = 1 | ((n_axes - axis_index - 1) << 26);
         let mut result = vec![MessageValue::Unsigned(num_axis_flags)];
         let name = format!("acc_{}", char::from_u32('X' as u32 + axis_index).unwrap()).to_string();
         let mut description = vec![

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -427,11 +427,11 @@ impl VhostUserBackendMut for VuScmiBackend {
 
     fn features(&self) -> u64 {
         debug!("Features called");
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
-            | 1 << VIRTIO_SCMI_F_P2A_CHANNELS
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
+            | (1 << VIRTIO_SCMI_F_P2A_CHANNELS)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 
@@ -540,7 +540,7 @@ mod tests {
     use super::*;
 
     fn scmi_header(message_id: u8, protocol_id: u8) -> u32 {
-        u32::from(message_id) | u32::from(protocol_id) << 10
+        u32::from(message_id) | (u32::from(protocol_id) << 10)
     }
 
     fn build_cmd_desc_chain(

--- a/vhost-device-scsi/src/vhu_scsi.rs
+++ b/vhost-device-scsi/src/vhu_scsi.rs
@@ -210,10 +210,10 @@ impl VhostUserBackendMut for VhostUserScsiBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_SCSI_F_HOTPLUG
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_SCSI_F_HOTPLUG)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 
@@ -287,7 +287,7 @@ impl VhostUserBackendMut for VhostUserScsiBackend {
             cdb_size: CDB_SIZE.try_into().expect("CDB_SIZE should fit 32bit"),
             max_channel: 0,
             max_target: 255,
-            max_lun: u32::from(!u16::from(VirtioScsiLun::ADDRESS_METHOD_PATTERN) << 8 | 0xff),
+            max_lun: u32::from((!u16::from(VirtioScsiLun::ADDRESS_METHOD_PATTERN) << 8) | 0xff),
         };
 
         // SAFETY:

--- a/vhost-device-scsi/src/virtio.rs
+++ b/vhost-device-scsi/src/virtio.rs
@@ -181,7 +181,7 @@ where
         self.add_written(bytes);
         while self
             .current
-            .map_or(false, |current| self.offset >= current.len())
+            .is_some_and(|current| self.offset >= current.len())
         {
             let current = self.current.expect("loop condition ensures existance");
             self.offset -= current.len();

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -602,10 +602,10 @@ impl VhostUserBackend for VhostUserSoundBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-sound/src/lib.rs
+++ b/vhost-device-sound/src/lib.rs
@@ -59,18 +59,18 @@ use vm_memory::{ByteValued, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemory
 
 use crate::device::VhostUserSoundBackend;
 
-pub const SUPPORTED_FORMATS: u64 = 1 << VIRTIO_SND_PCM_FMT_U8
-    | 1 << VIRTIO_SND_PCM_FMT_S16
-    | 1 << VIRTIO_SND_PCM_FMT_S24
-    | 1 << VIRTIO_SND_PCM_FMT_S32;
+pub const SUPPORTED_FORMATS: u64 = (1 << VIRTIO_SND_PCM_FMT_U8)
+    | (1 << VIRTIO_SND_PCM_FMT_S16)
+    | (1 << VIRTIO_SND_PCM_FMT_S24)
+    | (1 << VIRTIO_SND_PCM_FMT_S32);
 
-pub const SUPPORTED_RATES: u64 = 1 << VIRTIO_SND_PCM_RATE_8000
-    | 1 << VIRTIO_SND_PCM_RATE_11025
-    | 1 << VIRTIO_SND_PCM_RATE_16000
-    | 1 << VIRTIO_SND_PCM_RATE_22050
-    | 1 << VIRTIO_SND_PCM_RATE_32000
-    | 1 << VIRTIO_SND_PCM_RATE_44100
-    | 1 << VIRTIO_SND_PCM_RATE_48000;
+pub const SUPPORTED_RATES: u64 = (1 << VIRTIO_SND_PCM_RATE_8000)
+    | (1 << VIRTIO_SND_PCM_RATE_11025)
+    | (1 << VIRTIO_SND_PCM_RATE_16000)
+    | (1 << VIRTIO_SND_PCM_RATE_22050)
+    | (1 << VIRTIO_SND_PCM_RATE_32000)
+    | (1 << VIRTIO_SND_PCM_RATE_44100)
+    | (1 << VIRTIO_SND_PCM_RATE_48000);
 
 use virtio_queue::DescriptorChain;
 pub type SoundDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<()>>>;

--- a/vhost-device-spi/src/spi.rs
+++ b/vhost-device-spi/src/spi.rs
@@ -910,8 +910,8 @@ pub(crate) mod tests {
 
         // rdwr failure
         let mut reqs = [SpiIocTransfer {
-            tx_buf: vec![7, 4].as_ptr() as u64,
-            rx_buf: vec![7, 4].as_ptr() as u64,
+            tx_buf: [7, 4].as_ptr() as u64,
+            rx_buf: [7, 4].as_ptr() as u64,
             len: 2,
             speed_hz: 10000,
             delay_usecs: 0,

--- a/vhost-device-spi/src/vhu_spi.rs
+++ b/vhost-device-spi/src/vhu_spi.rs
@@ -415,10 +415,10 @@ impl<D: 'static + SpiDevice + Sync + Send> VhostUserBackendMut for VhostUserSpiB
 
     fn features(&self) -> u64 {
         // this matches the current libvhost defaults except VHOST_F_LOG_ALL
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 

--- a/vhost-device-template/src/vhu_foo.rs
+++ b/vhost-device-template/src/vhu_foo.rs
@@ -149,10 +149,10 @@ impl VhostUserBackendMut for VhostUserFooBackend {
 
     fn features(&self) -> u64 {
         // this matches the current libvhost defaults except VHOST_F_LOG_ALL
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_INDIRECT_DESC
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_INDIRECT_DESC)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
 
             // Protocol features are optional and must not be defined unless required and must be
             // accompanied by the supporting PROTOCOL_FEATURES bits in features.

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -296,9 +296,9 @@ impl VhostUserBackend for VhostUserVsockBackend {
     }
 
     fn features(&self) -> u64 {
-        1 << VIRTIO_F_VERSION_1
-            | 1 << VIRTIO_F_NOTIFY_ON_EMPTY
-            | 1 << VIRTIO_RING_F_EVENT_IDX
+        (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_NOTIFY_ON_EMPTY)
+            | (1 << VIRTIO_RING_F_EVENT_IDX)
             | VhostUserVirtioFeatures::PROTOCOL_FEATURES.bits()
     }
 


### PR DESCRIPTION
### Summary of the PR

Fix clippy warnings reported by clippy 0.1.85 (4d91de4e48 2025-02-17).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
