### PR TITLE
feat(vsock): implement the enq_rst function and handle TODOs that specified a rst should be the response

### DIFF
--- a/vhost-device-vsock/CHANGELOG.md
+++ b/vhost-device-vsock/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 
 ### Added
+- [#943](https://github.com/rust-vmm/vhost-device/pull/943) Send RST to guest for packets not of type VSOCK_TYPE_STREAM 
+  or packets from previously unseen connections that aren't a connection request.
 
 ### Changed
 

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -291,7 +291,10 @@ impl VsockThreadBackend {
                 // Handle other packet types per connection
                 conn.recv_pkt(pkt)
             }
-            None => Ok(()),
+            None => {
+                self.fill_rst_pkt(pkt, self.guest_cid, key.local_port, key.peer_port);
+                Ok(())
+            }
         }
     }
 

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -346,22 +346,20 @@ impl VsockThreadBackend {
             }
         }
 
-        // TODO: Rst if packet has unsupported type
         if pkt.type_() != VSOCK_TYPE_STREAM {
             info!("vsock: dropping packet of unknown type");
+            self.enq_rst(pkt.dst_port(), pkt.src_port());
             return Ok(());
         }
 
         let key = ConnMapKey::new(pkt.dst_port(), pkt.src_port());
 
-        // TODO: Handle cases where connection does not exist and packet op
-        // is not VSOCK_OP_REQUEST
         if !self.conn_map.contains_key(&key) {
             // The packet contains a new connection request
             if pkt.op() == VSOCK_OP_REQUEST {
                 self.handle_new_guest_conn(pkt);
             } else {
-                // TODO: send back RST
+                self.enq_rst(pkt.dst_port(), pkt.src_port());
             }
             return Ok(());
         }

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -595,6 +595,24 @@ mod tests {
         vtp.recv_pkt(&mut packet).unwrap();
 
         vtp.enq_rst(packet.src_port(), packet.dst_port());
+
+        // check that receiving should yield rst when we send an invalid type
+        packet.set_type(10);
+        packet.set_op(VSOCK_OP_RW);
+        vtp.send_pkt(&packet).unwrap();
+        vtp.recv_pkt(&mut packet).unwrap();
+        assert!(packet.op() == VSOCK_OP_RST);
+
+        // check that receiving should yield rst when we send a packet with ports that
+        // aren't in the connection map and the operation isn't a connection request
+        packet.set_type(VSOCK_TYPE_STREAM);
+        packet.set_dst_cid(VSOCK_HOST_CID);
+        packet.set_src_cid(CID);
+        packet.set_dst_port(12345);
+        packet.set_op(VSOCK_OP_RW);
+        vtp.send_pkt(&packet).unwrap();
+        vtp.recv_pkt(&mut packet).unwrap();
+        assert!(packet.op() == VSOCK_OP_RST);
     }
 
     #[test]
@@ -764,6 +782,77 @@ mod tests {
         assert_eq!(recvd_data_raw[1], 0xFEu8);
         assert_eq!(recvd_data_raw[2], 0xBAu8);
         assert_eq!(recvd_data_raw[3], 0xBEu8);
+
+        test_dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_recv_pkt_rst_cleans_up_conn() {
+        const CID: u64 = 3;
+        const LOCAL_PORT: u32 = 6000;
+        const PEER_PORT: u32 = 7000;
+
+        let epoll_fd = epoll::create(false).unwrap();
+        let groups_set: HashSet<String> = vec![GROUP_NAME.to_string()].into_iter().collect();
+        let cid_map: Arc<RwLock<CidMap>> = Arc::new(RwLock::new(HashMap::new()));
+
+        let test_dir = tempdir().expect("Could not create a temp test directory.");
+        let vsock_socket_path = test_dir.path().join("test_rst_cleanup.vsock");
+
+        let mut vtp = VsockThreadBackend::new(
+            BackendType::UnixDomainSocket(vsock_socket_path),
+            epoll_fd,
+            CID,
+            CONN_TX_BUF_SIZE,
+            Arc::new(RwLock::new(groups_set)),
+            cid_map,
+        );
+
+        // Create a unix stream pair. One end backs the connection (cloned so that
+        // the original can also be placed in stream_map, mirroring add_new_guest_conn).
+        let (stream_a, _stream_b) = std::os::unix::net::UnixStream::pair().unwrap();
+        let conn_stream = StreamType::Unix(stream_a.try_clone().unwrap());
+        let conn_stream_fd = conn_stream.as_raw_fd();
+
+        let mut conn = VsockConnection::new_local_init(
+            conn_stream,
+            VSOCK_HOST_CID,
+            LOCAL_PORT,
+            CID,
+            PEER_PORT,
+            epoll_fd,
+            CONN_TX_BUF_SIZE,
+        );
+        conn.rx_queue.enqueue(RxOps::Reset);
+
+        let key = ConnMapKey::new(LOCAL_PORT, PEER_PORT);
+
+        vtp.conn_map.insert(key.clone(), conn);
+        vtp.listener_map.insert(conn_stream_fd, key.clone());
+        vtp.stream_map
+            .insert(conn_stream_fd, StreamType::Unix(stream_a));
+        vtp.local_port_set.insert(LOCAL_PORT);
+        vtp.backend_rxq.push_back(key.clone());
+
+        let mut pkt_raw = [0u8; PKT_HEADER_SIZE + DATA_LEN];
+        let (hdr_raw, data_raw) = pkt_raw.split_at_mut(PKT_HEADER_SIZE);
+        // SAFETY: Safe as hdr_raw and data_raw are guaranteed to be valid.
+        let mut packet = unsafe { VsockPacket::new(hdr_raw, Some(data_raw)).unwrap() };
+
+        vtp.recv_pkt(&mut packet).unwrap();
+
+        // The packet should be a RST addressed back to the guest peer
+        assert_eq!(packet.op(), VSOCK_OP_RST);
+        assert_eq!(packet.src_cid(), VSOCK_HOST_CID);
+        assert_eq!(packet.dst_cid(), CID);
+        assert_eq!(packet.src_port(), LOCAL_PORT);
+        assert_eq!(packet.dst_port(), PEER_PORT);
+
+        // The connection should have been removed from all tracking structures
+        assert!(!vtp.conn_map.contains_key(&key));
+        assert!(!vtp.listener_map.contains_key(&conn_stream_fd));
+        assert!(!vtp.stream_map.contains_key(&conn_stream_fd));
+        assert!(!vtp.local_port_set.contains(&LOCAL_PORT));
 
         test_dir.close().unwrap();
     }

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -266,48 +266,33 @@ impl VsockThreadBackend {
     pub fn recv_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacket<B>) -> Result<()> {
         // Pop an event from the backend_rxq
         let key = self.backend_rxq.pop_front().ok_or(Error::EmptyBackendRxQ)?;
-        let conn = match self.conn_map.get_mut(&key) {
-            Some(conn) => conn,
-            None => {
-                // assume that the connection does not exist
-                return Ok(());
+        match self.conn_map.get_mut(&key) {
+            // We received a packet meant for a connection we are aware of
+            Some(conn) => {
+                if conn.rx_queue.peek() == Some(RxOps::Reset) {
+                    let conn = self.conn_map.remove(&key).unwrap();
+                    self.listener_map.remove(&conn.stream.as_raw_fd());
+                    self.stream_map.remove(&conn.stream.as_raw_fd());
+                    self.local_port_set.remove(&conn.local_port);
+                    VhostUserVsockThread::epoll_unregister(conn.epoll_fd, conn.stream.as_raw_fd())
+                        .unwrap_or_else(|err| {
+                            warn!(
+                                "Could not remove epoll listener for fd {:?}: {:?}",
+                                conn.stream.as_raw_fd(),
+                                err
+                            )
+                        });
+
+                    // Initialize the packet header to contain a VSOCK_OP_RST operation
+                    self.fill_rst_pkt(pkt, conn.guest_cid, conn.local_port, conn.peer_port);
+                    return Ok(());
+                }
+
+                // Handle other packet types per connection
+                conn.recv_pkt(pkt)
             }
-        };
-
-        if conn.rx_queue.peek() == Some(RxOps::Reset) {
-            // Handle RST events here
-            let conn = self.conn_map.remove(&key).unwrap();
-            self.listener_map.remove(&conn.stream.as_raw_fd());
-            self.stream_map.remove(&conn.stream.as_raw_fd());
-            self.local_port_set.remove(&conn.local_port);
-            VhostUserVsockThread::epoll_unregister(conn.epoll_fd, conn.stream.as_raw_fd())
-                .unwrap_or_else(|err| {
-                    warn!(
-                        "Could not remove epoll listener for fd {:?}: {:?}",
-                        conn.stream.as_raw_fd(),
-                        err
-                    )
-                });
-
-            // Initialize the packet header to contain a VSOCK_OP_RST operation
-            pkt.set_op(VSOCK_OP_RST)
-                .set_src_cid(VSOCK_HOST_CID)
-                .set_dst_cid(conn.guest_cid)
-                .set_src_port(conn.local_port)
-                .set_dst_port(conn.peer_port)
-                .set_len(0)
-                .set_type(VSOCK_TYPE_STREAM)
-                .set_flags(0)
-                .set_buf_alloc(0)
-                .set_fwd_cnt(0);
-
-            return Ok(());
+            None => Ok(()),
         }
-
-        // Handle other packet types per connection
-        conn.recv_pkt(pkt)?;
-
-        Ok(())
     }
 
     /// Deliver a guest generated packet to its destination in the backend.

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -440,7 +440,7 @@ impl VsockThreadBackend {
                     .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
                     .map_err(Error::UnixConnect)
                     .and_then(|stream| self.add_new_guest_conn(StreamType::Unix(stream), pkt))
-                    .unwrap_or_else(|_| self.enq_rst());
+                    .unwrap_or_else(|_| self.enq_rst(pkt.dst_port(), pkt.src_port()));
             }
             #[cfg(feature = "backend_vsock")]
             BackendType::Vsock(vsock_info) => {
@@ -448,7 +448,7 @@ impl VsockThreadBackend {
                     .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
                     .map_err(Error::VsockConnect)
                     .and_then(|stream| self.add_new_guest_conn(StreamType::Vsock(stream), pkt))
-                    .unwrap_or_else(|_| self.enq_rst());
+                    .unwrap_or_else(|_| self.enq_rst(pkt.dst_port(), pkt.src_port()));
             }
         }
     }
@@ -493,10 +493,14 @@ impl VsockThreadBackend {
         Ok(())
     }
 
-    /// Enqueue RST packets to be sent to guest.
-    fn enq_rst(&mut self) {
-        // TODO
+    /// Enqueue RST packets to be sent to guest by pushing a
+    /// conn_map_key to the front of the rx queue. marking that
+    /// we want to build a rst packet for the connection identified by
+    /// local_port, and dst_port.
+    fn enq_rst(&mut self, local_port: u32, dst_port: u32) {
         log::debug!("New guest conn error: Enqueue RST");
+        self.backend_rxq
+            .push_front(ConnMapKey::new(local_port, dst_port));
     }
 
     /// Fill out RST pkt data.
@@ -592,8 +596,7 @@ mod tests {
 
         vtp.recv_pkt(&mut packet).unwrap();
 
-        // TODO: it is a nop for now
-        vtp.enq_rst();
+        vtp.enq_rst(packet.src_port(), packet.dst_port());
     }
 
     #[test]

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -510,6 +510,26 @@ impl VsockThreadBackend {
         // TODO
         log::debug!("New guest conn error: Enqueue RST");
     }
+
+    /// Fill out RST pkt data.
+    fn fill_rst_pkt<B: BitmapSlice>(
+        &self,
+        pkt: &mut VsockPacket<B>,
+        cid: u64,
+        src_port: u32,
+        dst_port: u32,
+    ) {
+        pkt.set_op(VSOCK_OP_RST)
+            .set_src_cid(VSOCK_HOST_CID)
+            .set_dst_cid(cid)
+            .set_src_port(src_port)
+            .set_dst_port(dst_port)
+            .set_len(0)
+            .set_type(VSOCK_TYPE_STREAM)
+            .set_flags(0)
+            .set_buf_alloc(0)
+            .set_fwd_cnt(0);
+    }
 }
 
 #[cfg(test)]

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -230,8 +230,8 @@ impl VsockConfig {
 /// the corresponding connection.
 #[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub(crate) struct ConnMapKey {
-    local_port: u32,
-    peer_port: u32,
+    pub(crate) local_port: u32,
+    pub(crate) peer_port: u32,
 }
 
 impl ConnMapKey {


### PR DESCRIPTION
### Summary of the PR

- adds `enq_rst` body and `build_rst_pkt`
- refactors `recv_pkt` to use them
- use it for TODOs where rst is the appropriate response

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
