### PR TITLE
Fix tests in vhost-can-device

### DIFF
--- a/vhost-device-can/src/can.rs
+++ b/vhost-device-can/src/can.rs
@@ -367,6 +367,8 @@ mod tests {
 
         // Test start_read_thread
         let thread_handle = CanController::start_read_thread(arc_controller.clone());
+
+        arc_controller.write().unwrap().exit_read_thread();
         assert!(thread_handle.join().is_ok());
     }
 

--- a/vhost-device-can/src/can.rs
+++ b/vhost-device-can/src/can.rs
@@ -293,6 +293,7 @@ mod tests {
 
     use super::*;
     use crate::vhu_can::VhostUserCanBackend;
+    use crate::virtio_can::VIRTIO_CAN_TX;
 
     #[test]
     fn test_can_controller_creation() {
@@ -340,11 +341,11 @@ mod tests {
         let mut controller = CanController::new(can_name.clone()).unwrap();
 
         let frame = VirtioCanFrame {
-            msg_type: VIRTIO_CAN_RX.into(),
+            msg_type: VIRTIO_CAN_TX.into(),
             can_id: 123.into(),
             length: 64.into(),
             reserved: 0.into(),
-            flags: 0.into(),
+            flags: CAN_FRMF_TYPE_FD.into(),
             sdu: [0; 64],
         };
 

--- a/vhost-device-can/src/can.rs
+++ b/vhost-device-can/src/can.rs
@@ -50,10 +50,27 @@ pub(crate) enum Error {
 }
 
 #[derive(Debug)]
+pub(crate) enum CanSocketKind {
+    Fd(CanFdSocket),
+    #[cfg(test)]
+    Mock,
+}
+
+impl CanSocketKind {
+    pub fn write_frame(&self, frame: &CanAnyFrame) -> std::io::Result<()> {
+        match self {
+            CanSocketKind::Fd(socket) => socket.write_frame(frame),
+            #[cfg(test)]
+            CanSocketKind::Mock => Ok(()),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct CanController {
     pub config: VirtioCanConfig,
     pub can_name: String,
-    pub can_socket: Option<CanFdSocket>,
+    pub can_socket: Option<CanSocketKind>,
     pub rx_event_fd: EventFd,
     rx_fifo: Queue<VirtioCanFrame>,
     pub status: bool,
@@ -78,6 +95,30 @@ impl CanController {
             status: true,
             ctrl_state: CAN_CS_STOPPED,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_mock() -> Result<CanController> {
+        let rx_fifo = Queue::new();
+        let rx_efd = EventFd::new(EFD_NONBLOCK).map_err(|_| Error::EventFdFailed)?;
+
+        Ok(CanController {
+            config: VirtioCanConfig { status: 0x0.into() },
+            can_name: "vcan0".to_string(),
+            can_socket: Some(CanSocketKind::Mock),
+            rx_event_fd: rx_efd,
+            rx_fifo,
+            status: true,
+            ctrl_state: CAN_CS_STOPPED,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_test() -> Result<CanController> {
+        if let Ok(iface) = std::env::var("TEST_CAN_INTERFACE") {
+            return CanController::new(iface);
+        }
+        CanController::new_mock()
     }
 
     pub fn print_can_frame(canframe: VirtioCanFrame) {
@@ -129,7 +170,7 @@ impl CanController {
 
     pub fn open_can_socket(&mut self) -> Result<()> {
         self.can_socket = match CanFdSocket::open(&self.can_name) {
-            Ok(socket) => Some(socket),
+            Ok(socket) => Some(CanSocketKind::Fd(socket)),
             Err(_) => {
                 warn!("Error opening CAN socket");
                 return Err(Error::SocketOpen);
@@ -297,16 +338,13 @@ mod tests {
 
     #[test]
     fn test_can_controller_creation() {
-        let can_name = "can".to_string();
-
-        let controller = CanController::new(can_name.clone()).unwrap();
-        assert_eq!(controller.can_name, can_name);
+        let controller = CanController::new_test().unwrap();
+        assert!(!controller.can_name.is_empty());
     }
 
     #[test]
     fn test_can_controller_push_and_pop() {
-        let can_name = "can".to_string();
-        let mut controller = CanController::new(can_name.clone()).unwrap();
+        let mut controller = CanController::new_test().unwrap();
 
         let frame = VirtioCanFrame {
             msg_type: VIRTIO_CAN_RX.into(),
@@ -327,8 +365,7 @@ mod tests {
 
     #[test]
     fn test_can_controller_config() {
-        let can_name = "can".to_string();
-        let mut controller = CanController::new(can_name.clone()).unwrap();
+        let mut controller = CanController::new_test().unwrap();
 
         // Test config
         let config = controller.config();
@@ -337,8 +374,7 @@ mod tests {
 
     #[test]
     fn test_can_controller_operation() {
-        let can_name = "can".to_string();
-        let mut controller = CanController::new(can_name.clone()).unwrap();
+        let mut controller = CanController::new_test().unwrap();
 
         let frame = VirtioCanFrame {
             msg_type: VIRTIO_CAN_TX.into(),
@@ -355,14 +391,13 @@ mod tests {
                 let operation_result = controller.can_out(frame);
                 assert!(operation_result.is_ok());
             }
-            Err(_) => warn!("There is no CAN interface with {can_name} name"),
+            Err(_) => warn!("There is no CAN interface"),
         }
     }
 
     #[test]
     fn test_can_controller_start_read_thread() {
-        let can_name = "can".to_string();
-        let controller = CanController::new(can_name.clone()).unwrap();
+        let controller = CanController::new_test().unwrap();
         let arc_controller = Arc::new(RwLock::new(controller));
 
         // Test start_read_thread
@@ -375,7 +410,7 @@ mod tests {
     #[test]
     fn test_can_open_socket_fail() {
         let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+            CanController::new("nonexistent_can".to_string()).expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
 
@@ -388,7 +423,7 @@ mod tests {
     #[test]
     fn test_can_read_socket_fail() {
         let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+            CanController::new("nonexistent_can".to_string()).expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
 

--- a/vhost-device-can/src/vhu_can.rs
+++ b/vhost-device-can/src/vhu_can.rs
@@ -272,16 +272,12 @@ impl VhostUserCanBackend {
             can_rx.flags = (can_rx.flags.to_native() | VIRTIO_CAN_FLAGS_RTR).into();
         }
 
-        // Treat Vcan interface as CANFD if MTU is set to 64 bytes.
-        //
-        // Vcan can not be configured as CANFD interface, but it is
-        // possible to configure its MTU to 64 bytes. So if a messages
-        // bigger than 8 bytes is being received we consider it as
-        // CANFD message.
-        let can_name = self.controller.read().unwrap().can_name.clone();
-        if self.check_features(VIRTIO_CAN_F_CAN_FD) && res_len > 8 && can_name == "vcan0" {
+        // Classic CAN frames cannot exceed 8 bytes. If CAN-FD has been
+        // negotiated and the frame length is > 8, treat it as a CAN-FD
+        // frame. This also covers virtual interfaces (vcan) which do not
+        // distinguish between CAN and CAN-FD at the socket level.
+        if self.check_features(VIRTIO_CAN_F_CAN_FD) && res_len > 8 {
             res_flags |= CAN_FRMF_TYPE_FD;
-            warn!("\n\n\nCANFD VCAN0\n\n");
         }
 
         // Check if CAN/FD length is out-of-range (based on negotiated features)

--- a/vhost-device-can/src/vhu_can.rs
+++ b/vhost-device-can/src/vhu_can.rs
@@ -777,8 +777,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_empty_requests() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -801,8 +800,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_empty_handle_request() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -873,8 +871,7 @@ mod tests {
     #[test]
     fn test_virtio_can_ctrl_request() {
         // Initialize can device and vhost-device-can backend
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1100,8 +1097,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_tx_unknown_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1123,8 +1119,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_tx_can_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1171,8 +1166,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_tx_canfd_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller).expect("Could not build vhucan device");
@@ -1278,8 +1272,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_tx_rtr_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1340,8 +1333,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_tx_eff_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1401,8 +1393,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_tx_general_tests() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1498,8 +1489,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_tx_device_stopped_test() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1554,7 +1544,7 @@ mod tests {
     #[test]
     fn test_virtio_can_tx_device_started_test_send_fail() {
         let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+            CanController::new("nonexistent_can".to_string()).expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1611,8 +1601,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_tx_device_started_check_frame_fail() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1666,8 +1655,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_err_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1709,8 +1697,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_features_not_negotiated() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1746,8 +1733,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_eff_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1814,8 +1800,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_rtr_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1878,8 +1863,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_can_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -1925,8 +1909,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_canfd_frame() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -2010,8 +1993,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_check_rx_canfd_vcan0() {
-        let controller =
-            CanController::new("vcan0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");
@@ -2049,8 +2031,7 @@ mod tests {
 
     #[test]
     fn test_virtio_can_rx_request() {
-        let controller =
-            CanController::new("can0".to_string()).expect("Could not build controller");
+        let controller = CanController::new_test().expect("Could not build controller");
         let controller = Arc::new(RwLock::new(controller));
         let mut vu_can_backend =
             VhostUserCanBackend::new(controller.clone()).expect("Could not build vhucan device");


### PR DESCRIPTION
### Summary of the PR

This PR includes some fixes for the test in vhost-user-can device. It also adds a mock interface to run the tests in an environment that does not have a can interface. It adds an option to set the name of the interface for tests so it can run on a real interface too. The PR also removes the name of the interface that is hardcoded in check_rx_frame() that is not required.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
