### PR TITLE
can: make features values conforming to the virtio spec

### DIFF
--- a/vhost-device-can/CHANGELOG.md
+++ b/vhost-device-can/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- [[#888]](https://github.com/rust-vmm/vhost-device/pull/888) can: make features values conforming to the virtio spec
 
 ### Deprecated
 

--- a/vhost-device-can/src/virtio_can.rs
+++ b/vhost-device-can/src/virtio_can.rs
@@ -42,9 +42,9 @@ pub(crate) const VIRTIO_CAN_RX: u16 = 0x0101;
 pub const VIRTIO_CAN_F_CAN_CLASSIC: u16 = 0;
 pub const VIRTIO_CAN_F_CAN_FD: u16 = 1;
 pub const VIRTIO_CAN_S_CTRL_BUSOFF: u16 = 2; /* Controller BusOff */
+pub const VIRTIO_CAN_F_RTR_FRAMES: u16 = 2;
 #[allow(dead_code)]
-pub const VIRTIO_CAN_F_LATE_TX_ACK: u16 = 2;
-pub const VIRTIO_CAN_F_RTR_FRAMES: u16 = 3;
+pub const VIRTIO_CAN_F_LATE_TX_ACK: u16 = 3;
 
 /// Possible values of the status field
 pub const VIRTIO_CAN_RESULT_OK: u8 = 0x0;


### PR DESCRIPTION
### Summary of the PR

Fix the values of VIRTIO_CAN_F_RTR_FRAMES and VIRTIO_CAN_F_LATE_TX_ACK to be conform to the virtio spec. The driver also will follow the same values (see https://lkml.org/lkml/2025/9/11/1615 comments).

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
