### PR TITLE
vhost_device_vsock: fix wrap-around detection in allocate_local_port

### DIFF
--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -527,11 +527,11 @@ impl VhostUserVsockThread {
                 self.thread_backend.local_port_set.insert(alloc_local_port);
                 return Ok(alloc_local_port);
             } else {
+                alloc_local_port = alloc_local_port.wrapping_add(1);
                 if alloc_local_port == self.local_port.0 {
-                    // We have exhausted our search and wrapped back to the current port number
+                    // We have exhausted our search and wrapped back to the starting port
                     return Err(Error::NoFreeLocalPort);
                 }
-                alloc_local_port += 1;
             }
         }
     }


### PR DESCRIPTION
allocate_local_port() searches for a free port number starting from self.local_port.0.  When a candidate port is already in local_port_set, the code is supposed to advance to the next port and retry, stopping only when it has wrapped all the way around to the starting port.

The original wrap-around check was performed before incrementing alloc_local_port:

    } else {
        if alloc_local_port == self.local_port.0 { // checked first
            return Err(Error::NoFreeLocalPort);
        }
        alloc_local_port += 1;                     // incremented after
    }

Because alloc_local_port starts equal to self.local_port.0, the very first time the else branch is entered (i.e. the starting port is busy), the condition is immediately true and NoFreeLocalPort is returned without ever examining any other port.  In practice this means that if self.local_port.0 happens to still be held in local_port_set (e.g. due to a slow RST round-trip), the allocator gives up instantly rather than scanning the remaining ~4 billion available port numbers.

Fix by saving the starting port in a separate variable start_port before the loop, incrementing alloc_local_port first inside the else branch, and then comparing against start_port.  The allocator now correctly performs a full circular scan before declaring exhaustion.

Change-Id: I6eb909ce3e15de6c0c7058fb626a78b8eb681e4c

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
