### PR TITLE
vhost-device-gpu: Adapt to updated virglrenderer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,9 +2292,9 @@ dependencies = [
 
 [[package]]
 name = "virglrenderer"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b3ceb5f84adcbd531661a6c6c0883c3d6cd83427886d3179675b19268f4450"
+checksum = "6906bec0a34658c4a81933153a784f9f8d8bcdbe67dcf9e58ea7b67fd1f8ec0b"
 dependencies = [
  "libc 1.0.0-alpha.1",
  "log",
@@ -2304,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "virglrenderer-sys"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b62ecfe310dacb7a9cd5b9e4c2e25fa5663a9c860c3396ed3b11ee1e06e4b4"
+checksum = "5e1cd0732acd1881433c4689bb2d359d64b9a64ddf64ab7231d9db35edbd181a"
 dependencies = [
  "bindgen",
  "pkg-config",

--- a/vhost-device-gpu/CHANGELOG.md
+++ b/vhost-device-gpu/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- [[#916]] (https://github.com/rust-vmm/vhost-device/pull/916) vhost-device-gpu: Adapt to updated virglrenderer API
 - [[#852]] (https://github.com/rust-vmm/vhost-device/pull/890) vhost-device-gpu: Refactor vhost-device-gpu
 
 ### Fixed

--- a/vhost-device-gpu/Cargo.toml
+++ b/vhost-device-gpu/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4"
 [target.'cfg(not(target_env = "musl"))'.dependencies]
 rutabaga_gfx = "0.1.75"
 thiserror = "2.0.17"
-virglrenderer = {version = "0.1.2", optional = true }
+virglrenderer = {version = "0.1.3", optional = true }
 vhost = { version = "0.15.0", features = ["vhost-user-backend"] }
 vhost-user-backend = "0.21"
 virtio-bindings = "0.2.5"


### PR DESCRIPTION
### Summary of the PR

the updated virglrenderer crate no longer exposes a VirglContext type. Instead, context management is now handled directly through the VirglRenderer object, hence use the VirglRenderer directly.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
