### PR TITLE
vhost-device-input: Fix set_config offset handling

### DIFF
--- a/vhost-device-input/CHANGELOG.md
+++ b/vhost-device-input/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixed
 
+- [[#955]](https://github.com/rust-vmm/vhost-device/pull/955) vhost-device-input: Fix set_config offset handling
+
 ### Deprecated
 
 ## v0.1.0

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -378,12 +378,16 @@ impl<T: 'static + InputDevice + Sync + Send> VhostUserBackendMut for VuInputBack
         result
     }
 
-    // In virtio spec https://docs.oasis-open.org/virtio/virtio/v1.2/cs01/virtio-v1.2-cs01.pdf,
-    // section "5.8.5.1 Driver Requirements: Device Initialization", it doesn't
-    // mention to use 'offset' argument, so set it as unused.
-    fn set_config(&mut self, _offset: u32, buf: &[u8]) -> io::Result<()> {
-        self.select = buf[0];
-        self.subsel = buf[1];
+    fn set_config(&mut self, offset: u32, buf: &[u8]) -> io::Result<()> {
+        // The virtio-input config space has select at offset 0 and subsel at offset 1
+        // The VMM may write them separately or together
+        for (i, &byte) in buf.iter().enumerate() {
+            match offset as usize + i {
+                0 => self.select = byte,
+                1 => self.subsel = byte,
+                _ => {}
+            }
+        }
 
         Ok(())
     }

--- a/vhost-device-input/src/vhu_input.rs
+++ b/vhost-device-input/src/vhu_input.rs
@@ -10,7 +10,6 @@ use std::{
     io::{self, Result as IoResult},
 };
 
-use log::error;
 use nix::libc;
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};


### PR DESCRIPTION
### Summary of the PR

The current set_config implementation assumes the VMM writes both the select and subsel fields together in a single 2-byte buffer. But the Linux kernel virtio-input driver writes each field separately using offset-based writes via the `virtio_cwrite_le` macro.

The previous implementation would panic with "index out of bounds" when accessing buf[1] for the first write (offset=0, len=1). This fix properly handles offset-based writes by iterating through the buffer and writing each byte to the correct field based on offset.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
