### PR TITLE
Cargo.lock: upgrade chacha20 from 0.10.1 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
`cargo audit` warned about a yanked version of chacha20 we are using:
  Crate:     chacha20
  Version:   0.10.1
  Warning:   yanked
  Dependency tree:
  chacha20 0.10.1
  └── rand 0.10.2
      ├── vhost-device-sound 0.3.0
      ├── vhost-device-rng 0.1.0
      ├── vhost-device-input 0.1.0
      └── uuid 1.23.4
          ├── vhost-device-gpu 0.2.0
          └── vhost 0.17.0
              ├── vhost-user-backend 0.23.0
              │   ├── vhost-device-vsock 0.3.0
              │   ├── vhost-device-template 0.1.0
              │   ├── vhost-device-spi 0.1.0
              │   ├── vhost-device-sound 0.3.0
              │   ├── vhost-device-scsi 0.1.0
              │   ├── vhost-device-scmi 0.4.0
              │   ├── vhost-device-rtc 0.1.0
              │   ├── vhost-device-rng 0.1.0
              │   ├── vhost-device-media 0.1.0
              │   ├── vhost-device-input 0.1.0
              │   ├── vhost-device-i2c 0.1.0
              │   ├── vhost-device-gpu 0.2.0
              │   ├── vhost-device-gpio 0.1.0
              │   ├── vhost-device-console 0.1.0
              │   └── vhost-device-can 0.1.0
              ├── vhost-device-vsock 0.3.0
              ├── vhost-device-template 0.1.0
              ├── vhost-device-spi 0.1.0
              ├── vhost-device-sound 0.3.0
              ├── vhost-device-scsi 0.1.0
              ├── vhost-device-scmi 0.4.0
              ├── vhost-device-rtc 0.1.0
              ├── vhost-device-rng 0.1.0
              ├── vhost-device-media 0.1.0
              ├── vhost-device-input 0.1.0
              ├── vhost-device-i2c 0.1.0
              ├── vhost-device-gpu 0.2.0
              ├── vhost-device-gpio 0.1.0
              ├── vhost-device-console 0.1.0
              └── vhost-device-can 0.1.0