### PR TITLE
vsock : start forward-listen stream polling after guest accepts

### DIFF
--- a/vhost-device-vsock/CHANGELOG.md
+++ b/vhost-device-vsock/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- [#992](https://github.com/rust-vmm/vhost-device/pull/992) vsock : forward-listen stream polling after guest accepts
 
 ### Deprecated
 

--- a/vhost-device-vsock/src/vhu_vsock_thread.rs
+++ b/vhost-device-vsock/src/vhu_vsock_thread.rs
@@ -356,13 +356,6 @@ impl VhostUserVsockThread {
                                     local_port,
                                     peer_port,
                                 );
-                                if let Err(err) = Self::epoll_register(
-                                    self.get_epoll_fd(),
-                                    stream_raw_fd,
-                                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
-                                ) {
-                                    warn!("Failed to register with epoll: {err:?}");
-                                }
                             }
                             Err(err) => {
                                 warn!("Unable to accept new local connection: {err:?}");
@@ -420,13 +413,13 @@ impl VhostUserVsockThread {
 
                         self.add_new_connection_from_host(fd, stream, local_port, peer_port);
 
-                        // Re-register the fd to listen for EPOLLIN and EPOLLOUT events
-                        Self::epoll_modify(
-                            self.get_epoll_fd(),
-                            fd,
-                            epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
-                        )
-                        .unwrap();
+                        // wait till guest accepts connection before forwarding data
+                        if let Err(err) = Self::epoll_unregister(self.get_epoll_fd(), fd) {
+                            warn!(
+                                "Failed to unregister local stream before guest response: {:?}",
+                                err
+                            );
+                        }
                     }
                 }
             } else {

--- a/vhost-device-vsock/src/vsock_conn.rs
+++ b/vhost-device-vsock/src/vsock_conn.rs
@@ -238,6 +238,21 @@ impl<S: AsRawFd + ReadVolatile + Write + WriteVolatile + IsHybridVsock> VsockCon
                     self.stream.write_all(response.as_bytes()).unwrap();
                 }
                 self.connect = true;
+                if VhostUserVsockThread::epoll_register(
+                    self.epoll_fd,
+                    self.stream.as_raw_fd(),
+                    epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                )
+                .is_err()
+                {
+                    if let Err(e) = VhostUserVsockThread::epoll_modify(
+                        self.epoll_fd,
+                        self.stream.as_raw_fd(),
+                        epoll::Events::EPOLLIN | epoll::Events::EPOLLOUT,
+                    ) {
+                        error!("epoll_modify failed: {e:?}, but proceed further.");
+                    }
+                }
             }
             VSOCK_OP_RW => {
                 // Data has to be written to the host-side stream


### PR DESCRIPTION
### Summary of the PR

Fixes #963

This pr fixes host-initiated `forward-listen` connection so host-side data is not polled before the guest-side vsock connection is accepted

Previously, `VhostUserVsockThread::handle_event()` accepted the host socket, sent VSOCK_OP_REQUEST to the guest, immediately registered the host stream for polling, and in case the host writes before the guest replies with VSOCK_OP_RESPONSE, the backend read host bytes before the guest-side connection was ready -- and they're not forwarded to the guest which sees eof/0 bytes when eventually connected with VSOCK_OP_RESPONSE

Now host-initiated `forward-listen` streams are not registered for `EPOLLIN | EPOLLOUT` immediately after accept -- which now sends the guest connection VSOCK_OP_REQUEST first and waits for VSOCK_OP_RESPONSE to start host stream polling in `vhost-device-vsock/src/vsock_conn.rs`

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test -- repro requires host-to-guest forward-listen path with QEMU side, guest vsock endpoint, timing where the host writes before guest's VSOCK_OP_RESPONSE
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
