### PR TITLE
README.md: fix link to GPU docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here is the list of device backends that we support:
 - [CAN](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-can/README.md)
 - [Console](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-console/README.md)
 - [GPIO](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-gpio/README.md)
-- [GPU] (https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-gpu/README.md)
+- [GPU](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-gpu/README.md)
 - [I2C](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-i2c/README.md)
 - [Input](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-input/README.md)
 - [RNG](https://github.com/rust-vmm/vhost-device/blob/main/vhost-device-rng/README.md)


### PR DESCRIPTION
Sorry I failed to notice this when I was cleaning up.