### PR TITLE
vhost-device-vsock: use Reader/Writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,7 +2146,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2165,7 +2165,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2184,7 +2184,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2209,7 +2209,7 @@ dependencies = [
  "vhost",
  "vhost-user-backend",
  "virglrenderer",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2227,7 +2227,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2250,7 +2250,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2273,7 +2273,7 @@ dependencies = [
  "v4l2r 0.0.7 (git+https://github.com/Gnurou/v4l2r?rev=12afd03)",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-media",
  "virtio-media-ffmpeg-decoder",
  "virtio-queue",
@@ -2297,7 +2297,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2316,7 +2316,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2334,7 +2334,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2353,7 +2353,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2378,7 +2378,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2397,7 +2397,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2415,7 +2415,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2438,7 +2438,7 @@ dependencies = [
  "thiserror 2.0.18",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "virtio-vsock",
  "vm-memory",
@@ -2455,7 +2455,7 @@ dependencies = [
  "libc",
  "log",
  "vhost",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "virtio-queue",
  "vm-memory",
  "vmm-sys-util",
@@ -2488,6 +2488,11 @@ name = "virtio-bindings"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "git+https://github.com/luigix25/vm-virtio.git?branch=fix_vsock_next#7c4fdb31976110fe98af09601fa1687c6a58410e"
 
 [[package]]
 name = "virtio-media"
@@ -2523,12 +2528,11 @@ dependencies = [
 [[package]]
 name = "virtio-queue"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f631bfd09362a9b17f0cfd5ca3b0a1b179d153fa276f9ce86919d560891e61d6"
+source = "git+https://github.com/luigix25/vm-virtio.git?branch=fix_vsock_next#7c4fdb31976110fe98af09601fa1687c6a58410e"
 dependencies = [
  "libc",
  "log",
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (git+https://github.com/luigix25/vm-virtio.git?branch=fix_vsock_next)",
  "vm-memory",
  "vmm-sys-util",
 ]
@@ -2536,10 +2540,9 @@ dependencies = [
 [[package]]
 name = "virtio-vsock"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79123315dc0bad0a2923891c0cdf76269cc64f553548e7b090c2676776ea6baf"
+source = "git+https://github.com/luigix25/vm-virtio.git?branch=fix_vsock_next#7c4fdb31976110fe98af09601fa1687c6a58410e"
 dependencies = [
- "virtio-bindings",
+ "virtio-bindings 0.2.7 (git+https://github.com/luigix25/vm-virtio.git?branch=fix_vsock_next)",
  "virtio-queue",
  "vm-memory",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,7 @@ missing_safety_doc = "deny"
 undocumented_unsafe_blocks = "deny"
 option_if_let_else = "allow"
 cloned_ref_to_slice_refs = "allow"
+
+[patch.crates-io]
+virtio-vsock = { git = "https://github.com/luigix25/vm-virtio.git", branch = "fix_vsock_next" }
+virtio-queue = { git = "https://github.com/luigix25/vm-virtio.git", branch = "fix_vsock_next" }

--- a/vhost-device-vsock/src/main.rs
+++ b/vhost-device-vsock/src/main.rs
@@ -45,6 +45,9 @@ mod vhu_vsock;
 mod vhu_vsock_thread;
 mod vsock_conn;
 
+#[cfg(test)]
+mod test_utils;
+
 use std::{
     any::Any,
     collections::HashMap,

--- a/vhost-device-vsock/src/test_utils.rs
+++ b/vhost-device-vsock/src/test_utils.rs
@@ -42,10 +42,12 @@ pub(crate) fn prepare_desc_chain_vsock(
 ) -> (
     GuestMemoryAtomic<GuestMemoryMmap>,
     DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
+    GuestAddress,
 ) {
     let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
     let virt_queue = MockSplitQueue::new(&mem, 16);
     let mut next_addr = virt_queue.desc_table().total_size() + 0x100;
+    let buf_addr = GuestAddress(next_addr);
     let mut flags = 0;
 
     if write_only {
@@ -109,5 +111,6 @@ pub(crate) fn prepare_desc_chain_vsock(
             .unwrap()
             .next()
             .unwrap(),
+        buf_addr,
     )
 }

--- a/vhost-device-vsock/src/test_utils.rs
+++ b/vhost-device-vsock/src/test_utils.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
+
+use byteorder::{ByteOrder, LittleEndian};
+use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
+use virtio_queue::{
+    desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
+    mock::MockSplitQueue,
+    DescriptorChain, Queue, QueueOwnedT,
+};
+use virtio_vsock::packet::PKT_HEADER_SIZE;
+use vm_memory::{
+    Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard,
+    GuestMemoryMmap,
+};
+
+pub(crate) struct HeadParams {
+    head_len: usize,
+    data_len: u32,
+}
+
+impl HeadParams {
+    pub(crate) fn new(head_len: usize, data_len: u32) -> Self {
+        Self { head_len, data_len }
+    }
+
+    fn construct_head(&self) -> Vec<u8> {
+        let mut header = vec![0_u8; self.head_len];
+        if self.head_len == PKT_HEADER_SIZE {
+            // Offset into the header for data length
+            const HDROFF_LEN: usize = 24;
+            LittleEndian::write_u32(&mut header[HDROFF_LEN..], self.data_len);
+        }
+        header
+    }
+}
+
+pub(crate) fn prepare_desc_chain_vsock(
+    write_only: bool,
+    head_params: &HeadParams,
+    data_chain_len: u16,
+    head_data_len: u32,
+) -> (
+    GuestMemoryAtomic<GuestMemoryMmap>,
+    DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
+) {
+    let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
+    let virt_queue = MockSplitQueue::new(&mem, 16);
+    let mut next_addr = virt_queue.desc_table().total_size() + 0x100;
+    let mut flags = 0;
+
+    if write_only {
+        flags |= VRING_DESC_F_WRITE;
+    }
+
+    let mut head_flags = if data_chain_len > 0 {
+        flags | VRING_DESC_F_NEXT
+    } else {
+        flags
+    };
+
+    // vsock packet header
+    let header = head_params.construct_head();
+    let head_desc = RawDescriptor::from(SplitDescriptor::new(
+        next_addr,
+        head_params.head_len as u32,
+        head_flags as u16,
+        1,
+    ));
+    mem.write(&header, SplitDescriptor::from(head_desc).addr())
+        .unwrap();
+    virt_queue.desc_table().store(0, head_desc).unwrap();
+    next_addr += head_params.head_len as u64;
+
+    // Put the descriptor index 0 in the first available ring position.
+    mem.write_obj(0u16, virt_queue.avail_addr().unchecked_add(4))
+        .unwrap();
+
+    // Set `avail_idx` to 1.
+    mem.write_obj(1u16, virt_queue.avail_addr().unchecked_add(2))
+        .unwrap();
+
+    // chain len excludes the head
+    for i in 0..(data_chain_len) {
+        // last descr in chain
+        if i == data_chain_len - 1 {
+            head_flags &= !VRING_DESC_F_NEXT;
+        }
+        // vsock data
+        let data = vec![0_u8; head_data_len as usize];
+        let data_desc = RawDescriptor::from(SplitDescriptor::new(
+            next_addr,
+            data.len() as u32,
+            head_flags as u16,
+            i + 2,
+        ));
+        mem.write(&data, SplitDescriptor::from(data_desc).addr())
+            .unwrap();
+        virt_queue.desc_table().store(i + 1, data_desc).unwrap();
+        next_addr += u64::from(head_data_len);
+    }
+
+    // Create descriptor chain from pre-filled memory
+    (
+        GuestMemoryAtomic::new(mem.clone()),
+        virt_queue
+            .create_queue::<Queue>()
+            .unwrap()
+            .iter(GuestMemoryAtomic::new(mem.clone()).memory())
+            .unwrap()
+            .next()
+            .unwrap(),
+    )
+}

--- a/vhost-device-vsock/src/test_utils.rs
+++ b/vhost-device-vsock/src/test_utils.rs
@@ -13,32 +13,11 @@ use vm_memory::{
     GuestMemoryMmap,
 };
 
-pub(crate) struct HeadParams {
-    head_len: usize,
-    data_len: u32,
-}
-
-impl HeadParams {
-    pub(crate) fn new(head_len: usize, data_len: u32) -> Self {
-        Self { head_len, data_len }
-    }
-
-    fn construct_head(&self) -> Vec<u8> {
-        let mut header = vec![0_u8; self.head_len];
-        if self.head_len == PKT_HEADER_SIZE {
-            // Offset into the header for data length
-            const HDROFF_LEN: usize = 24;
-            LittleEndian::write_u32(&mut header[HDROFF_LEN..], self.data_len);
-        }
-        header
-    }
-}
-
 pub(crate) fn prepare_desc_chain_vsock(
     write_only: bool,
-    head_params: &HeadParams,
+    head_len: usize,
     data_chain_len: u16,
-    head_data_len: u32,
+    data: &[u8],
 ) -> (
     GuestMemoryAtomic<GuestMemoryMmap>,
     DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
@@ -61,17 +40,23 @@ pub(crate) fn prepare_desc_chain_vsock(
     };
 
     // vsock packet header
-    let header = head_params.construct_head();
+    let mut header = vec![0_u8; head_len];
+    if head_len == PKT_HEADER_SIZE {
+        // Offset into the header for data length
+        const HDROFF_LEN: usize = 24;
+        LittleEndian::write_u32(&mut header[HDROFF_LEN..], data.len() as u32);
+    }
+
     let head_desc = RawDescriptor::from(SplitDescriptor::new(
         next_addr,
-        head_params.head_len as u32,
+        head_len as u32,
         head_flags as u16,
         1,
     ));
     mem.write(&header, SplitDescriptor::from(head_desc).addr())
         .unwrap();
     virt_queue.desc_table().store(0, head_desc).unwrap();
-    next_addr += head_params.head_len as u64;
+    next_addr += head_len as u64;
 
     // Put the descriptor index 0 in the first available ring position.
     mem.write_obj(0u16, virt_queue.avail_addr().unchecked_add(4))
@@ -88,17 +73,16 @@ pub(crate) fn prepare_desc_chain_vsock(
             head_flags &= !VRING_DESC_F_NEXT;
         }
         // vsock data
-        let data = vec![0_u8; head_data_len as usize];
         let data_desc = RawDescriptor::from(SplitDescriptor::new(
             next_addr,
             data.len() as u32,
             head_flags as u16,
             i + 2,
         ));
-        mem.write(&data, SplitDescriptor::from(data_desc).addr())
+        mem.write(data, SplitDescriptor::from(data_desc).addr())
             .unwrap();
         virt_queue.desc_table().store(i + 1, data_desc).unwrap();
-        next_addr += u64::from(head_data_len);
+        next_addr += data.len() as u64;
     }
 
     // Create descriptor chain from pre-filled memory

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -16,10 +16,7 @@ use log::{info, warn};
 use virtio_queue::Writer;
 use virtio_vsock::packet_rw::{VsockPacketRx, VsockPacketTx};
 use virtio_vsock::{PacketHeader, PKT_HEADER_SIZE};
-use vm_memory::{
-    bitmap::BitmapSlice, ByteValued, ReadVolatile, VolatileMemoryError, VolatileSlice,
-    WriteVolatile,
-};
+use vm_memory::{bitmap::BitmapSlice, ByteValued};
 #[cfg(feature = "backend_vsock")]
 use vsock::VsockStream;
 
@@ -150,72 +147,6 @@ impl VsockStreamIo for StreamType {
             Err(std::io::Error::last_os_error())
         } else {
             Ok(bytes_written.try_into().unwrap())
-        }
-    }
-}
-
-impl ReadVolatile for StreamType {
-    fn read_volatile<B: BitmapSlice>(
-        &mut self,
-        buf: &mut VolatileSlice<'_, B>,
-    ) -> StdResult<usize, VolatileMemoryError> {
-        match self {
-            StreamType::Unix(stream) => stream.read_volatile(buf),
-            // Copied from vm_memory crate's ReadVolatile implementation for UnixStream
-            #[cfg(feature = "backend_vsock")]
-            StreamType::Vsock(stream) => {
-                let fd = stream.as_raw_fd();
-                let guard = buf.ptr_guard_mut();
-
-                let dst = guard.as_ptr().cast::<libc::c_void>();
-
-                // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to
-                // by `dst` is valid for writes of length `buf.len() by the
-                // invariants upheld by the constructor of `VolatileSlice`.
-                let bytes_read = unsafe { libc::read(fd, dst, buf.len()) };
-
-                if bytes_read < 0 {
-                    // We don't know if a partial read might have happened, so mark everything as
-                    // dirty
-                    buf.bitmap().mark_dirty(0, buf.len());
-
-                    Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
-                } else {
-                    let bytes_read = bytes_read.try_into().unwrap();
-                    buf.bitmap().mark_dirty(0, bytes_read);
-                    Ok(bytes_read)
-                }
-            }
-        }
-    }
-}
-
-impl WriteVolatile for StreamType {
-    fn write_volatile<B: BitmapSlice>(
-        &mut self,
-        buf: &VolatileSlice<'_, B>,
-    ) -> StdResult<usize, VolatileMemoryError> {
-        match self {
-            StreamType::Unix(stream) => stream.write_volatile(buf),
-            // Copied from vm_memory crate's WriteVolatile implementation for UnixStream
-            #[cfg(feature = "backend_vsock")]
-            StreamType::Vsock(stream) => {
-                let fd = stream.as_raw_fd();
-                let guard = buf.ptr_guard();
-
-                let src = guard.as_ptr().cast::<libc::c_void>();
-
-                // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to
-                // by `src` is valid for reads of length `buf.len() by the
-                // invariants upheld by the constructor of `VolatileSlice`.
-                let bytes_written = unsafe { libc::write(fd, src, buf.len()) };
-
-                if bytes_written < 0 {
-                    Err(VolatileMemoryError::IOError(std::io::Error::last_os_error()))
-                } else {
-                    Ok(bytes_written.try_into().unwrap())
-                }
-            }
         }
     }
 }

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -13,9 +13,12 @@ use std::{
 };
 
 use log::{info, warn};
-use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
+use virtio_queue::Writer;
+use virtio_vsock::packet_rw::{VsockPacketRx, VsockPacketTx};
+use virtio_vsock::{PacketHeader, PKT_HEADER_SIZE};
 use vm_memory::{
-    bitmap::BitmapSlice, ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile,
+    bitmap::BitmapSlice, ByteValued, ReadVolatile, VolatileMemoryError, VolatileSlice,
+    WriteVolatile,
 };
 #[cfg(feature = "backend_vsock")]
 use vsock::VsockStream;
@@ -38,17 +41,19 @@ pub(crate) struct RawVsockPacket {
 }
 
 impl RawVsockPacket {
-    fn from_vsock_packet<B: BitmapSlice>(pkt: &VsockPacket<B>) -> Result<Self> {
+    fn from_vsock_packet<B: BitmapSlice>(pkt: &VsockPacketTx<B>) -> Result<Self> {
         let mut raw_pkt = Self {
             header: [0; PKT_HEADER_SIZE],
-            data: vec![0; pkt.len() as usize],
+            data: vec![0; pkt.header().len() as usize],
         };
 
-        pkt.header_slice().copy_to(&mut raw_pkt.header);
-        if !pkt.is_empty() {
-            pkt.data_slice()
-                .ok_or(Error::PktBufMissing)?
-                .copy_to(raw_pkt.data.as_mut());
+        raw_pkt.header.copy_from_slice(pkt.header().as_slice());
+        if !pkt.header().is_empty() {
+            let mut pkt = pkt.clone();
+            let reader = pkt.data_slice_mut().ok_or(Error::PktBufMissing)?;
+            reader
+                .read_exact(&mut raw_pkt.data)
+                .map_err(|_| Error::GuestMemoryRead)?;
         }
 
         Ok(raw_pkt)
@@ -111,6 +116,40 @@ impl AsRawFd for StreamType {
             StreamType::Unix(stream) => stream.as_raw_fd(),
             #[cfg(feature = "backend_vsock")]
             StreamType::Vsock(stream) => stream.as_raw_fd(),
+        }
+    }
+}
+
+pub trait VsockStreamIo {
+    fn stream_read<B: BitmapSlice>(&mut self, buf: &mut Writer<B>) -> Result<usize>;
+    fn stream_write(&mut self, buf: &[u8]) -> StdResult<usize, std::io::Error>;
+}
+
+impl VsockStreamIo for StreamType {
+    /// Read from the stream into the guest buffer (H -> G)
+    fn stream_read<B: BitmapSlice>(&mut self, writer: &mut Writer<B>) -> Result<usize> {
+        //TODO: no zeropy is possible.
+        let mut tmp_data = vec![0u8; writer.available_bytes()];
+        let bytes_read = self.read(&mut tmp_data).map_err(Error::StreamRead)?;
+        writer
+            .write(&tmp_data[..bytes_read])
+            .map_err(|_| Error::GuestMemoryWrite)
+    }
+
+    /// Write from the guest buffer to the stream (G -> H)
+    fn stream_write(&mut self, buf: &[u8]) -> StdResult<usize, std::io::Error> {
+        let src = buf.as_ptr().cast::<libc::c_void>();
+        let fd = self.as_raw_fd();
+
+        // SAFETY: We got a valid file descriptor from `AsRawFd`. The memory pointed to
+        // by `src` is valid for reads of length `buf.len()` as it comes from a
+        // valid `&[u8]` slice.
+        let bytes_written = unsafe { libc::write(fd, src, buf.len()) };
+
+        if bytes_written < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(bytes_written.try_into().unwrap())
         }
     }
 }
@@ -263,7 +302,7 @@ impl VsockThreadBackend {
     /// Returns:
     /// - `Ok(())` if the packet was successfully filled in
     /// - `Err(Error::EmptyBackendRxQ) if there was no available data
-    pub fn recv_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacket<B>) -> Result<()> {
+    pub fn recv_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacketRx<B>) -> Result<()> {
         // Pop an event from the backend_rxq
         let key = self.backend_rxq.pop_front().ok_or(Error::EmptyBackendRxQ)?;
         let conn = match self.conn_map.get_mut(&key) {
@@ -273,6 +312,8 @@ impl VsockThreadBackend {
                 return Ok(());
             }
         };
+
+        let mut vsock_header = PacketHeader::default();
 
         if conn.rx_queue.peek() == Some(RxOps::Reset) {
             // Handle RST events here
@@ -290,7 +331,8 @@ impl VsockThreadBackend {
                 });
 
             // Initialize the packet header to contain a VSOCK_OP_RST operation
-            pkt.set_op(VSOCK_OP_RST)
+            vsock_header
+                .set_op(VSOCK_OP_RST)
                 .set_src_cid(VSOCK_HOST_CID)
                 .set_dst_cid(conn.guest_cid)
                 .set_src_port(conn.local_port)
@@ -301,11 +343,19 @@ impl VsockThreadBackend {
                 .set_buf_alloc(0)
                 .set_fwd_cnt(0);
 
+            pkt.header_slice()
+                .write_obj(vsock_header)
+                .map_err(|_| Error::GuestMemoryWrite)?;
+
             return Ok(());
         }
 
         // Handle other packet types per connection
-        conn.recv_pkt(pkt)?;
+        conn.recv_pkt(&mut vsock_header, pkt)?;
+
+        pkt.header_slice()
+            .write_obj(vsock_header)
+            .map_err(|_| Error::GuestMemoryWrite)?;
 
         Ok(())
     }
@@ -317,18 +367,18 @@ impl VsockThreadBackend {
     ///
     /// Returns:
     /// - always `Ok(())` if packet has been consumed correctly
-    pub fn send_pkt<B: BitmapSlice>(&mut self, pkt: &VsockPacket<B>) -> Result<()> {
-        if pkt.src_cid() != self.guest_cid {
+    pub fn send_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacketTx<B>) -> Result<()> {
+        if pkt.header().src_cid() != self.guest_cid {
             warn!(
                 "vsock: dropping packet with inconsistent src_cid: {:?} from guest configured with CID: {:?}",
-                pkt.src_cid(), self.guest_cid
+                pkt.header().src_cid(), self.guest_cid
             );
             return Ok(());
         }
 
         #[allow(irrefutable_let_patterns)]
         if let BackendType::UnixDomainSocket(_) = &self.backend_info {
-            let dst_cid = pkt.dst_cid();
+            let dst_cid = pkt.header().dst_cid();
             if dst_cid != VSOCK_HOST_CID {
                 let cid_map = self.cid_map.read().unwrap();
                 if cid_map.contains_key(&dst_cid) {
@@ -359,18 +409,18 @@ impl VsockThreadBackend {
         }
 
         // TODO: Rst if packet has unsupported type
-        if pkt.type_() != VSOCK_TYPE_STREAM {
+        if pkt.header().type_() != VSOCK_TYPE_STREAM {
             info!("vsock: dropping packet of unknown type");
             return Ok(());
         }
 
-        let key = ConnMapKey::new(pkt.dst_port(), pkt.src_port());
+        let key = ConnMapKey::new(pkt.header().dst_port(), pkt.header().src_port());
 
         // TODO: Handle cases where connection does not exist and packet op
         // is not VSOCK_OP_REQUEST
         if !self.conn_map.contains_key(&key) {
             // The packet contains a new connection request
-            if pkt.op() == VSOCK_OP_REQUEST {
+            if pkt.header().op() == VSOCK_OP_REQUEST {
                 self.handle_new_guest_conn(pkt);
             } else {
                 // TODO: send back RST
@@ -378,7 +428,7 @@ impl VsockThreadBackend {
             return Ok(());
         }
 
-        if pkt.op() == VSOCK_OP_RST {
+        if pkt.header().op() == VSOCK_OP_RST {
             // Handle an RST packet from the guest here
             let conn = self.conn_map.get(&key).unwrap();
             if conn.rx_queue.contains(RxOps::Reset.bitmask()) {
@@ -417,7 +467,7 @@ impl VsockThreadBackend {
     /// Returns:
     /// - `Ok(())` if packet was successfully filled in
     /// - `Err(Error::EmptyRawPktsQueue)` if there was no available data
-    pub fn recv_raw_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacket<B>) -> Result<()> {
+    pub fn recv_raw_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacketRx<B>) -> Result<()> {
         let raw_vsock_pkt = self
             .raw_pkts_queue
             .write()
@@ -425,10 +475,14 @@ impl VsockThreadBackend {
             .pop_front()
             .ok_or(Error::EmptyRawPktsQueue)?;
 
-        pkt.set_header_from_raw(&raw_vsock_pkt.header).unwrap();
+        pkt.header_slice()
+            .write_all(&raw_vsock_pkt.header)
+            .map_err(|_| Error::GuestMemoryWrite)?;
+
         if !raw_vsock_pkt.data.is_empty() {
-            let buf = pkt.data_slice().ok_or(Error::PktBufMissing)?;
-            buf.copy_from(&raw_vsock_pkt.data);
+            pkt.data_slice()
+                .write_all(&raw_vsock_pkt.data)
+                .map_err(|_| Error::GuestMemoryWrite)?;
         }
 
         Ok(())
@@ -444,10 +498,10 @@ impl VsockThreadBackend {
     ///
     /// In case of proxying using vosck, attempts to connect to the
     /// {forward_cid, local_port}
-    fn handle_new_guest_conn<B: BitmapSlice>(&mut self, pkt: &VsockPacket<B>) {
+    fn handle_new_guest_conn<B: BitmapSlice>(&mut self, pkt: &VsockPacketTx<B>) {
         match &self.backend_info {
             BackendType::UnixDomainSocket(uds_path) => {
-                let port_path = format!("{}_{}", uds_path.display(), pkt.dst_port());
+                let port_path = format!("{}_{}", uds_path.display(), pkt.header().dst_port());
                 UnixStream::connect(port_path)
                     .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
                     .map_err(Error::UnixConnect)
@@ -456,7 +510,7 @@ impl VsockThreadBackend {
             }
             #[cfg(feature = "backend_vsock")]
             BackendType::Vsock(vsock_info) => {
-                VsockStream::connect_with_cid_port(vsock_info.forward_cid, pkt.dst_port())
+                VsockStream::connect_with_cid_port(vsock_info.forward_cid, pkt.header().dst_port())
                     .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
                     .map_err(Error::VsockConnect)
                     .and_then(|stream| self.add_new_guest_conn(StreamType::Vsock(stream), pkt))
@@ -469,7 +523,7 @@ impl VsockThreadBackend {
     fn add_new_guest_conn<B: BitmapSlice>(
         &mut self,
         stream: StreamType,
-        pkt: &VsockPacket<B>,
+        pkt: &VsockPacketTx<B>,
     ) -> Result<()> {
         let conn = VsockConnection::new_peer_init(
             stream.try_clone().map_err(match stream {
@@ -477,25 +531,31 @@ impl VsockThreadBackend {
                 #[cfg(feature = "backend_vsock")]
                 StreamType::Vsock(_) => Error::VsockConnect,
             })?,
-            pkt.dst_cid(),
-            pkt.dst_port(),
-            pkt.src_cid(),
-            pkt.src_port(),
+            pkt.header().dst_cid(),
+            pkt.header().dst_port(),
+            pkt.header().src_cid(),
+            pkt.header().src_port(),
             self.epoll_fd,
-            pkt.buf_alloc(),
+            pkt.header().buf_alloc(),
             self.tx_buffer_size,
         );
         let stream_fd = conn.stream.as_raw_fd();
-        self.listener_map
-            .insert(stream_fd, ConnMapKey::new(pkt.dst_port(), pkt.src_port()));
+        self.listener_map.insert(
+            stream_fd,
+            ConnMapKey::new(pkt.header().dst_port(), pkt.header().src_port()),
+        );
 
-        self.conn_map
-            .insert(ConnMapKey::new(pkt.dst_port(), pkt.src_port()), conn);
-        self.backend_rxq
-            .push_back(ConnMapKey::new(pkt.dst_port(), pkt.src_port()));
+        self.conn_map.insert(
+            ConnMapKey::new(pkt.header().dst_port(), pkt.header().src_port()),
+            conn,
+        );
+        self.backend_rxq.push_back(ConnMapKey::new(
+            pkt.header().dst_port(),
+            pkt.header().src_port(),
+        ));
 
         self.stream_map.insert(stream_fd, stream);
-        self.local_port_set.insert(pkt.dst_port());
+        self.local_port_set.insert(pkt.header().dst_port());
 
         VhostUserVsockThread::epoll_register(
             self.epoll_fd,
@@ -517,7 +577,9 @@ mod tests {
     use std::os::unix::net::UnixListener;
 
     use tempfile::tempdir;
-    use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
+    use virtio_vsock::packet_rw::{VsockPacketRx, VsockPacketTx};
+    use virtio_vsock::PKT_HEADER_SIZE;
+    use vm_memory::{Address, Bytes, GuestAddressSpace};
     #[cfg(feature = "backend_vsock")]
     use vsock::{VsockListener, VMADDR_CID_ANY, VMADDR_CID_LOCAL};
 
@@ -526,10 +588,9 @@ mod tests {
     use crate::vhu_vsock::VsockProxyInfo;
     use crate::{
         test_utils::prepare_desc_chain_vsock,
-        vhu_vsock::{BackendType, VSOCK_OP_RW},
+        vhu_vsock::{BackendType, VhostUserVsockBackend, VsockConfig, VSOCK_OP_RW},
     };
 
-    const DATA_LEN: usize = 16;
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
     const QUEUE_SIZE: usize = 1024;
     const GROUP_NAME: &str = "default";
@@ -555,37 +616,46 @@ mod tests {
 
         assert!(!vtp.pending_rx());
 
-        let mut pkt_raw = [0u8; PKT_HEADER_SIZE + DATA_LEN];
-        let (hdr_raw, data_raw) = pkt_raw.split_at_mut(PKT_HEADER_SIZE);
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 1, b"hello");
+        let mem = mem.memory();
+        let mut packet =
+            VsockPacketTx::from_tx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
 
-        // SAFETY: Safe as hdr_raw and data_raw are guaranteed to be valid.
-        let mut packet = unsafe { VsockPacket::new(hdr_raw, Some(data_raw)).unwrap() };
+        let (mem_rx, descr_chain_rx, _) =
+            prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem_rx = mem_rx.memory();
+
+        let mut packet_rx =
+            VsockPacketRx::from_rx_virtq_chain(mem_rx.deref(), descr_chain_rx, CONN_TX_BUF_SIZE)
+                .unwrap();
 
         assert_eq!(
-            vtp.recv_pkt(&mut packet).unwrap_err().to_string(),
+            vtp.recv_pkt(&mut packet_rx).unwrap_err().to_string(),
             Error::EmptyBackendRxQ.to_string()
         );
 
-        vtp.send_pkt(&packet).unwrap();
+        vtp.send_pkt(&mut packet).unwrap();
 
-        packet.set_type(VSOCK_TYPE_STREAM);
-        vtp.send_pkt(&packet).unwrap();
+        packet.header_mut().set_type(VSOCK_TYPE_STREAM);
+        vtp.send_pkt(&mut packet).unwrap();
 
-        packet.set_src_cid(CID);
-        packet.set_dst_cid(VSOCK_HOST_CID);
-        packet.set_dst_port(VSOCK_PEER_PORT);
-        vtp.send_pkt(&packet).unwrap();
+        packet.header_mut().set_src_cid(CID);
+        packet.header_mut().set_dst_cid(VSOCK_HOST_CID);
+        packet.header_mut().set_dst_port(VSOCK_PEER_PORT);
+        vtp.send_pkt(&mut packet).unwrap();
 
-        packet.set_op(VSOCK_OP_REQUEST);
-        vtp.send_pkt(&packet).unwrap();
+        packet.header_mut().set_op(VSOCK_OP_REQUEST);
+        vtp.send_pkt(&mut packet).unwrap();
 
-        packet.set_op(VSOCK_OP_RW);
-        vtp.send_pkt(&packet).unwrap();
+        packet.header_mut().set_op(VSOCK_OP_RW);
+        vtp.send_pkt(&mut packet).unwrap();
 
-        packet.set_op(VSOCK_OP_RST);
-        vtp.send_pkt(&packet).unwrap();
+        packet.header_mut().set_op(VSOCK_OP_RST);
+        vtp.send_pkt(&mut packet).unwrap();
 
-        vtp.recv_pkt(&mut packet).unwrap();
+        // Connection was removed by RST above, but its key is still in backend_rxq.
+        // recv_pkt must handle the "connection gone" case gracefully.
+        vtp.recv_pkt(&mut packet_rx).unwrap();
 
         // TODO: it is a nop for now
         vtp.enq_rst();
@@ -632,6 +702,7 @@ mod tests {
         const SIBLING_CID: u64 = 4;
         const SIBLING2_CID: u64 = 5;
         const SIBLING_LISTENING_PORT: u32 = 1234;
+        const DATA: &[u8] = b"hello";
 
         let test_dir = tempdir().expect("Could not create a temp test directory.");
 
@@ -695,69 +766,131 @@ mod tests {
 
         assert!(!vtp.pending_raw_pkts());
 
-        let mut pkt_raw = [0u8; PKT_HEADER_SIZE + DATA_LEN];
-        let (hdr_raw, data_raw) = pkt_raw.split_at_mut(PKT_HEADER_SIZE);
+        // Build a TX descriptor chain: header (len field = DATA.len()) + data buffer = DATA.
+        let (mem_tx, descr_chain_tx, _) = prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 1, DATA);
+        let mem_tx = mem_tx.memory();
+        let mut pkt_tx =
+            VsockPacketTx::from_tx_virtq_chain(mem_tx.deref(), descr_chain_tx, CONN_TX_BUF_SIZE)
+                .unwrap();
 
-        // SAFETY: Safe as hdr_raw and data_raw are guaranteed to be valid.
-        let mut packet = unsafe { VsockPacket::new(hdr_raw, Some(data_raw)).unwrap() };
+        // Set header fields for an RW packet destined for the sibling VM.
+        pkt_tx.header_mut().set_type(VSOCK_TYPE_STREAM);
+        pkt_tx.header_mut().set_src_cid(CID);
+        pkt_tx.header_mut().set_dst_cid(SIBLING_CID);
+        pkt_tx.header_mut().set_dst_port(SIBLING_LISTENING_PORT);
+        pkt_tx.header_mut().set_op(VSOCK_OP_RW);
 
+        // Verify empty-queue error before any packet is queued.
+        let (mem_rx, descr_chain_rx, hdr_addr) =
+            prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; DATA.len()]);
+        let mem_rx = mem_rx.memory();
+        let mut pkt_rx =
+            VsockPacketRx::from_rx_virtq_chain(mem_rx.deref(), descr_chain_rx, CONN_TX_BUF_SIZE)
+                .unwrap();
         assert_eq!(
-            vtp.recv_raw_pkt(&mut packet).unwrap_err().to_string(),
+            sibling_backend.threads[0]
+                .lock()
+                .unwrap()
+                .thread_backend
+                .recv_raw_pkt(&mut pkt_rx)
+                .unwrap_err()
+                .to_string(),
             Error::EmptyRawPktsQueue.to_string()
         );
 
-        packet.set_type(VSOCK_TYPE_STREAM);
-        packet.set_src_cid(CID);
-        packet.set_dst_cid(SIBLING_CID);
-        packet.set_dst_port(SIBLING_LISTENING_PORT);
-        packet.set_op(VSOCK_OP_RW);
-        packet.set_len(DATA_LEN as u32);
-        packet
-            .data_slice()
-            .unwrap()
-            .copy_from(&[0xCAu8, 0xFEu8, 0xBAu8, 0xBEu8]);
-
-        vtp.send_pkt(&packet).unwrap();
+        vtp.send_pkt(&mut pkt_tx).unwrap();
         assert!(sibling_backend.threads[0]
             .lock()
             .unwrap()
             .thread_backend
             .pending_raw_pkts());
 
-        packet.set_dst_cid(SIBLING2_CID);
-        vtp.send_pkt(&packet).unwrap();
-        // packet should be discarded since sibling2 is not in the same group
+        // Packet to sibling2 is dropped: vtp has group3, sibling2 only has group1 — disjoint.
+        pkt_tx.header_mut().set_dst_cid(SIBLING2_CID);
+        vtp.send_pkt(&mut pkt_tx).unwrap();
         assert!(!sibling2_backend.threads[0]
             .lock()
             .unwrap()
             .thread_backend
             .pending_raw_pkts());
 
-        let mut recvd_pkt_raw = [0u8; PKT_HEADER_SIZE + DATA_LEN];
-        let (recvd_hdr_raw, recvd_data_raw) = recvd_pkt_raw.split_at_mut(PKT_HEADER_SIZE);
-
-        let mut recvd_packet =
-            // SAFETY: Safe as recvd_hdr_raw and recvd_data_raw are guaranteed to be valid.
-            unsafe { VsockPacket::new(recvd_hdr_raw, Some(recvd_data_raw)).unwrap() };
+        // Deliver the queued packet to the sibling and verify header + payload.
+        let data_addr = hdr_addr.unchecked_add(PKT_HEADER_SIZE as u64);
 
         sibling_backend.threads[0]
             .lock()
             .unwrap()
             .thread_backend
-            .recv_raw_pkt(&mut recvd_packet)
+            .recv_raw_pkt(&mut pkt_rx)
             .unwrap();
 
-        assert_eq!(recvd_packet.type_(), VSOCK_TYPE_STREAM);
-        assert_eq!(recvd_packet.src_cid(), CID);
-        assert_eq!(recvd_packet.dst_cid(), SIBLING_CID);
-        assert_eq!(recvd_packet.dst_port(), SIBLING_LISTENING_PORT);
-        assert_eq!(recvd_packet.op(), VSOCK_OP_RW);
-        assert_eq!(recvd_packet.len(), DATA_LEN as u32);
+        let recvd_header = mem_rx.read_obj::<PacketHeader>(hdr_addr).unwrap();
+        assert_eq!(recvd_header.type_(), VSOCK_TYPE_STREAM);
+        assert_eq!(recvd_header.src_cid(), CID);
+        assert_eq!(recvd_header.dst_cid(), SIBLING_CID);
+        assert_eq!(recvd_header.dst_port(), SIBLING_LISTENING_PORT);
+        assert_eq!(recvd_header.op(), VSOCK_OP_RW);
+        assert_eq!(recvd_header.len(), DATA.len() as u32);
 
-        assert_eq!(recvd_data_raw[0], 0xCAu8);
-        assert_eq!(recvd_data_raw[1], 0xFEu8);
-        assert_eq!(recvd_data_raw[2], 0xBAu8);
-        assert_eq!(recvd_data_raw[3], 0xBEu8);
+        let mut recvd_data = [0u8; DATA.len()];
+        mem_rx.read(&mut recvd_data, data_addr).unwrap();
+        assert_eq!(&recvd_data, DATA);
+
+        assert!(!sibling_backend.threads[0]
+            .lock()
+            .unwrap()
+            .thread_backend
+            .pending_raw_pkts());
+
+        // Zero-data control packet (VSOCK_OP_REQUEST, len=0): exercises the
+        // `pkt.header().is_empty()` branch in from_vsock_packet and the
+        // `raw_vsock_pkt.data.is_empty()` branch in recv_raw_pkt.
+        let (mem_tx2, descr_chain_tx2, _) =
+            prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 0, b"");
+        let mem_tx2 = mem_tx2.memory();
+        let mut pkt_ctrl =
+            VsockPacketTx::from_tx_virtq_chain(mem_tx2.deref(), descr_chain_tx2, CONN_TX_BUF_SIZE)
+                .unwrap();
+        pkt_ctrl.header_mut().set_type(VSOCK_TYPE_STREAM);
+        pkt_ctrl.header_mut().set_src_cid(CID);
+        pkt_ctrl.header_mut().set_dst_cid(SIBLING_CID);
+        pkt_ctrl.header_mut().set_op(VSOCK_OP_REQUEST);
+
+        vtp.send_pkt(&mut pkt_ctrl).unwrap();
+        assert!(sibling_backend.threads[0]
+            .lock()
+            .unwrap()
+            .thread_backend
+            .pending_raw_pkts());
+
+        // RX chain still needs a data buffer (from_rx_virtq_chain requires it),
+        // but recv_raw_pkt will not write to it for a zero-len packet.
+        let (mem_rx2, descr_chain_rx2, hdr_addr2) =
+            prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 1]);
+        let mem_rx2 = mem_rx2.memory();
+        let mut pkt_rx2 =
+            VsockPacketRx::from_rx_virtq_chain(mem_rx2.deref(), descr_chain_rx2, CONN_TX_BUF_SIZE)
+                .unwrap();
+
+        sibling_backend.threads[0]
+            .lock()
+            .unwrap()
+            .thread_backend
+            .recv_raw_pkt(&mut pkt_rx2)
+            .unwrap();
+
+        let ctrl_header = mem_rx2.read_obj::<PacketHeader>(hdr_addr2).unwrap();
+        assert_eq!(ctrl_header.type_(), VSOCK_TYPE_STREAM);
+        assert_eq!(ctrl_header.src_cid(), CID);
+        assert_eq!(ctrl_header.dst_cid(), SIBLING_CID);
+        assert_eq!(ctrl_header.op(), VSOCK_OP_REQUEST);
+        assert_eq!(ctrl_header.len(), 0);
+
+        assert!(!sibling_backend.threads[0]
+            .lock()
+            .unwrap()
+            .thread_backend
+            .pending_raw_pkts());
 
         test_dir.close().unwrap();
     }

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -524,7 +524,10 @@ mod tests {
     use super::*;
     #[cfg(feature = "backend_vsock")]
     use crate::vhu_vsock::VsockProxyInfo;
-    use crate::vhu_vsock::{BackendType, VhostUserVsockBackend, VsockConfig, VSOCK_OP_RW};
+    use crate::{
+        test_utils::prepare_desc_chain_vsock,
+        vhu_vsock::{BackendType, VSOCK_OP_RW},
+    };
 
     const DATA_LEN: usize = 16;
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;

--- a/vhost-device-vsock/src/txbuf.rs
+++ b/vhost-device-vsock/src/txbuf.rs
@@ -36,6 +36,31 @@ impl LocalTxBuf {
         self.len() == 0
     }
 
+    /// Add new data from a byte slice to the tx buffer, push all or none.
+    /// Returns LocalTxBufFull error if space not sufficient.
+    pub fn push_bytes(&mut self, data: &[u8]) -> Result<()> {
+        if self.get_buf_size() as usize - self.len() < data.len() {
+            // Tx buffer is full
+            return Err(Error::LocalTxBufFull);
+        }
+
+        // Get index into buffer at which data can be inserted
+        let tail_idx = self.tail.0 as usize % self.get_buf_size() as usize;
+
+        // Check if we can fit the data buffer between head and end of buffer
+        let len = std::cmp::min(self.get_buf_size() as usize - tail_idx, data.len());
+        self.buf[tail_idx..tail_idx + len].copy_from_slice(&data[..len]);
+
+        // Check if there is more data to be wrapped around
+        if len < data.len() {
+            self.buf[..(data.len() - len)].copy_from_slice(&data[len..]);
+        }
+
+        // Increment tail by the amount of data that has been added to the buffer
+        self.tail += Wrapping(data.len() as u32);
+        Ok(())
+    }
+
     /// Add new data to the tx buffer, push all or none.
     /// Returns LocalTxBufFull error if space not sufficient.
     pub fn push<B: BitmapSlice>(&mut self, data_buf: &VolatileSlice<B>) -> Result<()> {

--- a/vhost-device-vsock/src/txbuf.rs
+++ b/vhost-device-vsock/src/txbuf.rs
@@ -2,8 +2,6 @@
 
 use std::{io::Write, num::Wrapping};
 
-use vm_memory::{bitmap::BitmapSlice, Bytes, VolatileSlice};
-
 use crate::vhu_vsock::{Error, Result};
 
 #[derive(Debug)]
@@ -58,36 +56,6 @@ impl LocalTxBuf {
 
         // Increment tail by the amount of data that has been added to the buffer
         self.tail += Wrapping(data.len() as u32);
-        Ok(())
-    }
-
-    /// Add new data to the tx buffer, push all or none.
-    /// Returns LocalTxBufFull error if space not sufficient.
-    pub fn push<B: BitmapSlice>(&mut self, data_buf: &VolatileSlice<B>) -> Result<()> {
-        if self.get_buf_size() as usize - self.len() < data_buf.len() {
-            // Tx buffer is full
-            return Err(Error::LocalTxBufFull);
-        }
-
-        // Get index into buffer at which data can be inserted
-        let tail_idx = self.tail.0 as usize % self.get_buf_size() as usize;
-
-        // Check if we can fit the data buffer between head and end of buffer
-        let len = std::cmp::min(self.get_buf_size() as usize - tail_idx, data_buf.len());
-        let txbuf = &mut self.buf[tail_idx..tail_idx + len];
-        data_buf.copy_to(txbuf);
-
-        // Check if there is more data to be wrapped around
-        if len < data_buf.len() {
-            let remain_txbuf = &mut self.buf[..(data_buf.len() - len)];
-            data_buf
-                .read_slice(remain_txbuf, len)
-                .expect("shouldn't fail because remain_txbuf's len is data_buf.len() - len");
-        }
-
-        // Increment tail by the amount of data that has been added to the buffer
-        self.tail += Wrapping(data_buf.len() as u32);
-
         Ok(())
     }
 
@@ -166,33 +134,29 @@ mod tests {
     #[test]
     fn test_txbuf_push() {
         let mut loc_tx_buf = LocalTxBuf::new(CONN_TX_BUF_SIZE);
-        let mut buf = [0; CONN_TX_BUF_SIZE as usize];
-        // SAFETY: Safe as the buffer is guaranteed to be valid here.
-        let data = unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len()) };
+        let buf = [0; CONN_TX_BUF_SIZE as usize];
 
         // push data into empty tx buffer
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         res_push.unwrap();
         assert_eq!(loc_tx_buf.head, Wrapping(0));
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE));
 
         // push data into full tx buffer
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         assert!(res_push.is_err());
 
         // head and tail wrap at full
         loc_tx_buf.head = Wrapping(CONN_TX_BUF_SIZE);
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         res_push.unwrap();
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE * 2));
 
         // only tail wraps at full
-        let mut buf = vec![1, 1, 3, 3];
-        // SAFETY: Safe as the buffer is guaranteed to be valid here.
-        let data = unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len()) };
+        let buf = vec![1, 1, 3, 3];
         loc_tx_buf.head = Wrapping(2);
         loc_tx_buf.tail = Wrapping(CONN_TX_BUF_SIZE - 2);
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         res_push.unwrap();
         assert_eq!(loc_tx_buf.head, Wrapping(2));
         assert_eq!(loc_tx_buf.tail, Wrapping(CONN_TX_BUF_SIZE + 2));
@@ -208,12 +172,10 @@ mod tests {
         let mut loc_tx_buf = LocalTxBuf::new(CONN_TX_BUF_SIZE);
 
         // data to be flushed
-        let mut buf = vec![1; CONN_TX_BUF_SIZE as usize];
-        // SAFETY: Safe as the buffer is guaranteed to be valid here.
-        let data = unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len()) };
+        let buf = vec![1; CONN_TX_BUF_SIZE as usize];
 
         // target to which data is flushed
-        let mut cmp_vec = Vec::with_capacity(data.len());
+        let mut cmp_vec = Vec::with_capacity(buf.len());
 
         // flush no data
         let res_flush = loc_tx_buf.flush_to(&mut cmp_vec);
@@ -221,7 +183,7 @@ mod tests {
         assert_eq!(res_flush.unwrap(), 0);
 
         // flush data of CONN_TX_BUF_SIZE amount
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         res_push.unwrap();
         let res_flush = loc_tx_buf.flush_to(&mut cmp_vec);
         if let Ok(n) = res_flush {
@@ -234,12 +196,10 @@ mod tests {
         // wrapping head flush
         let mut buf = vec![0; (CONN_TX_BUF_SIZE / 2) as usize];
         buf.append(&mut vec![1; (CONN_TX_BUF_SIZE / 2) as usize]);
-        // SAFETY: Safe as the buffer is guaranteed to be valid here.
-        let data = unsafe { VolatileSlice::new(buf.as_mut_ptr(), buf.len()) };
 
         loc_tx_buf.head = Wrapping(0);
         loc_tx_buf.tail = Wrapping(0);
-        let res_push = loc_tx_buf.push(&data);
+        let res_push = loc_tx_buf.push_bytes(&buf);
         res_push.unwrap();
         cmp_vec.clear();
         loc_tx_buf.head = Wrapping(CONN_TX_BUF_SIZE / 2);

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -94,8 +94,8 @@ pub(crate) enum Error {
     EpollAdd(std::io::Error),
     #[error("Failed to modify evset associated with epoll")]
     EpollModify(std::io::Error),
-    #[error("Failed to read from unix stream")]
-    UnixRead(std::io::Error),
+    #[error("Failed to read from stream")]
+    StreamRead(std::io::Error),
     #[error("Failed to convert byte array to string")]
     ConvertFromUtf8(std::str::Utf8Error),
     #[error("Invalid vsock connection request from host")]
@@ -141,6 +141,10 @@ pub(crate) enum Error {
     EmptyRawPktsQueue,
     #[error("CID already in use by another vsock device")]
     CidAlreadyInUse,
+    #[error("Failed to write to guest memory")]
+    GuestMemoryWrite,
+    #[error("Failed to read from guest memory")]
+    GuestMemoryRead,
 }
 
 impl std::convert::From<Error> for std::io::Error {

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -21,7 +21,8 @@ use std::{
 use log::{error, warn};
 use vhost_user_backend::{VringEpollHandler, VringRwLock, VringT};
 use virtio_queue::QueueOwnedT;
-use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
+use virtio_vsock::packet_rw::{VsockPacketRx, VsockPacketTx};
+use virtio_vsock::PKT_HEADER_SIZE;
 use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
 use vmm_sys_util::{
     epoll::EventSet,
@@ -543,7 +544,7 @@ impl VhostUserVsockThread {
 
         let n = reader
             .read_until(b'\n', &mut buf)
-            .map_err(Error::UnixRead)?;
+            .map_err(Error::StreamRead)?;
 
         let mut word_iter = std::str::from_utf8(&buf[..n])
             .map_err(Error::ConvertFromUtf8)?
@@ -590,7 +591,7 @@ impl VhostUserVsockThread {
 
         let queue = vring_mut.get_queue_mut();
 
-        while let Some(mut avail_desc) = queue
+        while let Some(avail_desc) = queue
             .iter(atomic_mem.memory())
             .map_err(|_| Error::IterateQueue)?
             .next()
@@ -598,9 +599,9 @@ impl VhostUserVsockThread {
             let mem = atomic_mem.clone().memory();
 
             let head_idx = avail_desc.head_index();
-            let used_len = match VsockPacket::from_rx_virtq_chain(
+            let used_len = match VsockPacketRx::from_rx_virtq_chain(
                 mem.deref(),
-                &mut avail_desc,
+                avail_desc,
                 self.tx_buffer_size,
             ) {
                 Ok(mut pkt) => {
@@ -610,7 +611,7 @@ impl VhostUserVsockThread {
                     };
 
                     if recv_result.is_ok() {
-                        PKT_HEADER_SIZE + pkt.len() as usize
+                        PKT_HEADER_SIZE + pkt.data_slice().bytes_written()
                     } else {
                         queue.iter(mem).unwrap().go_to_previous_position();
                         break;
@@ -726,7 +727,7 @@ impl VhostUserVsockThread {
             None => return Err(Error::NoMemoryConfigured),
         };
 
-        while let Some(mut avail_desc) = vring
+        while let Some(avail_desc) = vring
             .get_mut()
             .get_queue_mut()
             .iter(atomic_mem.memory())
@@ -736,9 +737,9 @@ impl VhostUserVsockThread {
             let mem = atomic_mem.clone().memory();
 
             let head_idx = avail_desc.head_index();
-            let pkt = match VsockPacket::from_tx_virtq_chain(
+            let mut pkt = match VsockPacketTx::from_tx_virtq_chain(
                 mem.deref(),
-                &mut avail_desc,
+                avail_desc,
                 self.tx_buffer_size,
             ) {
                 Ok(pkt) => pkt,
@@ -748,7 +749,7 @@ impl VhostUserVsockThread {
                 }
             };
 
-            if self.thread_backend.send_pkt(&pkt).is_err() {
+            if self.thread_backend.send_pkt(&mut pkt).is_err() {
                 vring
                     .get_mut()
                     .get_queue_mut()

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -414,108 +414,12 @@ mod tests {
     };
 
     use super::*;
-    use crate::vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM};
+    use crate::{
+        test_utils::{prepare_desc_chain_vsock, HeadParams},
+        vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM},
+    };
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
-
-    struct HeadParams {
-        head_len: usize,
-        data_len: u32,
-    }
-
-    impl HeadParams {
-        fn new(head_len: usize, data_len: u32) -> Self {
-            Self { head_len, data_len }
-        }
-        fn construct_head(&self) -> Vec<u8> {
-            let mut header = vec![0_u8; self.head_len];
-            if self.head_len == PKT_HEADER_SIZE {
-                // Offset into the header for data length
-                const HDROFF_LEN: usize = 24;
-                LittleEndian::write_u32(&mut header[HDROFF_LEN..], self.data_len);
-            }
-            header
-        }
-    }
-
-    fn prepare_desc_chain_vsock(
-        write_only: bool,
-        head_params: &HeadParams,
-        data_chain_len: u16,
-        head_data_len: u32,
-    ) -> (
-        GuestMemoryAtomic<GuestMemoryMmap>,
-        DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>,
-    ) {
-        let mem = GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap();
-        let virt_queue = MockSplitQueue::new(&mem, 16);
-        let mut next_addr = virt_queue.desc_table().total_size() + 0x100;
-        let mut flags = 0;
-
-        if write_only {
-            flags |= VRING_DESC_F_WRITE;
-        }
-
-        let mut head_flags = if data_chain_len > 0 {
-            flags | VRING_DESC_F_NEXT
-        } else {
-            flags
-        };
-
-        // vsock packet header
-        // let header = vec![0 as u8; head_params.head_len];
-        let header = head_params.construct_head();
-        let head_desc = RawDescriptor::from(SplitDescriptor::new(
-            next_addr,
-            head_params.head_len as u32,
-            head_flags as u16,
-            1,
-        ));
-        mem.write(&header, SplitDescriptor::from(head_desc).addr())
-            .unwrap();
-        virt_queue.desc_table().store(0, head_desc).unwrap();
-        next_addr += head_params.head_len as u64;
-
-        // Put the descriptor index 0 in the first available ring position.
-        mem.write_obj(0u16, virt_queue.avail_addr().unchecked_add(4))
-            .unwrap();
-
-        // Set `avail_idx` to 1.
-        mem.write_obj(1u16, virt_queue.avail_addr().unchecked_add(2))
-            .unwrap();
-
-        // chain len excludes the head
-        for i in 0..(data_chain_len) {
-            // last descr in chain
-            if i == data_chain_len - 1 {
-                head_flags &= !VRING_DESC_F_NEXT;
-            }
-            // vsock data
-            let data = vec![0_u8; head_data_len as usize];
-            let data_desc = RawDescriptor::from(SplitDescriptor::new(
-                next_addr,
-                data.len() as u32,
-                head_flags as u16,
-                i + 2,
-            ));
-            mem.write(&data, SplitDescriptor::from(data_desc).addr())
-                .unwrap();
-            virt_queue.desc_table().store(i + 1, data_desc).unwrap();
-            next_addr += u64::from(head_data_len);
-        }
-
-        // Create descriptor chain from pre-filled memory
-        (
-            GuestMemoryAtomic::new(mem.clone()),
-            virt_queue
-                .create_queue::<Queue>()
-                .unwrap()
-                .iter(GuestMemoryAtomic::new(mem.clone()).memory())
-                .unwrap()
-                .next()
-                .unwrap(),
-        )
-    }
 
     struct VsockDummySocket {
         read_buffer: Arc<Mutex<VecDeque<u8>>>,

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0 or BSD-3-Clause
 
 use std::{
-    io::{ErrorKind, Write},
+    io::{ErrorKind, Read, Write},
     num::Wrapping,
     os::unix::prelude::{AsRawFd, RawFd},
 };
 
 use log::{error, info};
-use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
-use vm_memory::{bitmap::BitmapSlice, ReadVolatile, VolatileSlice, WriteVolatile};
+use virtio_queue::Reader;
+use virtio_vsock::packet_rw::{VsockPacketRx, VsockPacketTx};
+use virtio_vsock::PacketHeader;
+use vm_memory::bitmap::BitmapSlice;
 
 use crate::{
     rxops::*,
     rxqueue::*,
-    thread_backend::IsHybridVsock,
+    thread_backend::{IsHybridVsock, VsockStreamIo},
     txbuf::*,
     vhu_vsock::{
         Error, Result, VSOCK_FLAGS_SHUTDOWN_RCV, VSOCK_FLAGS_SHUTDOWN_SEND,
@@ -56,7 +58,7 @@ pub(crate) struct VsockConnection<S> {
     tx_buffer_size: u32,
 }
 
-impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockConnection<S> {
+impl<S: AsRawFd + Write + IsHybridVsock + VsockStreamIo> VsockConnection<S> {
     /// Create a new vsock connection object for locally i.e host-side
     /// inititated connections.
     pub fn new_local_init(
@@ -129,51 +131,58 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
     /// Process a vsock packet that is meant for this connection.
     /// Forward data to the host-side application if the vsock packet
     /// contains a RW operation.
-    pub fn recv_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacket<B>) -> Result<()> {
+    pub fn recv_pkt<B: BitmapSlice>(
+        &mut self,
+        header: &mut PacketHeader,
+        pkt: &mut VsockPacketRx<B>,
+    ) -> Result<()> {
         // Initialize all fields in the packet header
-        self.init_pkt(pkt);
+        self.init_pkt(header);
 
         match self.rx_queue.dequeue() {
             Some(RxOps::Request) => {
                 // Send a connection request to the guest-side application
-                pkt.set_op(VSOCK_OP_REQUEST);
+                header.set_op(VSOCK_OP_REQUEST);
                 Ok(())
             }
             Some(RxOps::Rw) => {
                 if !self.connect {
                     // There is no host-side application listening for this
                     // packet, hence send back an RST.
-                    pkt.set_op(VSOCK_OP_RST);
+                    header.set_op(VSOCK_OP_RST);
                     return Ok(());
                 }
 
                 // Check if peer has space for receiving data
                 if self.need_credit_update_from_peer() {
                     self.last_fwd_cnt = self.fwd_cnt;
-                    pkt.set_op(VSOCK_OP_CREDIT_REQUEST);
+                    header.set_op(VSOCK_OP_CREDIT_REQUEST);
                     return Ok(());
                 }
-                let buf = pkt.data_slice().ok_or(Error::PktBufMissing)?;
+                let data_writer = pkt.data_slice();
 
                 // Perform a credit check to find the maximum read size. The read
                 // data must fit inside a packet buffer and be within peer's
                 // available buffer space
-                let max_read_len = std::cmp::min(buf.len(), self.peer_avail_credit());
-                let mut buf = buf
-                    .subslice(0, max_read_len)
-                    .expect("subslicing should work since length was checked");
+                let max_read_len =
+                    std::cmp::min(data_writer.available_bytes(), self.peer_avail_credit());
+
+                // Limit the writer so we don't write beyond max_read_len
+                let _ = data_writer.split_at(max_read_len);
+
                 // Read data from the stream directly into the buffer
-                if let Ok(read_cnt) = self.stream.read_volatile(&mut buf) {
+                if let Ok(read_cnt) = self.stream.stream_read(data_writer) {
                     if read_cnt == 0 {
                         // If no data was read then the stream was closed down unexpectedly.
                         // Send a shutdown packet to the guest-side application.
-                        pkt.set_op(VSOCK_OP_SHUTDOWN)
+                        header
+                            .set_op(VSOCK_OP_SHUTDOWN)
                             .set_flag(VSOCK_FLAGS_SHUTDOWN_RCV)
                             .set_flag(VSOCK_FLAGS_SHUTDOWN_SEND);
                     } else {
                         // If data was read, then set the length field in the packet header
                         // to the amount of data that was read.
-                        pkt.set_op(VSOCK_OP_RW).set_len(read_cnt as u32);
+                        header.set_op(VSOCK_OP_RW).set_len(read_cnt as u32);
 
                         // Re-register the stream file descriptor for read and write events
                         if VhostUserVsockThread::epoll_modify(
@@ -196,7 +205,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                     }
 
                     // Update the rx_cnt with the amount of data in the vsock packet.
-                    self.rx_cnt += Wrapping(pkt.len());
+                    self.rx_cnt += Wrapping(header.len());
                     self.last_fwd_cnt = self.fwd_cnt;
                 }
                 Ok(())
@@ -204,14 +213,14 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             Some(RxOps::Response) => {
                 // A response has been received to a newly initiated host-side connection
                 self.connect = true;
-                pkt.set_op(VSOCK_OP_RESPONSE);
+                header.set_op(VSOCK_OP_RESPONSE);
                 Ok(())
             }
             Some(RxOps::CreditUpdate) => {
                 // Request credit update from the guest.
                 if !self.rx_queue.pending_rx() {
                     // Waste an rx buffer if no rx is pending
-                    pkt.set_op(VSOCK_OP_CREDIT_UPDATE);
+                    header.set_op(VSOCK_OP_CREDIT_UPDATE);
                     self.last_fwd_cnt = self.fwd_cnt;
                 }
                 Ok(())
@@ -224,12 +233,12 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
     ///
     /// Returns:
     /// - always `Ok(())` to indicate that the packet has been consumed
-    pub fn send_pkt<B: BitmapSlice>(&mut self, pkt: &VsockPacket<B>) -> Result<()> {
+    pub fn send_pkt<B: BitmapSlice>(&mut self, pkt: &mut VsockPacketTx<B>) -> Result<()> {
         // Update peer credit information
-        self.peer_buf_alloc = pkt.buf_alloc();
-        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+        self.peer_buf_alloc = pkt.header().buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.header().fwd_cnt());
 
-        match pkt.op() {
+        match pkt.header().op() {
             VSOCK_OP_RESPONSE => {
                 if self.stream.is_hybrid_vsock() {
                     // Confirmation for a host initiated connection
@@ -241,7 +250,8 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             }
             VSOCK_OP_RW => {
                 // Data has to be written to the host-side stream
-                match pkt.data_slice() {
+                let pkt_len = pkt.header().len() as usize;
+                match pkt.data_slice_mut() {
                     None => {
                         info!(
                             "Dropping empty packet from guest (lp={}, pp={})",
@@ -250,7 +260,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                         return Ok(());
                     }
                     Some(buf) => {
-                        if let Err(err) = self.send_bytes(buf) {
+                        if let Err(err) = self.send_bytes(buf, pkt_len) {
                             // TODO: Terminate this connection
                             log::debug!("err:{err:?}");
                             return Ok(());
@@ -285,8 +295,8 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             }
             VSOCK_OP_SHUTDOWN => {
                 // Shutdown this connection
-                let recv_off = pkt.flags() & VSOCK_FLAGS_SHUTDOWN_RCV != 0;
-                let send_off = pkt.flags() & VSOCK_FLAGS_SHUTDOWN_SEND != 0;
+                let recv_off = pkt.header().flags() & VSOCK_FLAGS_SHUTDOWN_RCV != 0;
+                let send_off = pkt.header().flags() & VSOCK_FLAGS_SHUTDOWN_SEND != 0;
 
                 if recv_off && send_off && self.tx_buf.is_empty() {
                     self.rx_queue.enqueue(RxOps::Reset);
@@ -303,28 +313,32 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
     /// Returns:
     /// - Ok(cnt) where cnt is the number of bytes written to the stream
     /// - Err(Error::StreamWrite) if there was an error writing to the stream
-    fn send_bytes<B: BitmapSlice>(&mut self, buf: &VolatileSlice<B>) -> Result<()> {
+    fn send_bytes<B: BitmapSlice>(&mut self, reader: &mut Reader<B>, len: usize) -> Result<()> {
+        // TODO: Not sure this is the best way to do it. PTAL
+        // Intermediate buffer: the Reader does not provide direct access to
+        // guest memory, so we copy the data out before writing to the stream.
+        let mut buffer = vec![0u8; len];
+        reader
+            .read_exact(&mut buffer)
+            .map_err(|_| Error::GuestMemoryRead)?;
+
         if !self.tx_buf.is_empty() {
             // Data is already present in the buffer and the backend
             // is waiting for a EPOLLOUT event to flush it
-            return self.tx_buf.push(buf);
+            return self.tx_buf.push_bytes(&buffer);
         }
 
         // Write data to the stream
 
-        let written_count = match self.stream.write_volatile(buf) {
+        let written_count = match self.stream.stream_write(&buffer) {
             Ok(cnt) => cnt,
-            Err(vm_memory::VolatileMemoryError::IOError(e)) => {
+            Err(e) => {
                 if e.kind() == ErrorKind::WouldBlock {
                     0
                 } else {
                     log::debug!("send_bytes error: {e:?}");
                     return Err(Error::StreamWrite);
                 }
-            }
-            Err(e) => {
-                log::debug!("send_bytes error: {e:?}");
-                return Err(Error::StreamWrite);
             }
         };
 
@@ -345,7 +359,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             }
         }
 
-        if written_count != buf.len() {
+        if written_count != len {
             // Try to re-enable EPOLLOUT in case it is disabled when txbuf is empty.
             if VhostUserVsockThread::epoll_modify(
                 self.epoll_fd,
@@ -356,21 +370,19 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             {
                 error!("Failed to re-enable EPOLLOUT");
             }
-            return self.tx_buf.push(&buf.offset(written_count).unwrap());
+            return self.tx_buf.push_bytes(&buffer[written_count..]);
         }
 
         Ok(())
     }
 
     /// Initialize all header fields in the vsock packet.
-    fn init_pkt<'a, 'b, B: BitmapSlice>(
-        &self,
-        pkt: &'a mut VsockPacket<'b, B>,
-    ) -> &'a mut VsockPacket<'b, B> {
+    fn init_pkt<'a>(&self, header: &'a mut PacketHeader) -> &'a mut PacketHeader {
         // Zero out the packet header
-        pkt.set_header_from_raw(&[0u8; PKT_HEADER_SIZE]).unwrap();
+        *header = PacketHeader::default();
 
-        pkt.set_src_cid(self.local_cid)
+        header
+            .set_src_cid(self.local_cid)
             .set_dst_cid(self.guest_cid)
             .set_src_port(self.local_port)
             .set_dst_port(self.peer_port)
@@ -401,17 +413,9 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use byteorder::{ByteOrder, LittleEndian};
-    use virtio_bindings::bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
-    use virtio_queue::{
-        desc::{split::Descriptor as SplitDescriptor, RawDescriptor},
-        mock::MockSplitQueue,
-        DescriptorChain, Queue, QueueOwnedT,
-    };
-    use vm_memory::{
-        Address, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard,
-        GuestMemoryMmap,
-    };
+    use virtio_queue::Writer;
+    use virtio_vsock::packet::PKT_HEADER_SIZE;
+    use vm_memory::{Address, Bytes, GuestAddressSpace, ReadVolatile, VolatileSlice};
 
     use super::*;
     use crate::{
@@ -472,19 +476,29 @@ mod tests {
         }
     }
 
-    impl WriteVolatile for VsockDummySocket {
-        fn write_volatile<B: BitmapSlice>(
-            &mut self,
-            buf: &VolatileSlice<B>,
-        ) -> std::result::Result<usize, vm_memory::VolatileMemoryError> {
+    impl VsockStreamIo for VsockDummySocket {
+        fn stream_write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             // VecDequeue has no fancy unsafe tricks that vm-memory can abstract.
             // One could do fairly efficient stuff using the moving From<Vec> imp...
             // But this is just for tests, so lets clone, convert to Vec, append, convert
             // back and replace.
             let mut write_buffer = self.write_buffer.lock().unwrap();
             let mut vec = Vec::from(write_buffer.clone());
-            let n = vec.write_volatile(buf)?;
+            let n = vec.write(buf).unwrap();
             *write_buffer = VecDeque::from(vec);
+
+            Ok(n)
+        }
+
+        fn stream_read<B: BitmapSlice>(&mut self, writer: &mut Writer<B>) -> Result<usize> {
+            // Similar to the std's Read impl, we only read on the head. Since
+            // we drain the head, successive reads will cover the rest of the
+            // queue.
+            let mut read_buffer = self.read_buffer.lock().unwrap();
+            let (head, _) = read_buffer.as_slices();
+            let n = writer.write(head).unwrap();
+
+            read_buffer.drain(..n);
 
             Ok(n)
         }
@@ -617,23 +631,18 @@ mod tests {
             CONN_TX_BUF_SIZE,
         );
 
-        // write only descriptor chain
-        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(true, &head_params, 2, 10);
-        let mem = mem.memory();
-        let mut pkt =
-            VsockPacket::from_rx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)
-                .unwrap();
-
+        let mut header = PacketHeader::default();
         // initialize a vsock packet for the guest
-        conn_local.init_pkt(&mut pkt);
+        conn_local.init_pkt(&mut header);
+        //pkt.header_slice().write_obj::<PacketHeader>(header).expect("TODO: write message");
 
-        assert_eq!(pkt.src_cid(), VSOCK_HOST_CID);
-        assert_eq!(pkt.dst_cid(), 3);
-        assert_eq!(pkt.src_port(), 5000);
-        assert_eq!(pkt.dst_port(), 5001);
-        assert_eq!(pkt.type_(), VSOCK_TYPE_STREAM);
-        assert_eq!(pkt.buf_alloc(), CONN_TX_BUF_SIZE);
-        assert_eq!(pkt.fwd_cnt(), 0);
+        assert_eq!(header.src_cid(), VSOCK_HOST_CID);
+        assert_eq!(header.dst_cid(), 3);
+        assert_eq!(header.src_port(), 5000);
+        assert_eq!(header.dst_port(), 5001);
+        assert_eq!(header.type_(), VSOCK_TYPE_STREAM);
+        assert_eq!(header.buf_alloc(), CONN_TX_BUF_SIZE);
+        assert_eq!(header.fwd_cnt(), 0);
     }
 
     #[test]
@@ -649,84 +658,122 @@ mod tests {
             CONN_TX_BUF_SIZE,
         );
 
-        // write only descriptor chain
-        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(true, &head_params, 1, 5);
-        let mem = mem.memory();
-        let mut pkt =
-            VsockPacket::from_rx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)
-                .unwrap();
+        let mut packet_header = PacketHeader::default();
 
         // VSOCK_OP_REQUEST: new local conn request
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.rx_queue.enqueue(RxOps::Request);
-        let op_req = conn_local.recv_pkt(&mut pkt);
+        let op_req = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_req.unwrap();
         assert!(!conn_local.rx_queue.pending_rx());
-        assert_eq!(pkt.op(), VSOCK_OP_REQUEST);
+        assert_eq!(packet_header.op(), VSOCK_OP_REQUEST);
 
         // VSOCK_OP_RST: reset if connection not established
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.rx_queue.enqueue(RxOps::Rw);
-        let op_rst = conn_local.recv_pkt(&mut pkt);
+        let op_rst = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_rst.unwrap();
         assert!(!conn_local.rx_queue.pending_rx());
-        assert_eq!(pkt.op(), VSOCK_OP_RST);
+        assert_eq!(packet_header.op(), VSOCK_OP_RST);
 
         // VSOCK_OP_CREDIT_UPDATE: need credit update from peer/guest
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.connect = true;
         conn_local.rx_queue.enqueue(RxOps::Rw);
         conn_local.fwd_cnt = Wrapping(1024);
-        let op_credit_update = conn_local.recv_pkt(&mut pkt);
+        let op_credit_update = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_credit_update.unwrap();
         assert!(!conn_local.rx_queue.pending_rx());
-        assert_eq!(pkt.op(), VSOCK_OP_CREDIT_REQUEST);
+        assert_eq!(packet_header.op(), VSOCK_OP_CREDIT_REQUEST);
         assert_eq!(conn_local.last_fwd_cnt, Wrapping(1024));
 
         // VSOCK_OP_SHUTDOWN: zero data read from stream/file
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.peer_buf_alloc = 65536;
         conn_local.rx_queue.enqueue(RxOps::Rw);
-        let op_zero_read_shutdown = conn_local.recv_pkt(&mut pkt);
+        let op_zero_read_shutdown = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_zero_read_shutdown.unwrap();
         assert!(!conn_local.rx_queue.pending_rx());
         assert_eq!(conn_local.rx_cnt, Wrapping(0));
         assert_eq!(conn_local.last_fwd_cnt, Wrapping(1024));
-        assert_eq!(pkt.op(), VSOCK_OP_SHUTDOWN);
+        assert_eq!(packet_header.op(), VSOCK_OP_SHUTDOWN);
         assert_eq!(
-            pkt.flags(),
+            packet_header.flags(),
             VSOCK_FLAGS_SHUTDOWN_RCV | VSOCK_FLAGS_SHUTDOWN_SEND
         );
 
         // VSOCK_OP_RW: finite data read from stream/file
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, buf_addr) =
+            prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem_ref = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem_ref.deref(), descr_chain, CONN_TX_BUF_SIZE)
+                .unwrap();
         let payload = b"hello";
         host_socket.write_all(payload).unwrap();
         conn_local.rx_queue.enqueue(RxOps::Rw);
-        let op_zero_read = conn_local.recv_pkt(&mut pkt);
+        let op_zero_read = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_zero_read.unwrap();
-        assert_eq!(pkt.op(), VSOCK_OP_RW);
+        assert_eq!(packet_header.op(), VSOCK_OP_RW);
         assert!(!conn_local.rx_queue.pending_rx());
         assert_eq!(conn_local.rx_cnt, Wrapping(payload.len() as u32));
         assert_eq!(conn_local.last_fwd_cnt, Wrapping(1024));
-        assert_eq!(pkt.len(), 5);
-        let buf = &mut [0u8; 5];
-        pkt.data_slice().unwrap().read_slice(buf, 0).unwrap();
-        assert_eq!(buf, b"hello");
+        assert_eq!(packet_header.len(), 5);
+        let mut buf = [0u8; 5];
+        mem_ref
+            .read(&mut buf, buf_addr.unchecked_add(PKT_HEADER_SIZE as u64))
+            .unwrap();
+        assert_eq!(&buf, b"hello");
 
         // VSOCK_OP_RESPONSE: response from a locally initiated connection
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.rx_queue.enqueue(RxOps::Response);
-        let op_response = conn_local.recv_pkt(&mut pkt);
+        let op_response = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         op_response.unwrap();
         assert!(!conn_local.rx_queue.pending_rx());
-        assert_eq!(pkt.op(), VSOCK_OP_RESPONSE);
+        assert_eq!(packet_header.op(), VSOCK_OP_RESPONSE);
         assert!(conn_local.connect);
 
         // VSOCK_OP_CREDIT_UPDATE: guest needs credit update
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
         conn_local.rx_queue.enqueue(RxOps::CreditUpdate);
-        let op_credit_update = conn_local.recv_pkt(&mut pkt);
+        let op_credit_update = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         assert!(!conn_local.rx_queue.pending_rx());
         op_credit_update.unwrap();
-        assert_eq!(pkt.op(), VSOCK_OP_CREDIT_UPDATE);
+        assert_eq!(packet_header.op(), VSOCK_OP_CREDIT_UPDATE);
         assert_eq!(conn_local.last_fwd_cnt, Wrapping(1024));
 
         // non-existent request
-        let op_error = conn_local.recv_pkt(&mut pkt);
+        packet_header = PacketHeader::default();
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(true, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let mem = mem.memory();
+        let mut pkt =
+            VsockPacketRx::from_rx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
+        let op_error = conn_local.recv_pkt(&mut packet_header, &mut pkt);
         assert!(op_error.is_err());
     }
 
@@ -745,25 +792,24 @@ mod tests {
         );
 
         // write only descriptor chain
-        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 1, &[0u8; 5]);
+        let (mem, descr_chain, _) = prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 1, b"hello");
         let mem = mem.memory();
         let mut pkt =
-            VsockPacket::from_tx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)
-                .unwrap();
+            VsockPacketTx::from_tx_virtq_chain(mem.deref(), descr_chain, CONN_TX_BUF_SIZE).unwrap();
 
         // peer credit information
-        pkt.set_buf_alloc(65536).set_fwd_cnt(1024);
+        pkt.header_mut().set_buf_alloc(65536).set_fwd_cnt(1024);
 
         // check if peer credit information is updated currently
-        let credit_check = conn_local.send_pkt(&pkt);
+        let credit_check = conn_local.send_pkt(&mut pkt);
         credit_check.unwrap();
         assert_eq!(conn_local.peer_buf_alloc, 65536);
         assert_eq!(conn_local.peer_fwd_cnt, Wrapping(1024));
 
         // VSOCK_OP_RESPONSE
-        pkt.set_op(VSOCK_OP_RESPONSE);
+        pkt.header_mut().set_op(VSOCK_OP_RESPONSE);
         assert_eq!(conn_local.peer_port, 5001);
-        let peer_response = conn_local.send_pkt(&pkt);
+        let peer_response = conn_local.send_pkt(&mut pkt);
         peer_response.unwrap();
         assert!(conn_local.connect);
         let mut resp_buf = vec![0; 8];
@@ -771,25 +817,25 @@ mod tests {
         assert_eq!(&resp_buf, b"OK 5001\n");
 
         // VSOCK_OP_RW
-        pkt.set_op(VSOCK_OP_RW);
-        let buf = b"hello";
-        pkt.data_slice().unwrap().write_slice(buf, 0).unwrap();
-        let rw_response = conn_local.send_pkt(&pkt);
+        pkt.header_mut().set_op(VSOCK_OP_RW);
+        // TODO: Data is already written in the descriptor by prepare_desc_chain_vsock
+        let rw_response = conn_local.send_pkt(&mut pkt);
         rw_response.unwrap();
         let mut resp_buf = vec![0; 5];
         host_socket.read_exact(&mut resp_buf).unwrap();
         assert_eq!(resp_buf, b"hello");
 
         // VSOCK_OP_CREDIT_REQUEST
-        pkt.set_op(VSOCK_OP_CREDIT_REQUEST);
-        let credit_response = conn_local.send_pkt(&pkt);
+        pkt.header_mut().set_op(VSOCK_OP_CREDIT_REQUEST);
+        let credit_response = conn_local.send_pkt(&mut pkt);
         credit_response.unwrap();
         assert_eq!(conn_local.rx_queue.peek().unwrap(), RxOps::CreditUpdate);
 
         // VSOCK_OP_SHUTDOWN
-        pkt.set_op(VSOCK_OP_SHUTDOWN);
-        pkt.set_flags(VSOCK_FLAGS_SHUTDOWN_RCV | VSOCK_FLAGS_SHUTDOWN_SEND);
-        let shutdown_response = conn_local.send_pkt(&pkt);
+        pkt.header_mut().set_op(VSOCK_OP_SHUTDOWN);
+        pkt.header_mut()
+            .set_flags(VSOCK_FLAGS_SHUTDOWN_RCV | VSOCK_FLAGS_SHUTDOWN_SEND);
+        let shutdown_response = conn_local.send_pkt(&mut pkt);
         shutdown_response.unwrap();
         assert!(conn_local.rx_queue.contains(RxOps::Reset.bitmask()));
     }

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -415,7 +415,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        test_utils::{prepare_desc_chain_vsock, HeadParams},
+        test_utils::prepare_desc_chain_vsock,
         vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM},
     };
 
@@ -606,9 +606,6 @@ mod tests {
 
     #[test]
     fn test_vsock_conn_init_pkt() {
-        // parameters for packet head construction
-        let head_params = HeadParams::new(PKT_HEADER_SIZE, 10);
-
         let dummy_file = VsockDummySocket::new();
         let conn_local = VsockConnection::new_local_init(
             dummy_file,
@@ -641,9 +638,6 @@ mod tests {
 
     #[test]
     fn test_vsock_conn_recv_pkt() {
-        // parameters for packet head construction
-        let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);
-
         let (mut host_socket, backend_socket) = VsockDummySocket::pair();
         let mut conn_local = VsockConnection::new_local_init(
             backend_socket,
@@ -738,9 +732,6 @@ mod tests {
 
     #[test]
     fn test_vsock_conn_send_pkt() {
-        // parameters for packet head construction
-        let head_params = HeadParams::new(PKT_HEADER_SIZE, 5);
-
         // new locally inititated connection
         let (mut host_socket, backend_socket) = VsockDummySocket::pair();
         let mut conn_local = VsockConnection::new_local_init(
@@ -754,7 +745,7 @@ mod tests {
         );
 
         // write only descriptor chain
-        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(false, &head_params, 1, 5);
+        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(false, PKT_HEADER_SIZE, 1, &[0u8; 5]);
         let mem = mem.memory();
         let mut pkt =
             VsockPacket::from_tx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -415,7 +415,7 @@ mod tests {
 
     use virtio_queue::Writer;
     use virtio_vsock::packet::PKT_HEADER_SIZE;
-    use vm_memory::{Address, Bytes, GuestAddressSpace, ReadVolatile, VolatileSlice};
+    use vm_memory::{Address, Bytes, GuestAddressSpace};
 
     use super::*;
     use crate::{
@@ -507,23 +507,6 @@ mod tests {
     impl Read for VsockDummySocket {
         fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
             self.read_buffer.lock().unwrap().read(buf)
-        }
-    }
-
-    impl ReadVolatile for VsockDummySocket {
-        fn read_volatile<B: BitmapSlice>(
-            &mut self,
-            buf: &mut VolatileSlice<B>,
-        ) -> std::result::Result<usize, vm_memory::VolatileMemoryError> {
-            // Similar to the std's Read impl, we only read on the head. Since
-            // we drain the head, successive reads will cover the rest of the
-            // queue.
-            let mut read_buffer = self.read_buffer.lock().unwrap();
-            let (head, _) = read_buffer.as_slices();
-            let n = ReadVolatile::read_volatile(&mut &head[..], buf)?;
-            read_buffer.drain(..n);
-
-            Ok(n)
         }
     }
 

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -621,7 +621,7 @@ mod tests {
         );
 
         // write only descriptor chain
-        let (mem, mut descr_chain) = prepare_desc_chain_vsock(true, &head_params, 2, 10);
+        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(true, &head_params, 2, 10);
         let mem = mem.memory();
         let mut pkt =
             VsockPacket::from_rx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)
@@ -656,7 +656,7 @@ mod tests {
         );
 
         // write only descriptor chain
-        let (mem, mut descr_chain) = prepare_desc_chain_vsock(true, &head_params, 1, 5);
+        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(true, &head_params, 1, 5);
         let mem = mem.memory();
         let mut pkt =
             VsockPacket::from_rx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)
@@ -754,7 +754,7 @@ mod tests {
         );
 
         // write only descriptor chain
-        let (mem, mut descr_chain) = prepare_desc_chain_vsock(false, &head_params, 1, 5);
+        let (mem, mut descr_chain, _) = prepare_desc_chain_vsock(false, &head_params, 1, 5);
         let mem = mem.memory();
         let mut pkt =
             VsockPacket::from_tx_virtq_chain(mem.deref(), &mut descr_chain, CONN_TX_BUF_SIZE)


### PR DESCRIPTION
### Summary of the PR

Currently vhost-device-vsock doesn't work with upstream linux using a payload larger than 32kB.
(See https://github.com/rust-vmm/vhost-device/issues/934)

This PR switches to the Reader/Writer removing the burden of handling descriptors.

This PR requires https://github.com/rust-vmm/vm-virtio/pull/392 ~and https://github.com/rust-vmm/vhost/pull/348~

Closes: https://github.com/rust-vmm/vhost-device/issues/934

This PR is very big and I'd like to gather some feedback around it.

Currently the biggest problem I see is about an extra copy I had to introduce because Reader/Writer do not support zerocopy.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [X] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
