### PR TITLE
vhost-device-can: consume desc chain based on rx fifo queue

### DIFF
--- a/vhost-device-can/src/can.rs
+++ b/vhost-device-can/src/can.rs
@@ -116,6 +116,10 @@ impl CanController {
         self.rx_fifo.size() == 0
     }
 
+    pub fn rx_fifo_size(&self) -> usize {
+        self.rx_fifo.size()
+    }
+
     pub fn pop(&mut self) -> Result<VirtioCanFrame> {
         if self.rx_fifo.size() < 1 {
             return Err(Error::QueueEmpty);


### PR DESCRIPTION
### Summary of the PR
Consume descriptor chains from the rx queue based on the size of the reception fifo queue. Before this fix, the device was consuming all available buffers from the rx queue. If the reception fifo queue was shorter than the number of descriptors, those remainder descriptors were lost, i.e., the device was signaling that it used them but they were never returned to the used vring. Some descriptors chains are returned though thus allowing the driver to recycle them. This results in an available ring with less and less descriptors until the vring runs out of descriptors thus blocking the device.

Fixes: #923

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
