### PR TITLE
chore: move rust-vmm deps to workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,14 @@ members = [
     "xtask",
 ]
 
+[workspace.dependencies]
+vhost = { version = "0.15", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.21"
+virtio-bindings = "0.2.5"
+virtio-queue = "0.17"
+vm-memory = "0.17.1"
+vmm-sys-util = "0.15"
+
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
 

--- a/staging/Cargo.toml
+++ b/staging/Cargo.toml
@@ -1,5 +1,14 @@
 [workspace]
 resolver = "2"
+
 members = [
   "vhost-device-video",
 ]
+
+[workspace.dependencies]
+vhost = { version = "0.15", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.21"
+virtio-bindings = "0.2.5"
+virtio-queue = "0.17"
+vm-memory = "0.17.1"
+vmm-sys-util = "0.15"

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -26,17 +26,17 @@ log = "0.4"
 libc = "0.2.185"
 thiserror = "2.0"
 futures-executor = { version = "0.3", features = ["thread-pool"] }
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 v4l2r = { git =  "https://github.com/Gnurou/v4l2r", rev = "110fd77", optional = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
 rstest = "0.26.1"
 tempfile = "3.27.0"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-can/Cargo.toml
+++ b/vhost-device-can/Cargo.toml
@@ -21,14 +21,14 @@ log = "0.4"
 thiserror = "2.0"
 queues = "1.0.2"
 socketcan = "3.5.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-console/Cargo.toml
+++ b/vhost-device-console/Cargo.toml
@@ -23,17 +23,17 @@ env_logger = "0.11"
 epoll = "4.4"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-gpio/Cargo.toml
+++ b/vhost-device-gpio/Cargo.toml
@@ -21,17 +21,17 @@ env_logger = "0.11"
 libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [target.'cfg(target_env = "gnu")'.dependencies]
 libgpiod = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-gpu/Cargo.toml
+++ b/vhost-device-gpu/Cargo.toml
@@ -29,12 +29,12 @@ log = "0.4"
 rutabaga_gfx = "0.1.75"
 thiserror = "2.0.18"
 virglrenderer = {version = "0.1.3", optional = true }
-vhost = { version = "0.15.0", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17.0"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15.0"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 bitflags = "2.11.1"
 uuid = { version = "1.23", features = ["v4"] }
 
@@ -43,5 +43,5 @@ assert_matches = "1.5"
 mockall = "0.14.0"
 rusty-fork = "0.3.1"
 tempfile = "3.27"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }

--- a/vhost-device-i2c/Cargo.toml
+++ b/vhost-device-i2c/Cargo.toml
@@ -20,17 +20,17 @@ env_logger = "0.11"
 libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-input/Cargo.toml
+++ b/vhost-device-input/Cargo.toml
@@ -22,19 +22,19 @@ log = "0.4"
 rand = "0.10.0"
 tempfile = "3.27"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 evdev = "0.13"
 nix = { version = "0.31", features = ["ioctl"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-rng/Cargo.toml
+++ b/vhost-device-rng/Cargo.toml
@@ -21,17 +21,17 @@ log = "0.4"
 rand = "0.10.0"
 tempfile = "3.27"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-rtc/Cargo.toml
+++ b/vhost-device-rtc/Cargo.toml
@@ -20,17 +20,17 @@ libc = "0.2"
 log = "0.4"
 nix = { version = "0.31", features = ["time"] }
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-scmi/Cargo.toml
+++ b/vhost-device-scmi/Cargo.toml
@@ -15,16 +15,16 @@ env_logger = "0.11"
 itertools = "0.14"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/vhost-device-scsi/Cargo.toml
+++ b/vhost-device-scsi/Cargo.toml
@@ -20,17 +20,17 @@ env_logger = "0.11"
 epoll = "4.4"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
 tempfile = "3.27.0"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/vhost-device-sound/Cargo.toml
+++ b/vhost-device-sound/Cargo.toml
@@ -22,12 +22,12 @@ clap = { version = "4.6", features = ["derive"] }
 env_logger = "0.11"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 # Make alsa and pipewire backends available only on gnu
 [target.'cfg(target_env = "gnu")'.dependencies]
@@ -40,8 +40,8 @@ gst-audio = {package = "gstreamer-audio", version = "0.24.2", optional = true, f
 [dev-dependencies]
 rstest = "0.26.1"
 tempfile = "3.27"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [target.'cfg(target_env = "gnu")'.dev-dependencies]
 rand = { version = "0.10.0" }

--- a/vhost-device-spi/Cargo.toml
+++ b/vhost-device-spi/Cargo.toml
@@ -21,18 +21,18 @@ env_logger = "0.11"
 libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 bitflags = "2.11.1"
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-template/Cargo.toml
+++ b/vhost-device-template/Cargo.toml
@@ -20,17 +20,17 @@ env_logger = "0.11"
 libc = "0.2"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
-vm-memory = { version = "0.17.1", features = ["backend-mmap", "backend-atomic"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 
 [lints]
 workspace = true

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -21,13 +21,13 @@ env_logger = "0.11"
 epoll = "4.4.0"
 log = "0.4"
 thiserror = "2.0"
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
-virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
+vhost = { workspace = true }
+vhost-user-backend = { workspace = true }
+virtio-bindings = { workspace = true }
+virtio-queue = { workspace = true }
 virtio-vsock = "0.11"
-vm-memory = "0.17.1"
-vmm-sys-util = "0.15"
+vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 figment = { version = "0.10.19", features = ["yaml"] }
 vsock = { version = "0.5.4", optional = true }
 libc = { version = "0.2.185", optional = true }
@@ -35,7 +35,7 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { version = "0.17", features = ["test-utils"] }
+virtio-queue = { workspace = true, features = ["test-utils"] }
 tempfile = "3.27.0"
 
 [lints]


### PR DESCRIPTION
### Summary of the PR

This PR moves rust-vmm related dependencies to workspace dependencies, and alphabetically reorders some of the crate declarations.

Closes https://github.com/rust-vmm/vhost-device/issues/906

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
