### PR TITLE
chore: bump virtio-queue, vhost-user-backend and virtio-vscok 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1944,7 +1944,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1965,7 +1965,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1984,7 +1984,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2025,7 +2025,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2048,7 +2048,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2087,7 +2087,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2129,7 +2129,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2190,15 +2190,15 @@ dependencies = [
  "virtio-queue",
  "virtio-vsock",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
  "vsock",
 ]
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76e8acbdaf760efa37dbd414870c81717a65a64d3351b1a93d03bc249a3e987"
+checksum = "c8cc4fc4d33a521e1d912b61da986aba6f04c8b67cc1af0adaac21da3ce59fa6"
 dependencies = [
  "libc",
  "log",
@@ -2206,7 +2206,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2220,21 +2220,21 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872e2f3fbd70a7e6f01689720cce3d5c2c5efe52b484dd07b674246ada0e9a8d"
+checksum = "efd3ef6079fc0de4d687a6ff364a5f5633f3aabcd29982ef866bc49fba0349a4"
 dependencies = [
  "log",
  "virtio-bindings",
  "vm-memory",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "virtio-vsock"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4118ce26599dc8a238c6ee795d90250c88d8ebfece9e65c1f01dec6e4e2aeb67"
+checksum = "cf6ab06b1894d6c4198de00df8af8715d080d3c7c6b82ea570ad78642990d89b"
 dependencies = [
  "virtio-bindings",
  "virtio-queue",
@@ -2251,18 +2251,8 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "thiserror 1.0.69",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
  "winapi",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]

--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -928,14 +928,14 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76e8acbdaf760efa37dbd414870c81717a65a64d3351b1a93d03bc249a3e987"
+checksum = "c8cc4fc4d33a521e1d912b61da986aba6f04c8b67cc1af0adaac21da3ce59fa6"
 dependencies = [
  "libc",
  "log",
@@ -943,7 +943,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -957,14 +957,14 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872e2f3fbd70a7e6f01689720cce3d5c2c5efe52b484dd07b674246ada0e9a8d"
+checksum = "efd3ef6079fc0de4d687a6ff364a5f5633f3aabcd29982ef866bc49fba0349a4"
 dependencies = [
  "log",
  "virtio-bindings",
  "vm-memory",
- "vmm-sys-util 0.12.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -977,18 +977,8 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "thiserror 1.0.69",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
  "winapi",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -27,9 +27,9 @@ libc = "0.2.172"
 thiserror = "2.0"
 futures-executor = { version = "0.3", features = ["thread-pool"] }
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.0"
 vmm-sys-util = "0.14"
 v4l2r = { git =  "https://github.com/Gnurou/v4l2r", rev = "110fd77", optional = true }
@@ -38,5 +38,5 @@ v4l2r = { git =  "https://github.com/Gnurou/v4l2r", rev = "110fd77", optional = 
 assert_matches = "1.5"
 rstest = "0.25.0"
 tempfile = "3.20.0"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.0", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-can/Cargo.toml
+++ b/vhost-device-can/Cargo.toml
@@ -22,13 +22,13 @@ thiserror = "2.0"
 queues = "1.0.2"
 socketcan = "3.5.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-can/src/vhu_can.rs
+++ b/vhost-device-can/src/vhu_can.rs
@@ -724,7 +724,11 @@ mod tests {
     use crate::virtio_can::{VirtioCanCtrlResponse, VirtioCanTxResponse};
     use std::mem::size_of;
     use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue,
+    };
     use vm_memory::{Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap, Le16, Le32};
 
     #[test]
@@ -831,7 +835,12 @@ mod tests {
                 flags[i as usize] & !VRING_DESC_F_NEXT as u16
             };
 
-            let desc = Descriptor::new((0x100 * (i + 1)) as u64, len, desc_flags, i + 1);
+            let desc = RawDescriptor::from(SplitDescriptor::new(
+                (0x100 * (i + 1)) as u64,
+                len,
+                desc_flags,
+                i + 1,
+            ));
             desc_vec.push(desc);
         }
 

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -24,13 +24,13 @@ epoll = "4.3"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -860,7 +860,11 @@ mod tests {
     use std::io::Cursor;
 
     use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue,
+    };
     use vm_memory::{Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 
     use super::*;
@@ -972,7 +976,12 @@ mod tests {
                 flags[i as usize] & !VRING_DESC_F_NEXT as u16
             };
 
-            let desc = Descriptor::new(u64::from(0x100 * (i + 1)), len, desc_flags, i + 1);
+            let desc = RawDescriptor::from(SplitDescriptor::new(
+                u64::from(0x100 * (i + 1)),
+                len,
+                desc_flags,
+                i + 1,
+            ));
             desc_vec.push(desc);
         }
 

--- a/vhost-device-gpio/Cargo.toml
+++ b/vhost-device-gpio/Cargo.toml
@@ -22,9 +22,9 @@ libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
@@ -33,5 +33,5 @@ libgpiod = "0.2"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-gpio/src/vhu_gpio.rs
+++ b/vhost-device-gpio/src/vhu_gpio.rs
@@ -502,7 +502,11 @@ impl<D: 'static + GpioDevice + Sync + Send> VhostUserBackendMut for VhostUserGpi
 #[cfg(test)]
 mod tests {
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue,
+    };
     use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 
     use super::Error;
@@ -523,7 +527,7 @@ mod tests {
         let mut next_addr = vq.desc_table().total_size() + 0x100;
         let mut index = 0;
 
-        let desc_out = Descriptor::new(
+        let desc_out = SplitDescriptor::new(
             next_addr,
             size_of::<R>() as u32,
             VRING_DESC_F_NEXT as u16,
@@ -531,12 +535,19 @@ mod tests {
         );
 
         mem.write_obj::<R>(out_hdr, desc_out.addr()).unwrap();
-        vq.desc_table().store(index, desc_out).unwrap();
+        vq.desc_table()
+            .store(index, RawDescriptor::from(desc_out))
+            .unwrap();
         next_addr += desc_out.len() as u64;
         index += 1;
 
         // In response descriptor
-        let desc_in = Descriptor::new(next_addr, response_len, VRING_DESC_F_WRITE as u16, 0);
+        let desc_in = RawDescriptor::from(SplitDescriptor::new(
+            next_addr,
+            response_len,
+            VRING_DESC_F_WRITE as u16,
+            0,
+        ));
         vq.desc_table().store(index, desc_in).unwrap();
 
         // Put the descriptor index 0 in the first available ring position.
@@ -610,7 +621,7 @@ mod tests {
                 _ => 0x100,
             };
 
-            let desc = Descriptor::new(offset, len[i], f, (i + 1) as u16);
+            let desc = RawDescriptor::from(SplitDescriptor::new(offset, len[i], f, (i + 1) as u16));
             vq.desc_table().store(i as u16, desc).unwrap();
         }
 

--- a/vhost-device-gpu/Cargo.toml
+++ b/vhost-device-gpu/Cargo.toml
@@ -28,9 +28,9 @@ log = "0.4"
 rutabaga_gfx = { version = "0.1.5", features = ["virgl_renderer"] }
 thiserror = "2.0.12"
 vhost = { version = "0.14.0", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14.0"
+virtio-queue = "0.15.0"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14.0"
 bitflags = "2.9.1"
@@ -40,5 +40,5 @@ assert_matches = "1.5"
 mockall = "0.13.0"
 rusty-fork = "0.3.0"
 tempfile = "3.20"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-gpu/src/protocol.rs
+++ b/vhost-device-gpu/src/protocol.rs
@@ -1151,7 +1151,10 @@ impl GpuResponse {
 #[cfg(test)]
 mod tests {
     use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
-    use virtio_queue::{mock::MockSplitQueue, Descriptor};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+    };
     use vm_memory::GuestMemoryMmap;
 
     use super::*;
@@ -1337,7 +1340,12 @@ mod tests {
 
         let vq = MockSplitQueue::new(&mem, 8);
         let desc_chain = vq
-            .build_desc_chain(&[Descriptor::new(0x1000, 8192, VRING_DESC_F_WRITE as u16, 0)])
+            .build_desc_chain(&[RawDescriptor::from(SplitDescriptor::new(
+                0x1000,
+                8192,
+                VRING_DESC_F_WRITE as u16,
+                0,
+            ))])
             .unwrap();
 
         let mut writer = desc_chain

--- a/vhost-device-i2c/Cargo.toml
+++ b/vhost-device-i2c/Cargo.toml
@@ -21,13 +21,13 @@ libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-input/Cargo.toml
+++ b/vhost-device-input/Cargo.toml
@@ -23,9 +23,9 @@ rand = "0.9.1"
 tempfile = "3.20"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 evdev = "0.13"
@@ -33,5 +33,5 @@ nix = { version = "0.30", features = ["ioctl"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -430,7 +430,7 @@ mod tests {
     use std::mem;
     use std::os::fd::RawFd;
     use std::path::PathBuf;
-    use virtio_queue::Descriptor;
+    use virtio_queue::desc::{split::Descriptor as SplitDescriptor, RawDescriptor};
     use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 
     use super::*;
@@ -588,10 +588,10 @@ mod tests {
         vring.set_queue_info(0x100, 0x200, 0x300).unwrap();
 
         // Create a descriptor chain with two descriptors.
-        let desc = Descriptor::new(0x400_u64, 0x100, 0, 0);
+        let desc = RawDescriptor::from(SplitDescriptor::new(0x400_u64, 0x100, 0, 0));
         mem_map.write_obj(desc, GuestAddress(0x100)).unwrap();
 
-        let desc = Descriptor::new(0x500_u64, 0x100, 0, 0);
+        let desc = RawDescriptor::from(SplitDescriptor::new(0x500_u64, 0x100, 0, 0));
         mem_map.write_obj(desc, GuestAddress(0x100 + 16)).unwrap();
 
         // Put the descriptor index 0 in the first available ring position.

--- a/vhost-device-rng/Cargo.toml
+++ b/vhost-device-rng/Cargo.toml
@@ -22,13 +22,13 @@ rand = "0.9.1"
 tempfile = "3.20"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -291,7 +291,11 @@ mod tests {
     use std::io::ErrorKind;
 
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue,
+    };
     use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 
     // Add VuRngBackend accessor to artificially manipulate internal fields
@@ -359,7 +363,12 @@ mod tests {
                 flags & !VRING_DESC_F_NEXT as u16
             };
 
-            let desc = Descriptor::new((0x100 * (i + 1)) as u64, 0x200, desc_flags, i + 1);
+            let desc = RawDescriptor::from(SplitDescriptor::new(
+                (0x100 * (i + 1)) as u64,
+                0x200,
+                desc_flags,
+                i + 1,
+            ));
             vq.desc_table().store(i, desc).unwrap();
         }
 

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -16,12 +16,12 @@ itertools = "0.14"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -538,7 +538,11 @@ impl VhostUserBackendMut for VuScmiBackend {
 #[cfg(test)]
 mod tests {
     use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue,
+    };
     use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
 
     use super::*;
@@ -560,7 +564,7 @@ mod tests {
 
         // Descriptor for the SCMI request
         let desc_request =
-            Descriptor::new(next_addr, request_size, VRING_DESC_F_NEXT as u16, index + 1);
+            SplitDescriptor::new(next_addr, request_size, VRING_DESC_F_NEXT as u16, index + 1);
         let mut bytes: Vec<u8> = vec![];
         bytes.append(&mut scmi_header(message_id, protocol_id).to_le_bytes().to_vec());
         for p in parameters {
@@ -568,13 +572,17 @@ mod tests {
         }
         mem.write_slice(bytes.as_slice(), desc_request.addr())
             .unwrap();
-        vq.desc_table().store(index, desc_request).unwrap();
+        vq.desc_table()
+            .store(index, RawDescriptor::from(desc_request))
+            .unwrap();
         next_addr += u64::from(desc_request.len());
         index += 1;
 
         // Descriptor for the SCMI response
-        let desc_response = Descriptor::new(next_addr, 0x100, VRING_DESC_F_WRITE as u16, 0);
-        vq.desc_table().store(index, desc_response).unwrap();
+        let desc_response = SplitDescriptor::new(next_addr, 0x100, VRING_DESC_F_WRITE as u16, 0);
+        vq.desc_table()
+            .store(index, RawDescriptor::from(desc_response))
+            .unwrap();
 
         // Put the descriptor index 0 in the first available ring position.
         mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
@@ -597,8 +605,10 @@ mod tests {
         let next_addr = vq.desc_table().total_size() + 0x100;
 
         // Descriptor for the SCMI event
-        let desc_response = Descriptor::new(next_addr, 0x100, VRING_DESC_F_WRITE as u16, 0);
-        vq.desc_table().store(0, desc_response).unwrap();
+        let desc_response = SplitDescriptor::new(next_addr, 0x100, VRING_DESC_F_WRITE as u16, 0);
+        vq.desc_table()
+            .store(0, RawDescriptor::from(desc_response))
+            .unwrap();
 
         // Put the descriptor index 0 in the first available ring position.
         mem.write_obj(0u16, vq.avail_addr().unchecked_add(4))
@@ -636,7 +646,7 @@ mod tests {
                 Some(addr) => addr,
                 _ => 0x100,
             };
-            let desc = Descriptor::new(offset, p.len, f, (i + 1) as u16);
+            let desc = RawDescriptor::from(SplitDescriptor::new(offset, p.len, f, (i + 1) as u16));
             vq.desc_table().store(i as u16, desc).unwrap();
         }
 

--- a/vhost-device-scsi/Cargo.toml
+++ b/vhost-device-scsi/Cargo.toml
@@ -22,9 +22,9 @@ log = "0.4"
 num_enum = "0.7"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 

--- a/vhost-device-scsi/src/vhu_scsi.rs
+++ b/vhost-device-scsi/src/vhu_scsi.rs
@@ -334,7 +334,10 @@ mod tests {
             VIRTIO_SCSI_S_FAILURE, VIRTIO_SCSI_S_OK,
         },
     };
-    use virtio_queue::{mock::MockSplitQueue, Descriptor};
+    use virtio_queue::{
+        desc::{split::Descriptor, RawDescriptor},
+        mock::MockSplitQueue,
+    };
     use vm_memory::{
         Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
         GuestMemoryMmap,
@@ -426,8 +429,13 @@ mod tests {
         );
         // The `build_desc_chain` function will populate the `NEXT` related flags and field.
         let v = vec![
-            Descriptor::new(0x10_0000, 0x100, 0, 0), // request
-            Descriptor::new(0x20_0000, 0x100, VRING_DESC_F_WRITE as u16, 0), // response
+            RawDescriptor::from(Descriptor::new(0x10_0000, 0x100, 0, 0)), // request
+            RawDescriptor::from(Descriptor::new(
+                0x20_0000,
+                0x100,
+                VRING_DESC_F_WRITE as u16,
+                0,
+            )), // response
         ];
 
         mem.memory()

--- a/vhost-device-scsi/src/virtio.rs
+++ b/vhost-device-scsi/src/virtio.rs
@@ -14,7 +14,7 @@ use std::{
 
 use log::error;
 use virtio_bindings::virtio_scsi::virtio_scsi_cmd_req;
-use virtio_queue::{Descriptor, DescriptorChain, DescriptorChainRwIter};
+use virtio_queue::{desc::split::Descriptor, DescriptorChain, DescriptorChainRwIter};
 use vm_memory::{Bytes, GuestAddress, GuestMemory};
 
 /// virtio-scsi has its own format for LUNs, documented in 5.6.6.1 of virtio
@@ -315,7 +315,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use virtio_bindings::virtio_scsi::{virtio_scsi_cmd_req, virtio_scsi_cmd_resp};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor};
+    use virtio_queue::{desc::RawDescriptor, mock::MockSplitQueue};
     use vm_memory::{ByteValued, GuestAddress, GuestMemoryMmap};
 
     use super::*;
@@ -353,7 +353,7 @@ pub(crate) mod tests {
         // The `build_desc_chain` function will populate the `NEXT` related flags and field.
         let v = vec![
             // A device-writable request header descriptor.
-            Descriptor::new(0x10_0000, 0x100, 0, 0),
+            RawDescriptor::from(Descriptor::new(0x10_0000, 0x100, 0, 0)),
         ];
 
         let req = report_luns_command();

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -22,9 +22,9 @@ env_logger = "0.11"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
@@ -36,7 +36,7 @@ pw = { package = "pipewire", version = "0.8", optional = true }
 [dev-dependencies]
 rstest = "0.25.0"
 tempfile = "3.20"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }
 
 [target.'cfg(target_env = "gnu")'.dev-dependencies]

--- a/vhost-device-sound/src/stream.rs
+++ b/vhost-device-sound/src/stream.rs
@@ -374,7 +374,11 @@ mod tests {
 
     use vhost_user_backend::{VringRwLock, VringT};
     use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{mock::MockSplitQueue, Descriptor, Queue, QueueOwnedT};
+    use virtio_queue::{
+        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+        mock::MockSplitQueue,
+        Queue, QueueOwnedT,
+    };
     use vm_memory::{
         Address, ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic,
         GuestMemoryMmap,
@@ -395,7 +399,7 @@ mod tests {
         let mut next_addr = vq.desc_table().total_size() + 0x100;
         let mut index = 0;
 
-        let desc_out = Descriptor::new(
+        let desc_out = SplitDescriptor::new(
             next_addr,
             (std::mem::size_of::<R>() as u32)
                 .checked_add(payload_len)
@@ -405,12 +409,19 @@ mod tests {
         );
 
         mem.write_obj::<R>(hdr, desc_out.addr()).unwrap();
-        vq.desc_table().store(index, desc_out).unwrap();
+        vq.desc_table()
+            .store(index, RawDescriptor::from(desc_out))
+            .unwrap();
         next_addr += u64::from(desc_out.len());
         index += 1;
 
         // In response descriptor
-        let desc_in = Descriptor::new(next_addr, response_len, VRING_DESC_F_WRITE as u16, 0);
+        let desc_in = RawDescriptor::from(SplitDescriptor::new(
+            next_addr,
+            response_len,
+            VRING_DESC_F_WRITE as u16,
+            0,
+        ));
         vq.desc_table().store(index, desc_in).unwrap();
 
         // Put the descriptor index 0 in the first available ring position.

--- a/vhost-device-spi/Cargo.toml
+++ b/vhost-device-spi/Cargo.toml
@@ -22,14 +22,14 @@ libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 bitflags = "2.9.1"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-template/Cargo.toml
+++ b/vhost-device-template/Cargo.toml
@@ -22,13 +22,13 @@ libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
+virtio-queue = "0.15"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 vm-memory = { version = "0.16.1", features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -22,10 +22,10 @@ epoll = "4.3.2"
 log = "0.4"
 thiserror = "2.0"
 vhost = { version = "0.14", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.18"
+vhost-user-backend = "0.19"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.14"
-virtio-vsock = "0.8"
+virtio-queue = "0.15"
+virtio-vsock = "0.9"
 vm-memory = "0.16.1"
 vmm-sys-util = "0.14"
 figment = { version = "0.10.19", features = ["yaml"] }
@@ -35,5 +35,5 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.14", features = ["test-utils"] }
+virtio-queue = { version = "0.15", features = ["test-utils"] }
 tempfile = "3.20.0"


### PR DESCRIPTION
### Summary of the PR

virtio-queue v0.15 introduces a new Descriptor API supporting both
split and packed virtqueue.
Update our dependencies and code to work with the new version
of the crate, including updating vhost-user-backend and virtio-vsock.

Updates `vhost-user-backend` from 0.18.0 to 0.19.0
- [Release notes](https://github.com/rust-vmm/vhost/releases)
- [Commits](rust-vmm/vhost@vhost-user-backend-v0.18.0...vhost-user-backend-v0.19.0)

Updates `virtio-queue` from 0.14.0 to 0.15.0
- [Release notes](https://github.com/rust-vmm/vm-virtio/releases)
- [Commits](rust-vmm/vm-virtio@virtio-queue-v0.14.0...virtio-queue-v0.15.0)

Updates `virtio-vsock` from 0.8.0 to 0.9.0
- [Release notes](https://github.com/rust-vmm/vm-virtio/releases)
- [Commits](rust-vmm/vm-virtio@virtio-vsock-v0.8.0...virtio-vsock-v0.9.0)

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
