### PR TITLE
vhost-device-gpio: Fix typos in README

### DIFF
--- a/vhost-device-gpio/README.md
+++ b/vhost-device-gpio/README.md
@@ -52,7 +52,7 @@ asking for trouble you can enable the "mock_gpio" feature in your build:
 
 You can then enable simulated GPIOs using the 's' prefix:
 
-    --device-list s4,s8
+    --device-list s4:s8
 
 Which will create two gpio devices, the first with 4 pins and the
 second with 8. By default updates are display via env logger:
@@ -71,7 +71,7 @@ The daemon should be started first:
 
 ::
 
-  host# vhost-device-gpio --socket-path=gpio.sock --socket-count=1 --device-list 0:3
+  host# vhost-device-gpio --socket-path=gpio.sock --socket-count=2 --device-list 0:3
 
 The QEMU invocation needs to create a chardev socket the device can
 use to communicate as well as share the guests memory over a memfd.


### PR DESCRIPTION
### Summary of the PR

In the examples of using vhost-device-gpio, the options should be 
--device-list=s4:s8 instead of --device-list=s4,s8, and 
--socket-count=2 instead of --socket-count=1.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.