### PR TITLE
chore: remove pub visibility from exit event fields

### DIFF
--- a/staging/vhost-device-video/src/vhu_video.rs
+++ b/staging/vhost-device-video/src/vhu_video.rs
@@ -127,8 +127,8 @@ unsafe impl ByteValued for VirtioVideoConfig {}
 pub(crate) struct VuVideoBackend {
     config: VirtioVideoConfig,
     pub threads: Vec<Mutex<VhostUserVideoThread>>,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
 }
 
 impl VuVideoBackend {

--- a/vhost-device-console/src/vhu_console.rs
+++ b/vhost-device-console/src/vhu_console.rs
@@ -141,8 +141,8 @@ pub struct VhostUserConsoleBackend {
     pub stream: Option<Box<dyn ReadWrite + Send + Sync>>,
     pub rx_event: EventFd,
     pub rx_ctrl_event: EventFd,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-gpio/src/vhu_gpio.rs
+++ b/vhost-device-gpio/src/vhu_gpio.rs
@@ -160,8 +160,8 @@ pub(crate) struct VhostUserGpioBackend<D: GpioDevice> {
     controller: Arc<GpioController<D>>,
     handles: Arc<RwLock<Vec<Option<JoinHandle<()>>>>>,
     event_idx: bool,
-    pub(crate) exit_consumer: EventConsumer,
-    pub(crate) exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-gpu/src/device.rs
+++ b/vhost-device-gpu/src/device.rs
@@ -141,8 +141,8 @@ struct VhostUserGpuBackendInner {
     virtio_cfg: VirtioGpuConfig,
     event_idx_enabled: bool,
     gpu_backend: Option<GpuBackend>,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     gpu_config: GpuConfig,
 }

--- a/vhost-device-i2c/src/vhu_i2c.rs
+++ b/vhost-device-i2c/src/vhu_i2c.rs
@@ -105,8 +105,8 @@ unsafe impl ByteValued for VirtioI2cInHdr {}
 pub(crate) struct VhostUserI2cBackend<D: I2cDevice> {
     i2c_map: Arc<I2cMap<D>>,
     event_idx: bool,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryLoadGuard<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -124,8 +124,8 @@ impl From<VuInputError> for io::Error {
 pub(crate) struct VuInputBackend<T: InputDevice> {
     event_idx: bool,
     ev_dev: T,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     select: u8,
     subsel: u8,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,

--- a/vhost-device-rng/src/vhu_rng.rs
+++ b/vhost-device-rng/src/vhu_rng.rs
@@ -90,8 +90,8 @@ pub(crate) struct VuRngBackend<T: ReadVolatile> {
     event_idx: bool,
     timer: VuRngTimerConfig,
     rng_source: Arc<Mutex<T>>,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-scmi/src/vhu_scmi.rs
+++ b/vhost-device-scmi/src/vhu_scmi.rs
@@ -96,8 +96,8 @@ type ScmiDescriptorChain = DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap<
 
 pub struct VuScmiBackend {
     event_idx: bool,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     /// Event vring and descriptors serve for asynchronous responses and
     /// notifications. They are obtained from the driver and we store them

--- a/vhost-device-scsi/src/vhu_scsi.rs
+++ b/vhost-device-scsi/src/vhu_scsi.rs
@@ -39,8 +39,8 @@ pub struct VhostUserScsiBackend {
     event_idx: bool,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     targets: Vec<Box<dyn Target>>,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
 }
 
 impl Default for VhostUserScsiBackend {

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -486,8 +486,8 @@ impl VhostUserSoundThread {
 pub struct VhostUserSoundBackend {
     pub threads: Vec<RwLock<VhostUserSoundThread>>,
     virtio_cfg: VirtioSoundConfig,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     audio_backend: RwLock<Box<dyn AudioBackend + Send + Sync>>,
 }
 

--- a/vhost-device-spi/src/vhu_spi.rs
+++ b/vhost-device-spi/src/vhu_spi.rs
@@ -137,8 +137,8 @@ unsafe impl ByteValued for VirtioSpiConfig {}
 pub(crate) struct VhostUserSpiBackend<D: SpiDevice> {
     spi_ctrl: Arc<SpiController<D>>,
     event_idx: bool,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-template/src/backend.rs
+++ b/vhost-device-template/src/backend.rs
@@ -53,8 +53,8 @@ impl From<Error> for std::io::Error {
 pub struct VhostUserFooBackend {
     info: FooInfo,
     event_idx: bool,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
     mem: Option<GuestMemoryLoadGuard<GuestMemoryMmap>>,
 }
 

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -259,8 +259,8 @@ pub(crate) struct VhostUserVsockBackend {
     queue_size: usize,
     pub threads: Vec<Mutex<VhostUserVsockThread>>,
     queues_per_thread: Vec<u64>,
-    pub exit_consumer: EventConsumer,
-    pub exit_notifier: EventNotifier,
+    exit_consumer: EventConsumer,
+    exit_notifier: EventNotifier,
 }
 
 impl VhostUserVsockBackend {


### PR DESCRIPTION
### Summary of the PR

The `exit_consumer` and `exit_notifier` fields are only used internally by the exit_event() method implementation or by send_exit_event() in the sound device. So, they do not need to be exposed in the public API of backend structures.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
