### PR TITLE
vhost-device-gpu: Add support for specifying GPU path

### DIFF
--- a/vhost-device-gpu/CHANGELOG.md
+++ b/vhost-device-gpu/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- [https://github.com/rust-vmm/vhost-device/pull/900] vhost-device-gpu: Add support for specifying GPU path
+
 ### Changed
 
 ### Fixed

--- a/vhost-device-gpu/README.md
+++ b/vhost-device-gpu/README.md
@@ -56,6 +56,9 @@ A virtio-gpu device using the vhost-user protocol.
           [default: true]
           [possible values: true, false]
 
+  -p, --gpu-path <PATH>
+          GPU path (e.g. /dev/dri/renderD128), only available for virglrenderer backend
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/vhost-device-gpu/src/device.rs
+++ b/vhost-device-gpu/src/device.rs
@@ -765,6 +765,7 @@ mod tests {
             GpuMode::VirglRenderer,
             Some(GpuCapset::VIRGL | GpuCapset::VIRGL2),
             GpuFlags::default(),
+            None,
         )
         .unwrap();
         let backend = VhostUserGpuBackend::new(config).unwrap();
@@ -1353,7 +1354,7 @@ mod tests {
     rusty_fork_test! {
         #[test]
         fn test_verify_backend() {
-            let gpu_config = GpuConfig::new(GpuMode::VirglRenderer, None, GpuFlags::default()).unwrap();
+            let gpu_config = GpuConfig::new(GpuMode::VirglRenderer, None, GpuFlags::default(), None).unwrap();
             let backend = VhostUserGpuBackend::new(gpu_config).unwrap();
 
             assert_eq!(backend.num_queues(), NUM_QUEUES);

--- a/vhost-device-gpu/src/main.rs
+++ b/vhost-device-gpu/src/main.rs
@@ -63,6 +63,11 @@ pub struct GpuArgs {
 
     #[clap(flatten)]
     pub flags: GpuFlagsArgs,
+
+    /// GPU path (e.g. /dev/dri/renderD128), only available for
+    /// virglrenderer backend.
+    #[clap(short = 'p', long, value_name = "PATH")]
+    pub gpu_path: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -115,7 +120,7 @@ impl From<GpuFlagsArgs> for GpuFlags {
 pub fn config_from_args(args: GpuArgs) -> Result<(PathBuf, GpuConfig), GpuConfigError> {
     let flags = GpuFlags::from(args.flags);
     let capset = args.capset.map(capset_names_into_capset);
-    let config = GpuConfig::new(args.gpu_mode, capset, flags)?;
+    let config = GpuConfig::new(args.gpu_mode, capset, flags, args.gpu_path)?;
     Ok((args.socket_path, config))
 }
 
@@ -186,6 +191,7 @@ mod tests {
                 use_gles: false,
                 use_surfaceless: false,
             },
+            gpu_path: None,
         };
 
         let (socket_path, config) = config_from_args(args).unwrap();


### PR DESCRIPTION
Rutabaga_gfx, since v0.1.75, supports specifying a GPU path (e.g.
/dev/dri/renderD128) for virglrenderer. This patch introduces a
`--gpu-path` argument to allow users to use any GPU they want.
