### PR TITLE
vhost-device-sound: test dbus-daemon from PATH

### DIFF
--- a/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire/test_utils.rs
@@ -36,7 +36,7 @@ pub struct DbusSession {
 impl DbusSession {
     pub fn new(working_dir: &Path) -> Self {
         let address_prefix = format!("unix:path={}", working_dir.join("dbus").display());
-        let mut child = Command::new("/usr/bin/dbus-daemon")
+        let mut child = Command::new("dbus-daemon")
             .args(["--session", "--address", &address_prefix, "--print-address"])
             .env("DBUS_VERBOSE", "1")
             .stdout(Stdio::piped())


### PR DESCRIPTION
### Summary of the PR

On my NixOS system, dbus-daemon is not at /usr/bin/dbus-daemon, but on systems where it is, it should also be in PATH.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
