### PR TITLE
Adding unix support for vhost-device-vsock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,18 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vhost"
+version = "0.14.0"
+source = "git+https://github.com/eric-14/rust_vhost_.git?branch=experimental_mac#4f0384ab5b24593c3af467613c87fb4975e7a5d6"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc 0.2.186",
+ "uuid",
+ "vm-memory 0.16.1",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "vhost"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c76d90ce3c6b37d610a5304c9a445cfff580cf8b4b9fd02fb256aaf68552c28a"
@@ -2052,8 +2064,8 @@ dependencies = [
  "bitflags 2.11.1",
  "libc 0.2.186",
  "uuid",
- "vm-memory",
- "vmm-sys-util",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2067,12 +2079,12 @@ dependencies = [
  "queues",
  "socketcan",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2088,12 +2100,12 @@ dependencies = [
  "log",
  "queues",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2107,12 +2119,12 @@ dependencies = [
  "libgpiod",
  "log",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2131,13 +2143,13 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
- "vhost",
- "vhost-user-backend",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
  "virglrenderer",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2150,12 +2162,12 @@ dependencies = [
  "libc 0.2.186",
  "log",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2173,12 +2185,12 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2194,12 +2206,12 @@ dependencies = [
  "rand",
  "tempfile",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2213,12 +2225,12 @@ dependencies = [
  "log",
  "nix 0.31.2",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2231,12 +2243,12 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2250,12 +2262,12 @@ dependencies = [
  "log",
  "tempfile",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2275,12 +2287,12 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2294,12 +2306,12 @@ dependencies = [
  "libc 0.2.186",
  "log",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2312,12 +2324,12 @@ dependencies = [
  "libc 0.2.186",
  "log",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "vhost-user-backend 0.21.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2328,21 +2340,37 @@ dependencies = [
  "byteorder",
  "clap",
  "env_logger",
- "epoll",
  "figment",
  "libc 0.2.186",
  "log",
+ "mio",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
- "vhost",
- "vhost-user-backend",
- "virtio-bindings",
- "virtio-queue",
+ "vhost 0.14.0",
+ "vhost-user-backend 0.20.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0",
  "virtio-vsock",
- "vm-memory",
- "vmm-sys-util",
+ "vm-memory 0.16.1",
+ "vmm-sys-util 0.15.0",
  "vsock",
+]
+
+[[package]]
+name = "vhost-user-backend"
+version = "0.20.0"
+source = "git+https://github.com/eric-14/rust_vhost_.git?branch=experimental_mac#4f0384ab5b24593c3af467613c87fb4975e7a5d6"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc 0.2.186",
+ "log",
+ "mio",
+ "vhost 0.14.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.16.0",
+ "vm-memory 0.16.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2353,11 +2381,11 @@ checksum = "783587813a59c42c36519a6e12bb31eb2d7fa517377428252ba4cc2312584243"
 dependencies = [
  "libc 0.2.186",
  "log",
- "vhost",
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util",
+ "vhost 0.15.0",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "virtio-queue 0.17.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -2389,6 +2417,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f498a26d5a63be7bbb8bdcd3869c3f286c4c4a17108905276454da0caf8cb"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.6"
+source = "git+https://github.com/uran0sh/vm-virtio.git?branch=update-vm-memory#9f91e13a2d29c98e539e94eb8dfb15e53b429642"
+
+[[package]]
+name = "virtio-queue"
+version = "0.16.0"
+source = "git+https://github.com/uran0sh/vm-virtio.git?branch=update-vm-memory#9f91e13a2d29c98e539e94eb8dfb15e53b429642"
+dependencies = [
+ "libc 0.2.186",
+ "log",
+ "virtio-bindings 0.2.6 (git+https://github.com/uran0sh/vm-virtio.git?branch=update-vm-memory)",
+ "vm-memory 0.16.1",
+ "vmm-sys-util 0.14.0",
+]
+
+[[package]]
 name = "virtio-queue"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,20 +2441,32 @@ checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
 dependencies = [
  "libc 0.2.186",
  "log",
- "virtio-bindings",
- "vm-memory",
- "vmm-sys-util",
+ "virtio-bindings 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "virtio-vsock"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7822f0d005c2451d4cdbb42cc9581cabb42a0fb64347efe5492fa548e8931a"
+version = "0.10.0"
+source = "git+https://github.com/uran0sh/vm-virtio.git?branch=update-vm-memory#9f91e13a2d29c98e539e94eb8dfb15e53b429642"
 dependencies = [
- "virtio-bindings",
- "virtio-queue",
- "vm-memory",
+ "virtio-bindings 0.2.6 (git+https://github.com/uran0sh/vm-virtio.git?branch=update-vm-memory)",
+ "virtio-queue 0.16.0",
+ "vm-memory 0.16.1",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.16.1"
+source = "git+https://github.com/rust-vmm/vm-memory.git?rev=b2eaf989de2c3b9146ea7625250472501cd793fd#b2eaf989de2c3b9146ea7625250472501cd793fd"
+dependencies = [
+ "arc-swap",
+ "bitflags 2.11.1",
+ "libc 0.2.186",
+ "thiserror 1.0.69",
+ "vmm-sys-util 0.12.1",
+ "winapi",
 ]
 
 [[package]]
@@ -2422,8 +2479,28 @@ dependencies = [
  "bitflags 2.11.1",
  "libc 0.2.186",
  "thiserror 2.0.18",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
  "winapi",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc 0.2.186",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc 0.2.186",
 ]
 
 [[package]]

--- a/vhost-device-vsock/Cargo.toml
+++ b/vhost-device-vsock/Cargo.toml
@@ -18,15 +18,15 @@ xen = ["vm-memory/xen", "vhost/xen", "vhost-user-backend/xen"]
 byteorder = "1"
 clap = { version = "4.6",  features = ["derive"] }
 env_logger = "0.11"
-epoll = "4.4.0"
+mio = { version = "1.0.4", features = ["os-poll", "os-ext"] }
 log = "0.4"
 thiserror = "2.0"
-vhost = { workspace = true }
-vhost-user-backend = { workspace = true }
+vhost = { git="https://github.com/eric-14/rust_vhost_.git", branch="experimental_mac" }
+vhost-user-backend = { git="https://github.com/eric-14/rust_vhost_.git", branch="experimental_mac" }
 virtio-bindings = { workspace = true }
-virtio-queue = { workspace = true }
-virtio-vsock = "0.11"
-vm-memory = { workspace = true }
+virtio-queue = { git = "https://github.com/uran0sh/vm-virtio.git", branch = "update-vm-memory" }
+virtio-vsock = { git = "https://github.com/uran0sh/vm-virtio.git", branch = "update-vm-memory" }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory.git", rev = "b2eaf989de2c3b9146ea7625250472501cd793fd", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vmm-sys-util = { workspace = true }
 figment = { version = "0.10.19", features = ["yaml"] }
 vsock = { version = "0.5.4", optional = true }
@@ -35,7 +35,7 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5"
-virtio-queue = { workspace = true, features = ["test-utils"] }
+virtio-queue = { git = "https://github.com/uran0sh/vm-virtio.git", branch = "update-vm-memory", features = ["test-utils"] }
 tempfile = "3.27.0"
 
 [lints]

--- a/vhost-device-vsock/src/thread_backend.rs
+++ b/vhost-device-vsock/src/thread_backend.rs
@@ -9,10 +9,11 @@ use std::{
         prelude::{AsRawFd, RawFd},
     },
     result::Result as StdResult,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use log::{info, warn};
+use mio::Poll;
 use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
 use vm_memory::{
     bitmap::BitmapSlice, ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile,
@@ -202,8 +203,8 @@ pub(crate) struct VsockThreadBackend {
     pub stream_map: HashMap<i32, StreamType>,
     /// Host side socket info for listening to new connections from the host.
     backend_info: BackendType,
-    /// epoll for registering new host-side connections.
-    epoll_fd: i32,
+    /// Poller for registering new host-side connections.
+    poller: Arc<Mutex<Poll>>,
     /// CID of the guest.
     guest_cid: u64,
     /// Set of allocated local ports.
@@ -224,7 +225,7 @@ impl VsockThreadBackend {
     /// New instance of VsockThreadBackend.
     pub fn new(
         backend_info: BackendType,
-        epoll_fd: i32,
+        poller: Arc<Mutex<Poll>>,
         guest_cid: u64,
         tx_buffer_size: u32,
         groups_set: Arc<RwLock<HashSet<String>>>,
@@ -238,7 +239,7 @@ impl VsockThreadBackend {
             // TODO: think of a better solution
             stream_map: HashMap::new(),
             backend_info,
-            epoll_fd,
+            poller,
             guest_cid,
             local_port_set: HashSet::new(),
             tx_buffer_size,
@@ -280,7 +281,7 @@ impl VsockThreadBackend {
             self.listener_map.remove(&conn.stream.as_raw_fd());
             self.stream_map.remove(&conn.stream.as_raw_fd());
             self.local_port_set.remove(&conn.local_port);
-            VhostUserVsockThread::epoll_unregister(conn.epoll_fd, conn.stream.as_raw_fd())
+            VhostUserVsockThread::epoll_unregister(&conn.poller, conn.stream.as_raw_fd())
                 .unwrap_or_else(|err| {
                     warn!(
                         "Could not remove epoll listener for fd {:?}: {:?}",
@@ -332,7 +333,7 @@ impl VsockThreadBackend {
             if dst_cid != VSOCK_HOST_CID {
                 let cid_map = self.cid_map.read().unwrap();
                 if cid_map.contains_key(&dst_cid) {
-                    let (sibling_raw_pkts_queue, sibling_groups_set, sibling_event_fd) =
+                    let (sibling_raw_pkts_queue, sibling_groups_set, sibling_event_notifier) =
                         cid_map.get(&dst_cid).unwrap();
 
                     if self
@@ -349,7 +350,7 @@ impl VsockThreadBackend {
                         .write()
                         .unwrap()
                         .push_back(RawVsockPacket::from_vsock_packet(pkt)?);
-                    let _ = sibling_event_fd.write(1);
+                    let _ = sibling_event_notifier.notify();
                 } else {
                     warn!("vsock: dropping packet for unknown cid: {dst_cid:?}");
                 }
@@ -388,7 +389,7 @@ impl VsockThreadBackend {
             self.listener_map.remove(&conn.stream.as_raw_fd());
             self.stream_map.remove(&conn.stream.as_raw_fd());
             self.local_port_set.remove(&conn.local_port);
-            VhostUserVsockThread::epoll_unregister(conn.epoll_fd, conn.stream.as_raw_fd())
+            VhostUserVsockThread::epoll_unregister(&conn.poller, conn.stream.as_raw_fd())
                 .unwrap_or_else(|err| {
                     warn!(
                         "Could not remove epoll listener for fd {:?}: {:?}",
@@ -481,7 +482,7 @@ impl VsockThreadBackend {
             pkt.dst_port(),
             pkt.src_cid(),
             pkt.src_port(),
-            self.epoll_fd,
+            self.poller.clone(),
             pkt.buf_alloc(),
             self.tx_buffer_size,
         );
@@ -498,9 +499,9 @@ impl VsockThreadBackend {
         self.local_port_set.insert(pkt.dst_port());
 
         VhostUserVsockThread::epoll_register(
-            self.epoll_fd,
+            &self.poller,
             stream_fd,
-            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+            mio::Interest::READABLE | mio::Interest::WRITABLE,
         )?;
         Ok(())
     }
@@ -535,7 +536,7 @@ mod tests {
     fn test_vsock_thread_backend(backend_info: BackendType) {
         const CID: u64 = 3;
 
-        let epoll_fd = epoll::create(false).unwrap();
+        let poller = Arc::new(Mutex::new(Poll::new().unwrap()));
 
         let groups_set: HashSet<String> = vec![GROUP_NAME.to_string()].into_iter().collect();
 
@@ -543,7 +544,7 @@ mod tests {
 
         let mut vtp = VsockThreadBackend::new(
             backend_info,
-            epoll_fd,
+            poller.clone(),
             CID,
             CONN_TX_BUF_SIZE,
             Arc::new(RwLock::new(groups_set)),
@@ -673,8 +674,7 @@ mod tests {
             Arc::new(VhostUserVsockBackend::new(sibling_config, cid_map.clone()).unwrap());
         let sibling2_backend =
             Arc::new(VhostUserVsockBackend::new(sibling2_config, cid_map.clone()).unwrap());
-
-        let epoll_fd = epoll::create(false).unwrap();
+        let poller = Arc::new(Mutex::new(Poll::new().unwrap()));
 
         let groups_set: HashSet<String> = vec!["groupA", "groupB", "group3"]
             .into_iter()
@@ -683,7 +683,7 @@ mod tests {
 
         let mut vtp = VsockThreadBackend::new(
             BackendType::UnixDomainSocket(vsock_socket_path),
-            epoll_fd,
+            poller,
             CID,
             CONN_TX_BUF_SIZE,
             Arc::new(RwLock::new(groups_set)),

--- a/vhost-device-vsock/src/vhu_vsock.rs
+++ b/vhost-device-vsock/src/vhu_vsock.rs
@@ -10,22 +10,26 @@ use std::{
 use log::warn;
 use thiserror::Error as ThisError;
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
-use vhost_user_backend::{VhostUserBackend, VringRwLock};
+use vhost_user_backend::{EventSet, VhostUserBackend, VringRwLock};
 use virtio_bindings::bindings::{
     virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1},
     virtio_ring::VIRTIO_RING_F_EVENT_IDX,
 };
 use vm_memory::{ByteValued, GuestMemoryAtomic, GuestMemoryMmap, Le64};
-use vmm_sys_util::{
-    epoll::EventSet,
-    event::{new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier},
-    eventfd::EventFd,
+use vmm_sys_util::event::{
+    new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
 };
 
 use crate::{thread_backend::RawPktsQ, vhu_vsock_thread::*};
 
-pub(crate) type CidMap =
-    HashMap<u64, (Arc<RwLock<RawPktsQ>>, Arc<RwLock<HashSet<String>>>, EventFd)>;
+pub(crate) type CidMap = HashMap<
+    u64,
+    (
+        Arc<RwLock<RawPktsQ>>,
+        Arc<RwLock<HashSet<String>>>,
+        EventNotifier,
+    ),
+>;
 
 const NUM_QUEUES: usize = 3;
 
@@ -104,7 +108,7 @@ pub(crate) enum Error {
     ParseInteger(std::num::ParseIntError),
     #[error("Error reading stream port")]
     ReadStreamPort(Box<Error>),
-    #[error("Failed to de-register fd from epoll")]
+    #[error("Failed to de-register fd from mio::poll")]
     EpollRemove(std::io::Error),
     #[error("No memory configured")]
     NoMemoryConfigured,
@@ -135,8 +139,8 @@ pub(crate) enum Error {
     NoFreeLocalPort,
     #[error("Backend rx queue is empty")]
     EmptyBackendRxQ,
-    #[error("Failed to create an EventFd")]
-    EventFdCreate(std::io::Error),
+    #[error("Failed to create an EventFlag")]
+    EventFlagCreate(std::io::Error),
     #[error("Raw vsock packets queue is empty")]
     EmptyRawPktsQueue,
     #[error("CID already in use by another vsock device")]
@@ -275,7 +279,7 @@ impl VhostUserVsockBackend {
         let queues_per_thread = vec![QUEUE_MASK];
 
         let (exit_consumer, exit_notifier) =
-            new_event_consumer_and_notifier(EventFlag::NONBLOCK).map_err(Error::EventFdCreate)?;
+            new_event_consumer_and_notifier(EventFlag::NONBLOCK).map_err(Error::EventFlagCreate)?;
 
         Ok(Self {
             config: VirtioVsockConfig {
@@ -336,7 +340,7 @@ impl VhostUserBackend for VhostUserVsockBackend {
         let vring_rx = &vrings[0];
         let vring_tx = &vrings[1];
 
-        if evset != EventSet::IN {
+        if evset != EventSet::READABLE {
             return Err(Error::HandleEventNotEpollIn.into());
         }
 
@@ -363,7 +367,7 @@ impl VhostUserBackend for VhostUserVsockBackend {
                 }
             }
             SIBLING_VM_EVENT => {
-                let _ = thread.sibling_event_fd.read();
+                let _ = thread.sibling_event_consumer.consume();
                 thread.process_raw_pkts(vring_rx, evt_idx)?;
                 return Ok(());
             }
@@ -458,16 +462,16 @@ mod tests {
         let (_, notifier) = exit.unwrap();
         notifier.notify().unwrap();
 
-        let ret = backend.handle_event(RX_QUEUE_EVENT, EventSet::IN, &vrings, 0);
+        let ret = backend.handle_event(RX_QUEUE_EVENT, EventSet::READABLE, &vrings, 0);
         ret.unwrap();
 
-        let ret = backend.handle_event(TX_QUEUE_EVENT, EventSet::IN, &vrings, 0);
+        let ret = backend.handle_event(TX_QUEUE_EVENT, EventSet::READABLE, &vrings, 0);
         ret.unwrap();
 
-        let ret = backend.handle_event(EVT_QUEUE_EVENT, EventSet::IN, &vrings, 0);
+        let ret = backend.handle_event(EVT_QUEUE_EVENT, EventSet::READABLE, &vrings, 0);
         ret.unwrap();
 
-        let ret = backend.handle_event(BACKEND_EVENT, EventSet::IN, &vrings, 0);
+        let ret = backend.handle_event(BACKEND_EVENT, EventSet::READABLE, &vrings, 0);
         ret.unwrap();
     }
 
@@ -579,14 +583,14 @@ mod tests {
 
         assert_eq!(
             backend
-                .handle_event(RX_QUEUE_EVENT, EventSet::OUT, &vrings, 0)
+                .handle_event(RX_QUEUE_EVENT, EventSet::WRITABLE, &vrings, 0)
                 .unwrap_err()
                 .to_string(),
             Error::HandleEventNotEpollIn.to_string()
         );
         assert_eq!(
             backend
-                .handle_event(SIBLING_VM_EVENT + 1, EventSet::IN, &vrings, 0)
+                .handle_event(SIBLING_VM_EVENT + 1, EventSet::READABLE, &vrings, 0)
                 .unwrap_err()
                 .to_string(),
             Error::HandleUnknownEvent.to_string()

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -2,30 +2,30 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    fs::File,
     io::{self, BufRead, BufReader},
     iter::FromIterator,
     num::Wrapping,
     ops::Deref,
     os::unix::{
         net::{UnixListener, UnixStream},
-        prelude::{AsRawFd, FromRawFd, RawFd},
+        prelude::{AsRawFd, RawFd},
     },
     sync::{
         mpsc::{self, Sender},
-        Arc, RwLock,
+        Arc, Mutex, RwLock,
     },
     thread,
+    time::Duration,
 };
 
 use log::{error, warn};
-use vhost_user_backend::{VringEpollHandler, VringRwLock, VringT};
+use mio::{unix::SourceFd, Events, Interest, Poll, Token};
+use vhost_user_backend::{EventSet, VringEpollHandler, VringRwLock, VringT};
 use virtio_queue::QueueOwnedT;
 use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
 use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryMmap};
-use vmm_sys_util::{
-    epoll::EventSet,
-    eventfd::{EventFd, EFD_NONBLOCK},
+use vmm_sys_util::event::{
+    new_event_consumer_and_notifier, EventConsumer, EventFlag, EventNotifier,
 };
 #[cfg(feature = "backend_vsock")]
 use vsock::{VsockListener, VMADDR_CID_ANY};
@@ -69,8 +69,9 @@ pub(crate) struct VhostUserVsockThread {
     backend_info: BackendType,
     /// Host socket raw file descriptor and listener.
     host_listeners_map: HashMap<i32, ListenerType>,
-    /// epoll fd to which new host connections are added.
-    epoll_file: File,
+    /// poll fd to which new host connections are added.
+    //poller which host connections are added
+    poller: Arc<Mutex<Poll>>,
     /// VsockThreadBackend instance.
     pub thread_backend: VsockThreadBackend,
     /// CID of the guest.
@@ -81,10 +82,13 @@ pub(crate) struct VhostUserVsockThread {
     local_port: Wrapping<u32>,
     /// The tx buffer size
     tx_buffer_size: u32,
-    /// EventFd to notify this thread for custom events. Currently used to
+    /// EventConsumer to consume custom events. Currently used to
     /// notify this thread to process raw vsock packets sent from a sibling
     /// VM.
-    pub sibling_event_fd: EventFd,
+    pub sibling_event_consumer: EventConsumer,
+    /// EventNotifier used by sibling devices to wake this thread.
+    _sibling_event_notifier: EventNotifier,
+
     /// Keeps track of which RX queue was processed first in the last iteration.
     /// Used to alternate between the RX queues to prevent the starvation of one
     /// by the other.
@@ -123,19 +127,18 @@ impl VhostUserVsockThread {
             }
         }
 
-        let epoll_fd = epoll::create(true).map_err(Error::EpollFdCreate)?;
-        // SAFETY: Safe as the fd is guaranteed to be valid here.
-        let epoll_file = unsafe { File::from_raw_fd(epoll_fd) };
+        let poller = Arc::new(Mutex::new(Poll::new().map_err(Error::EpollFdCreate)?));
 
         let mut groups = groups;
         let groups_set: Arc<RwLock<HashSet<String>>> =
             Arc::new(RwLock::new(HashSet::from_iter(groups.drain(..))));
 
-        let sibling_event_fd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+        let (sibling_event_consumer, sibling_event_notifier) =
+            new_event_consumer_and_notifier(EventFlag::NONBLOCK).map_err(Error::EventFlagCreate)?;
 
         let thread_backend = VsockThreadBackend::new(
             backend_info.clone(),
-            epoll_fd,
+            poller.clone(),
             guest_cid,
             tx_buffer_size,
             groups_set.clone(),
@@ -153,7 +156,7 @@ impl VhostUserVsockThread {
                 (
                     thread_backend.raw_pkts_queue.clone(),
                     groups_set,
-                    sibling_event_fd.try_clone().unwrap(),
+                    sibling_event_notifier.try_clone().unwrap(),
                 ),
             );
         }
@@ -172,18 +175,19 @@ impl VhostUserVsockThread {
             event_idx: false,
             backend_info: backend_info.clone(),
             host_listeners_map,
-            epoll_file,
+            poller,
             thread_backend,
             guest_cid,
             sender,
             local_port: Wrapping(0),
             tx_buffer_size,
-            sibling_event_fd,
+            sibling_event_consumer,
+            _sibling_event_notifier: sibling_event_notifier,
             last_processed: RxQueueType::Standard,
         };
 
         for host_raw_fd in thread.host_listeners_map.keys() {
-            VhostUserVsockThread::epoll_register(epoll_fd, *host_raw_fd, epoll::Events::EPOLLIN)?;
+            VhostUserVsockThread::epoll_register(&thread.poller, *host_raw_fd, Interest::READABLE)?;
         }
 
         Ok(thread)
@@ -220,59 +224,67 @@ impl VhostUserVsockThread {
             event_data.vring.signal_used_queue().unwrap();
         }
     }
-    /// Register a file with an epoll to listen for events in evset.
-    pub fn epoll_register(epoll_fd: RawFd, fd: RawFd, evset: epoll::Events) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_ADD,
-            fd,
-            epoll::Event::new(evset, fd as u64),
-        )
-        .map_err(Error::EpollAdd)?;
+
+    /// Register a file with an mio::poll to listen for events in interests.
+    pub fn epoll_register(poller: &Arc<Mutex<Poll>>, fd: RawFd, interests: Interest) -> Result<()> {
+        let mut source = SourceFd(&fd);
+
+        poller
+            .lock()
+            .unwrap()
+            .registry()
+            .register(&mut source, Token(fd as usize), interests)
+            .map_err(Error::EpollAdd)?;
 
         Ok(())
     }
 
-    /// Remove a file from the epoll.
-    pub fn epoll_unregister(epoll_fd: RawFd, fd: RawFd) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_DEL,
-            fd,
-            epoll::Event::new(epoll::Events::empty(), 0),
-        )
-        .map_err(Error::EpollRemove)?;
+    /// Remove a file from the mio::poller.
+    pub fn epoll_unregister(poller: &Arc<Mutex<Poll>>, fd: RawFd) -> Result<()> {
+        let mut source = SourceFd(&fd);
+
+        poller
+            .lock()
+            .unwrap()
+            .registry()
+            .deregister(&mut source)
+            .map_err(Error::EpollRemove)?;
 
         Ok(())
     }
 
-    /// Modify the events we listen to for the fd in the epoll.
-    pub fn epoll_modify(epoll_fd: RawFd, fd: RawFd, evset: epoll::Events) -> Result<()> {
-        epoll::ctl(
-            epoll_fd,
-            epoll::ControlOptions::EPOLL_CTL_MOD,
-            fd,
-            epoll::Event::new(evset, fd as u64),
-        )
-        .map_err(Error::EpollModify)?;
+    /// Modify the interests we listen to for the fd in the mio::poll.
+    pub fn epoll_modify(poller: &Arc<Mutex<Poll>>, fd: RawFd, interests: Interest) -> Result<()> {
+        let mut source = SourceFd(&fd);
+
+        poller
+            .lock()
+            .unwrap()
+            .registry()
+            .reregister(&mut source, Token(fd as usize), interests)
+            .map_err(Error::EpollModify)?;
 
         Ok(())
     }
 
     /// Return raw file descriptor of the epoll file.
     fn get_epoll_fd(&self) -> RawFd {
-        self.epoll_file.as_raw_fd()
+        self.poller.lock().unwrap().as_raw_fd()
     }
 
     /// Register our listeners in the VringEpollHandler
-    pub fn register_listeners(&mut self, epoll_handler: Arc<VringEpollHandler<ArcVhostBknd>>) {
-        epoll_handler
-            .register_listener(self.get_epoll_fd(), EventSet::IN, u64::from(BACKEND_EVENT))
-            .unwrap();
-        epoll_handler
+    pub fn register_listeners(&mut self, poll_handler: Arc<VringEpollHandler<ArcVhostBknd>>) {
+        poll_handler
             .register_listener(
-                self.sibling_event_fd.as_raw_fd(),
-                EventSet::IN,
+                self.get_epoll_fd(),
+                EventSet::READABLE,
+                u64::from(BACKEND_EVENT),
+            )
+            .unwrap();
+        poll_handler
+            .register_listener(
+                self.sibling_event_consumer.as_raw_fd(),
+                EventSet::READABLE,
                 u64::from(SIBLING_VM_EVENT),
             )
             .unwrap();
@@ -280,31 +292,41 @@ impl VhostUserVsockThread {
 
     /// Process a BACKEND_EVENT received by VhostUserVsockBackend.
     pub fn process_backend_evt(&mut self, _evset: EventSet) {
-        let mut epoll_events = vec![epoll::Event::new(epoll::Events::empty(), 0); 32];
-        'epoll: loop {
-            match epoll::wait(self.epoll_file.as_raw_fd(), 0, epoll_events.as_mut_slice()) {
-                Ok(ev_cnt) => {
-                    for evt in epoll_events.iter().take(ev_cnt) {
-                        self.handle_event(
-                            evt.data as RawFd,
-                            epoll::Events::from_bits(evt.events).unwrap(),
-                        );
+        let mut events = Events::with_capacity(32);
+        loop {
+            let polled = self
+                .poller
+                .lock()
+                .unwrap()
+                .poll(&mut events, Some(Duration::ZERO));
+            match polled {
+                Ok(()) => {
+                    let ready: Vec<(RawFd, bool)> = events
+                        .iter()
+                        .map(|event| {
+                            (
+                                event.token().0.try_into().unwrap_or(-1) as RawFd,
+                                event.is_writable(),
+                            )
+                        })
+                        .collect();
+                    for (fd, writable) in ready {
+                        self.handle_event(fd, writable);
                     }
+                    break;
                 }
-                Err(e) => {
-                    if e.kind() == io::ErrorKind::Interrupted {
-                        continue;
-                    }
-                    warn!("failed to consume new epoll event");
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(_) => {
+                    warn!("failed to consume new poll event");
+                    break;
                 }
             }
-            break 'epoll;
         }
     }
 
     /// Handle a BACKEND_EVENT by either accepting a new connection or
     /// forwarding a request to the appropriate connection object.
-    fn handle_event(&mut self, fd: RawFd, evset: epoll::Events) {
+    fn handle_event(&mut self, fd: RawFd, writable: bool) {
         if let Some(listener) = self.host_listeners_map.get(&fd) {
             // This is a new connection initiated by an application running on the host
             match listener {
@@ -357,11 +379,11 @@ impl VhostUserVsockThread {
                                     peer_port,
                                 );
                                 if let Err(err) = Self::epoll_register(
-                                    self.get_epoll_fd(),
+                                    &self.poller,
                                     stream_raw_fd,
-                                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                                    Interest::READABLE | Interest::WRITABLE,
                                 ) {
-                                    warn!("Failed to register with epoll: {err:?}");
+                                    warn!("Failed to register with poller: {err:?}");
                                 }
                             }
                             Err(err) => {
@@ -382,8 +404,8 @@ impl VhostUserVsockThread {
                 self.thread_backend.listener_map.entry(fd)
             {
                 // New connection from the host
-                if evset.bits() != epoll::Events::EPOLLIN.bits() {
-                    // Has to be EPOLLIN as it was not connected previously
+                if writable {
+                    // A brand-new host connection must first arrive as readable.
                     return;
                 }
                 let mut stream = match self.thread_backend.stream_map.remove(&fd) {
@@ -420,11 +442,11 @@ impl VhostUserVsockThread {
 
                         self.add_new_connection_from_host(fd, stream, local_port, peer_port);
 
-                        // Re-register the fd to listen for EPOLLIN and EPOLLOUT events
+                        // Re-register the fd to listen for readable and writable events.
                         Self::epoll_modify(
-                            self.get_epoll_fd(),
+                            &self.poller,
                             fd,
-                            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                            Interest::READABLE | Interest::WRITABLE,
                         )
                         .unwrap();
                     }
@@ -432,12 +454,10 @@ impl VhostUserVsockThread {
             } else {
                 // Previously connected connection
 
-                // Get epoll fd before getting conn as that takes self mut ref
-                let epoll_fd = self.get_epoll_fd();
                 let key = self.thread_backend.listener_map.get(&fd).unwrap();
                 let conn = self.thread_backend.conn_map.get_mut(key).unwrap();
 
-                if evset.bits() == epoll::Events::EPOLLOUT.bits() {
+                if writable {
                     // Flush any remaining data from the tx buffer
                     match conn.tx_buf.flush_to(&mut conn.stream) {
                         Ok(cnt) => {
@@ -445,10 +465,10 @@ impl VhostUserVsockThread {
                                 conn.fwd_cnt += Wrapping(cnt as u32);
                                 conn.rx_queue.enqueue(RxOps::CreditUpdate);
                             } else {
-                                // If no remaining data to flush, try to disable EPOLLOUT
-                                if Self::epoll_modify(epoll_fd, fd, epoll::Events::EPOLLIN).is_err()
+                                // If no remaining data to flush, keep only readable interest.
+                                if Self::epoll_modify(&self.poller, fd, Interest::READABLE).is_err()
                                 {
-                                    error!("Failed to disable EPOLLOUT");
+                                    error!("Failed to disable writable interest");
                                 }
                             }
                             self.thread_backend
@@ -462,9 +482,9 @@ impl VhostUserVsockThread {
                     return;
                 }
 
-                // Unregister stream from the epoll, register when connection is
-                // established with the guest
-                Self::epoll_unregister(self.epoll_file.as_raw_fd(), fd).unwrap();
+                // Unregister the stream from the poller and register it again when the
+                // connection is established with the guest
+                let _ = Self::epoll_unregister(&self.poller, fd);
 
                 // Enqueue a read request
                 conn.rx_queue.enqueue(RxOps::Rw);
@@ -496,7 +516,7 @@ impl VhostUserVsockThread {
             local_port,
             self.guest_cid,
             peer_port,
-            self.get_epoll_fd(),
+            self.poller.clone(),
             self.tx_buffer_size,
         );
         new_conn.rx_queue.enqueue(RxOps::Request);
@@ -564,17 +584,13 @@ impl VhostUserVsockThread {
             .map_err(|e| Error::ReadStreamPort(Box::new(e)))
     }
 
-    /// Add a stream to epoll to listen for EPOLLIN events.
+    /// Add a stream to the poller with readable interest.
     fn add_stream_listener(&mut self, stream: UnixStream) -> Result<()> {
         let stream_fd = stream.as_raw_fd();
         self.thread_backend
             .stream_map
             .insert(stream_fd, StreamType::Unix(stream));
-        VhostUserVsockThread::epoll_register(
-            self.get_epoll_fd(),
-            stream_fd,
-            epoll::Events::EPOLLIN,
-        )?;
+        VhostUserVsockThread::epoll_register(&self.poller, stream_fd, Interest::READABLE)?;
 
         Ok(())
     }
@@ -826,7 +842,7 @@ mod tests {
 
     use tempfile::tempdir;
     use vm_memory::GuestAddress;
-    use vmm_sys_util::eventfd::EventFd;
+    use vmm_sys_util::event::{new_event_consumer_and_notifier, EventFlag};
     #[cfg(feature = "backend_vsock")]
     use vsock::{VsockStream, VMADDR_CID_LOCAL};
 
@@ -835,12 +851,6 @@ mod tests {
     use crate::vhu_vsock::VsockProxyInfo;
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
-
-    impl VhostUserVsockThread {
-        fn get_epoll_file(&self) -> &File {
-            &self.epoll_file
-        }
-    }
 
     fn test_vsock_thread(backend_info: BackendType) {
         let groups: Vec<String> = vec![String::from("default")];
@@ -851,31 +861,20 @@ mod tests {
         assert!(t.is_ok());
 
         let mut t = t.unwrap();
-        let epoll_fd = t.get_epoll_file().as_raw_fd();
-
         let mem = GuestMemoryAtomic::new(
             GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap(),
         );
 
         t.mem = Some(mem.clone());
 
-        let dummy_fd = EventFd::new(0).unwrap();
+        let (dummy_fd, _dummy_notifier) =
+            new_event_consumer_and_notifier(EventFlag::NONBLOCK).unwrap();
 
-        VhostUserVsockThread::epoll_register(
-            epoll_fd,
-            dummy_fd.as_raw_fd(),
-            epoll::Events::EPOLLOUT,
-        )
-        .unwrap();
-        VhostUserVsockThread::epoll_modify(epoll_fd, dummy_fd.as_raw_fd(), epoll::Events::EPOLLIN)
+        VhostUserVsockThread::epoll_register(&t.poller, dummy_fd.as_raw_fd(), Interest::WRITABLE)
             .unwrap();
-        VhostUserVsockThread::epoll_unregister(epoll_fd, dummy_fd.as_raw_fd()).unwrap();
-        VhostUserVsockThread::epoll_register(
-            epoll_fd,
-            dummy_fd.as_raw_fd(),
-            epoll::Events::EPOLLIN,
-        )
-        .unwrap();
+        VhostUserVsockThread::epoll_modify(&t.poller, dummy_fd.as_raw_fd(), Interest::READABLE)
+            .unwrap();
+        VhostUserVsockThread::epoll_unregister(&t.poller, dummy_fd.as_raw_fd()).unwrap();
 
         let vring = VringRwLock::new(mem, 0x1000).unwrap();
         vring.set_queue_info(0x100, 0x200, 0x300).unwrap();
@@ -905,7 +904,7 @@ mod tests {
             used_len: 0,
         });
 
-        dummy_fd.write(1).unwrap();
+        _dummy_notifier.notify().unwrap();
 
         t.process_backend_evt(EventSet::empty());
     }
@@ -955,9 +954,14 @@ mod tests {
             cid_map.clone(),
         )
         .unwrap();
-        assert!(VhostUserVsockThread::epoll_register(-1, -1, epoll::Events::EPOLLIN).is_err());
-        assert!(VhostUserVsockThread::epoll_modify(-1, -1, epoll::Events::EPOLLIN).is_err());
-        assert!(VhostUserVsockThread::epoll_unregister(-1, -1).is_err());
+        let invalid_poller = Arc::new(Mutex::new(Poll::new().unwrap()));
+        assert!(
+            VhostUserVsockThread::epoll_register(&invalid_poller, -1, Interest::READABLE).is_err()
+        );
+        assert!(
+            VhostUserVsockThread::epoll_modify(&invalid_poller, -1, Interest::READABLE).is_err()
+        );
+        assert!(VhostUserVsockThread::epoll_unregister(&invalid_poller, -1).is_err());
 
         let mem = GuestMemoryAtomic::new(
             GuestMemoryMmap::<()>::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap(),

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -3,10 +3,12 @@
 use std::{
     io::{ErrorKind, Write},
     num::Wrapping,
-    os::unix::prelude::{AsRawFd, RawFd},
+    os::unix::prelude::AsRawFd,
+    sync::{Arc, Mutex},
 };
 
 use log::{error, info};
+use mio::{Interest, Poll};
 use virtio_vsock::packet::{VsockPacket, PKT_HEADER_SIZE};
 use vm_memory::{bitmap::BitmapSlice, ReadVolatile, VolatileSlice, WriteVolatile};
 
@@ -48,8 +50,8 @@ pub(crate) struct VsockConnection<S> {
     peer_fwd_cnt: Wrapping<u32>,
     /// The total number of bytes sent to the guest vsock driver.
     rx_cnt: Wrapping<u32>,
-    /// epoll fd to which this connection's stream has to be added.
-    pub epoll_fd: RawFd,
+    /// Poller used to manage this connection's stream readiness.
+    pub poller: Arc<Mutex<Poll>>,
     /// Local tx buffer.
     pub tx_buf: LocalTxBuf,
     /// Local tx buffer size
@@ -65,7 +67,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
         local_port: u32,
         guest_cid: u64,
         guest_port: u32,
-        epoll_fd: RawFd,
+        poller: Arc<Mutex<Poll>>,
         tx_buffer_size: u32,
     ) -> Self {
         Self {
@@ -81,7 +83,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             peer_buf_alloc: 0,
             peer_fwd_cnt: Wrapping(0),
             rx_cnt: Wrapping(0),
-            epoll_fd,
+            poller,
             tx_buf: LocalTxBuf::new(tx_buffer_size),
             tx_buffer_size,
         }
@@ -96,7 +98,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
         local_port: u32,
         guest_cid: u64,
         guest_port: u32,
-        epoll_fd: RawFd,
+        poller: Arc<Mutex<Poll>>,
         peer_buf_alloc: u32,
         tx_buffer_size: u32,
     ) -> Self {
@@ -115,7 +117,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
             peer_buf_alloc,
             peer_fwd_cnt: Wrapping(0),
             rx_cnt: Wrapping(0),
-            epoll_fd,
+            poller,
             tx_buf: LocalTxBuf::new(tx_buffer_size),
             tx_buffer_size,
         }
@@ -177,20 +179,20 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
 
                         // Re-register the stream file descriptor for read and write events
                         if VhostUserVsockThread::epoll_modify(
-                            self.epoll_fd,
+                            &self.poller,
                             self.stream.as_raw_fd(),
-                            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                            Interest::READABLE | Interest::WRITABLE,
                         )
                         .is_err()
                         {
                             if let Err(e) = VhostUserVsockThread::epoll_register(
-                                self.epoll_fd,
+                                &self.poller,
                                 self.stream.as_raw_fd(),
-                                epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                                Interest::READABLE | Interest::WRITABLE,
                             ) {
                                 // TODO: let's move this logic out of this func, and handle it
                                 // properly
-                                error!("epoll_register failed: {e:?}, but proceed further.");
+                                error!("poll_register failed: {e:?}, but proceed further.");
                             }
                         };
                     }
@@ -263,19 +265,19 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
 
                 // Re-register the stream file descriptor for read and write events
                 if VhostUserVsockThread::epoll_modify(
-                    self.epoll_fd,
+                    &self.poller,
                     self.stream.as_raw_fd(),
-                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                    Interest::READABLE | Interest::WRITABLE,
                 )
                 .is_err()
                 {
                     if let Err(e) = VhostUserVsockThread::epoll_register(
-                        self.epoll_fd,
+                        &self.poller,
                         self.stream.as_raw_fd(),
-                        epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                        Interest::READABLE | Interest::WRITABLE,
                     ) {
                         // TODO: let's move this logic out of this func, and handle it properly
-                        error!("epoll_register failed: {e:?}, but proceed further.");
+                        error!("poll_register failed: {e:?}, but proceed further.");
                     }
                 };
             }
@@ -306,7 +308,7 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
     fn send_bytes<B: BitmapSlice>(&mut self, buf: &VolatileSlice<B>) -> Result<()> {
         if !self.tx_buf.is_empty() {
             // Data is already present in the buffer and the backend
-            // is waiting for a EPOLLOUT event to flush it
+            // is waiting for writable readiness to flush it
             return self.tx_buf.push(buf);
         }
 
@@ -346,15 +348,16 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
         }
 
         if written_count != buf.len() {
-            // Try to re-enable EPOLLOUT in case it is disabled when txbuf is empty.
+            // Try to re-enable writable interest in case it is disabled when txbuf is
+            // empty.
             if VhostUserVsockThread::epoll_modify(
-                self.epoll_fd,
+                &self.poller,
                 self.stream.as_raw_fd(),
-                epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                Interest::READABLE | Interest::WRITABLE,
             )
             .is_err()
             {
-                error!("Failed to re-enable EPOLLOUT");
+                error!("Failed to re-enable writable interest");
             }
             return self.tx_buf.push(&buf.offset(written_count).unwrap());
         }
@@ -398,6 +401,7 @@ mod tests {
         collections::VecDeque,
         io::{Read, Result as IoResult},
         ops::Deref,
+        os::unix::io::RawFd,
         sync::{Arc, Mutex},
     };
 
@@ -417,6 +421,10 @@ mod tests {
     use crate::vhu_vsock::{VSOCK_HOST_CID, VSOCK_OP_RW, VSOCK_TYPE_STREAM};
 
     const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
+
+    fn test_poller() -> Arc<Mutex<Poll>> {
+        Arc::new(Mutex::new(Poll::new().unwrap()))
+    }
 
     struct HeadParams {
         head_len: usize,
@@ -632,7 +640,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -655,7 +663,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             65536,
             CONN_TX_BUF_SIZE,
         );
@@ -680,7 +688,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -712,7 +720,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -747,7 +755,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             CONN_TX_BUF_SIZE,
         );
 
@@ -845,7 +853,7 @@ mod tests {
             5000,
             3,
             5001,
-            -1,
+            test_poller(),
             CONN_TX_BUF_SIZE,
         );
 


### PR DESCRIPTION
### Summary of the PR

*The PR updates vhost-device-vsock from epoll to mio to support unix systems*
In this PR, I have changed the epoll naming to poller for struct vhostdevice. I found retaining epoll would be misleading. 
However, I could maintain the naming of epoll to avoid any confusion. 


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
