### PR TITLE
vhost-device-sound: fix choppy audio in PipeWire backend

### DIFF
--- a/vhost-device-sound/CHANGELOG.md
+++ b/vhost-device-sound/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Fixed
 
+- [[#984]](https://github.com/rust-vmm/vhost-device/pull/984) pipewire: fix choppy audio when the guest queue is empty. The process callback returned early without updating `chunk.size`, causing PipeWire to replay stale buffer data. Fill with silence instead.
+
 ### Deprecated
 
 ## v0.3.0

--- a/vhost-device-sound/src/audio_backends/pipewire.rs
+++ b/vhost-device-sound/src/audio_backends/pipewire.rs
@@ -432,42 +432,52 @@ impl AudioBackend for PwBackend {
                                     let streams = streams
                                         .get_mut(stream_id as usize)
                                         .expect("Stream does not exist");
-                                    let Some(request) = streams.requests.front_mut() else {
-                                        return;
-                                    };
-
-                                    let mut start = request.pos;
-
-                                    let avail = request.len().saturating_sub(start);
-
-                                    if avail < n_bytes {
-                                        n_bytes = avail;
-                                    }
-                                    let p = &mut slice[0..n_bytes];
-                                    if avail == 0 {
-                                        // SAFETY: We have assured above that the pointer is not
-                                        // null
-                                        // safe to zero-initialize the pointer.
-                                        unsafe {
-                                            // pad with silence
-                                            ptr::write_bytes(p.as_mut_ptr(), 0, n_bytes);
+                                    match streams.requests.front_mut() {
+                                        None => {
+                                            // Queue empty: fill with silence so PipeWire gets
+                                            // clean audio instead of stale data in the buffer.
+                                            // SAFETY: slice is a valid mutable byte slice of
+                                            // length n_bytes obtained from data.data() above.
+                                            unsafe {
+                                                ptr::write_bytes(slice.as_mut_ptr(), 0, n_bytes);
+                                            }
+                                            n_bytes
                                         }
-                                    } else {
-                                        // read_output() always reads (buffer.desc_len() -
-                                        // buffer.pos) bytes
-                                        request
-                                            .read_output(p)
-                                            .expect("failed to read buffer from guest");
+                                        Some(request) => {
+                                            let mut start = request.pos;
 
-                                        start += n_bytes;
+                                            let avail = request.len().saturating_sub(start);
 
-                                        request.pos = start;
+                                            if avail < n_bytes {
+                                                n_bytes = avail;
+                                            }
+                                            let p = &mut slice[0..n_bytes];
+                                            if avail == 0 {
+                                                // SAFETY: We have assured above that the pointer
+                                                // is not null
+                                                // safe to zero-initialize the pointer.
+                                                unsafe {
+                                                    // pad with silence
+                                                    ptr::write_bytes(p.as_mut_ptr(), 0, n_bytes);
+                                                }
+                                            } else {
+                                                // read_output() always reads (buffer.desc_len() -
+                                                // buffer.pos) bytes
+                                                request
+                                                    .read_output(p)
+                                                    .expect("failed to read buffer from guest");
 
-                                        if start >= request.len() {
-                                            streams.requests.pop_front();
+                                                start += n_bytes;
+
+                                                request.pos = start;
+
+                                                if start >= request.len() {
+                                                    streams.requests.pop_front();
+                                                }
+                                            }
+                                            n_bytes
                                         }
                                     }
-                                    n_bytes
                                 } else {
                                     0
                                 };


### PR DESCRIPTION
### Summary of the PR

When the guest queue is empty, the process callback returned early without updating chunk.size, causing PipeWire to replay stale buffer data. Fill with silence and set chunk.size to the full buffer length instead.

Tested with libkrun & AAOS.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test -> Can't be easily tested I believe. The original code didn't have a test case neither. 
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
