### PR TITLE
scsi: fix test compilation

### DIFF
--- a/vhost-device-scsi/Cargo.toml
+++ b/vhost-device-scsi/Cargo.toml
@@ -31,4 +31,4 @@ vmm-sys-util = "0.14"
 [dev-dependencies]
 assert_matches = "1.5"
 tempfile = "3.20.0"
-
+virtio-queue = { version = "0.16", features = ["test-utils"] }


### PR DESCRIPTION
Fix scsi test compilation by correcting the dev-dependency for
virtio-queue. This would happen if someone runs the tests only for this
crate, and not workspace-wide.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
