### PR TITLE
vhost-device-sound: reuse socket between requests

### DIFF
--- a/vhost-device-sound/CHANGELOG.md
+++ b/vhost-device-sound/CHANGELOG.md
@@ -5,6 +5,22 @@
 
 ### Changed
 
+- [[#907]](https://github.com/rust-vmm/vhost-device/pull/907)
+  `vhost_device_sound::start_backend_server` now mutably borrows a
+  `vhost::vhost_user::Listener`, so the socket isn't removed and
+  re-created between each connection, and there's no longer a short
+  window of time where there's no socket for clients to connect to.
+
+  As a consequence of this change:
+
+  - `vhost_device_sound::SoundConfig::new` no longer takes a `socket` argument.
+  - `vhost_device_sound::SoundConfig::get_socket_path` has been removed.
+  - `vhost_device_sound::SoundConfig` no longer implements
+    `From<vhost_device_sound::args::SoundArgs>` (since the `socket`
+    argument should be handled separately).
+  - `vhost_device_sound::start_backend_server` now additionally takes
+    a `listener` argument.
+
 ### Fixed
 
 ### Deprecated

--- a/vhost-device-sound/src/device.rs
+++ b/vhost-device-sound/src/device.rs
@@ -682,8 +682,6 @@ impl VhostUserBackend for VhostUserSoundBackend {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use tempfile::tempdir;
     use virtio_bindings::virtio_ring::VRING_DESC_F_WRITE;
     use virtio_queue::{
@@ -696,8 +694,6 @@ mod tests {
 
     use super::*;
     use crate::BackendType;
-
-    const SOCKET_PATH: &str = "vsound.socket";
 
     fn setup_descs(descs: &[RawDescriptor]) -> (VringRwLock, GuestMemoryAtomic<GuestMemoryMmap>) {
         let mem = GuestMemoryAtomic::new(
@@ -739,7 +735,7 @@ mod tests {
     #[test]
     fn test_sound_thread_success() {
         crate::init_logger();
-        let config = SoundConfig::new(PathBuf::from(SOCKET_PATH), false, BackendType::Null);
+        let config = SoundConfig::new(false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -849,7 +845,7 @@ mod tests {
     #[test]
     fn test_sound_thread_failure() {
         crate::init_logger();
-        let config = SoundConfig::new(PathBuf::from(SOCKET_PATH), false, BackendType::Null);
+        let config = SoundConfig::new(false, BackendType::Null);
 
         let chmaps = Arc::new(RwLock::new(vec![]));
         let jacks = Arc::new(RwLock::new(vec![]));
@@ -938,8 +934,7 @@ mod tests {
     fn test_sound_backend() {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
-        let socket_path = test_dir.path().join(SOCKET_PATH);
-        let config = SoundConfig::new(socket_path, false, BackendType::Null);
+        let config = SoundConfig::new(false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config).expect("Could not create backend.");
 
         assert_eq!(backend.num_queues(), NUM_QUEUES as usize);
@@ -1017,9 +1012,7 @@ mod tests {
         crate::init_logger();
         let test_dir = tempdir().expect("Could not create a temp test directory.");
 
-        let socket_path = test_dir.path().join("sound_failures.socket");
-
-        let config = SoundConfig::new(socket_path, false, BackendType::Null);
+        let config = SoundConfig::new(false, BackendType::Null);
         let backend = VhostUserSoundBackend::new(config);
 
         let backend = backend.unwrap();


### PR DESCRIPTION
### Summary of the PR

This removes a race where there's a moment in between connections where the socket is unlinked and recreated, so there's no socket available for clients to connect to.  This unfortunately requires changing the public API.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
