### PR TITLE
vhost-device-gpu: Add support for GPU device path

### DIFF
--- a/vhost-device-gpu/CHANGELOG.md
+++ b/vhost-device-gpu/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 
+- [[#932]] (https://github.com/rust-vmm/vhost-device/pull/932) vhost-device-gpu: Add support for GPU device path
 - [[#927]] (https://github.com/rust-vmm/vhost-device/pull/927) vhost-device-gpu: Introduce headless mode
 
 ### Changed

--- a/vhost-device-gpu/README.md
+++ b/vhost-device-gpu/README.md
@@ -58,6 +58,11 @@ A virtio-gpu device using the vhost-user protocol.
 
       --headless
           Enable headless mode (no display output)
+      --gpu-device <PATH>
+          GPU device path (e.g., /dev/dri/renderD128)
+
+          [Optional] Specifies which GPU device to use for rendering. Only
+          applicable when using the virglrenderer backend.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -135,6 +140,12 @@ First start the daemon on the host machine using one of the available gpu modes:
 
 ```shell
 host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virglrenderer
+```
+
+To specify a particular GPU device (e.g., when you have multiple GPUs):
+
+```shell
+host# vhost-device-gpu --socket-path /tmp/gpu.socket --gpu-mode virglrenderer --gpu-device /dev/dri/renderD128
 ```
 
 With QEMU, there are two device front-ends you can use with this device.

--- a/vhost-device-gpu/src/backend/virgl.rs
+++ b/vhost-device-gpu/src/backend/virgl.rs
@@ -14,6 +14,7 @@ use std::{
 use libc::c_void;
 use log::{debug, error, trace, warn};
 use rutabaga_gfx::RutabagaFence;
+use thiserror::Error as ThisError;
 use vhost::vhost_user::{
     gpu_message::{
         VhostUserGpuCursorPos, VhostUserGpuDMABUFScanout, VhostUserGpuDMABUFScanout2,
@@ -50,6 +51,20 @@ use crate::{
 const CAPSET_ID_VIRGL: u32 = 1;
 const CAPSET_ID_VIRGL2: u32 = 2;
 const CAPSET_ID_VENUS: u32 = 4;
+
+#[derive(Debug, ThisError)]
+pub enum VirglAdapterError {
+    #[error("Failed to clone GPU device FD: {0}")]
+    CloneGpuDeviceFd(io::Error),
+    #[error("Failed to initialize virglrenderer: {0:?}")]
+    InitVirglRenderer(virglrenderer::VirglError),
+}
+
+impl From<VirglAdapterError> for io::Error {
+    fn from(e: VirglAdapterError) -> Self {
+        io::Error::other(e)
+    }
+}
 
 #[derive(Clone)]
 pub struct GpuResource {
@@ -163,8 +178,16 @@ impl VirglRendererAdapter {
             fence_state.clone(),
         ));
 
-        let renderer = VirglRenderer::init(virglrenderer_flags, fence_handler, None)
-            .expect("Failed to initialize virglrenderer");
+        let render_server_fd = match config.render_server_fd() {
+            Some(fd) => Some(
+                fd.try_clone()
+                    .map_err(VirglAdapterError::CloneGpuDeviceFd)?,
+            ),
+            None => None,
+        };
+
+        let renderer = VirglRenderer::init(virglrenderer_flags, fence_handler, render_server_fd)
+            .map_err(VirglAdapterError::InitVirglRenderer)?;
         Ok(Self {
             renderer,
             gpu_backend,

--- a/vhost-device-gpu/src/device.rs
+++ b/vhost-device-gpu/src/device.rs
@@ -24,7 +24,7 @@ macro_rules! handle_adapter {
                     // Pass $vrings to the call
                     let (control_vring, gpu_backend) = $self.extract_backend_and_vring($vrings)?;
 
-                    let renderer = $new_adapter(control_vring, gpu_backend);
+                    let renderer = $new_adapter(control_vring, gpu_backend)?;
 
                     event_poll_fd = renderer.get_event_poll_fd();
                     maybe_renderer.insert(renderer)
@@ -622,8 +622,12 @@ impl VhostUserGpuBackendInner {
             GpuMode::Gfxstream => handle_adapter!(
                 GfxstreamAdapter,
                 TLS_GFXSTREAM,
-                |control_vring, gpu_backend| {
-                    GfxstreamAdapter::new(control_vring, &self.gpu_config, gpu_backend)
+                |control_vring, gpu_backend| -> io::Result<GfxstreamAdapter> {
+                    Ok(GfxstreamAdapter::new(
+                        control_vring,
+                        &self.gpu_config,
+                        gpu_backend,
+                    ))
                 },
                 self,
                 device_event,
@@ -645,8 +649,12 @@ impl VhostUserGpuBackendInner {
             GpuMode::Null => handle_adapter!(
                 NullAdapter,
                 TLS_NULL,
-                |control_vring, gpu_backend| {
-                    NullAdapter::new(control_vring, &self.gpu_config, gpu_backend)
+                |control_vring, gpu_backend| -> io::Result<NullAdapter> {
+                    Ok(NullAdapter::new(
+                        control_vring,
+                        &self.gpu_config,
+                        gpu_backend,
+                    ))
                 },
                 self,
                 device_event,


### PR DESCRIPTION
### Summary of the PR

Add a new --gpu-device CLI argument that allows users to specify which GPU device to use for rendering when using the virglrenderer backend.
This is useful for systems with multiple GPUs where a specific device needs to be selected.

Supersedes #910 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
