### PR TITLE
vhost-device-gpu: Fix get_capset_info parameter

### DIFF
--- a/vhost-device-gpu/CHANGELOG.md
+++ b/vhost-device-gpu/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 
 ### Fixed
+- [[#969] (https://github.com/rust-vmm/vhost-device/pull/970) vhost-device-gpu: Fix get_capset_info parameter
 - [[#967] (https://github.com/rust-vmm/vhost-device/pull/967) vhost-device-gpu: Fix DRM device selection with --gpu-device option
 
 ### Deprecated

--- a/vhost-device-gpu/src/backend/virgl.rs
+++ b/vhost-device-gpu/src/backend/virgl.rs
@@ -376,7 +376,7 @@ impl Renderer for VirglRendererAdapter {
         let capset_id = match index {
             0 => CAPSET_ID_VIRGL,
             1 => CAPSET_ID_VIRGL2,
-            3 => CAPSET_ID_VENUS,
+            2 => CAPSET_ID_VENUS,
             _ => return Err(ErrInvalidParameter),
         };
         let (version, size) = self.renderer.get_capset_info(index);
@@ -938,7 +938,7 @@ mod virgl_cov_tests {
             assert_matches!(gpu.flush_resource(0, dirty), Ok(GpuResponse::OkNoData));
 
             // Test capset queries
-            for index in [0, 1, 3] {
+            for index in [0, 1, 2] {
                 test_capset_operations(&gpu, index);
             }
 

--- a/vhost-device-gpu/src/backend/virgl.rs
+++ b/vhost-device-gpu/src/backend/virgl.rs
@@ -379,7 +379,7 @@ impl Renderer for VirglRendererAdapter {
             2 => CAPSET_ID_VENUS,
             _ => return Err(ErrInvalidParameter),
         };
-        let (version, size) = self.renderer.get_capset_info(index);
+        let (version, size) = self.renderer.get_capset_info(capset_id);
         Ok(OkCapsetInfo {
             capset_id,
             version,


### PR DESCRIPTION
### Summary of the PR

This fixes the issue where the get_capset_info function was passing the capset index instead of capset_id to virglrenderer. This caused the guest to receive wrong capset information.

Hence applications like Android SurfaceFlinger detects "OpenGL ES 3.0 Mesa" instead of the correct "OpenGL ES 3.2 Mesa".

Fixes: #969

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
