### PR TITLE
build(deps): bump the rust-vmm group across 1 directory with 5 updates

### DIFF
--- a/staging/Cargo.lock
+++ b/staging/Cargo.lock
@@ -95,12 +95,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,17 +396,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
-dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -809,9 +792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom",
- "js-sys",
  "rand",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -829,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76d90ce3c6b37d610a5304c9a445cfff580cf8b4b9fd02fb256aaf68552c28a"
+checksum = "1c63c14485260662b4257bd929d5fd4aaf96bbecbe61d2224bad8807849f5f8f"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -867,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783587813a59c42c36519a6e12bb31eb2d7fa517377428252ba4cc2312584243"
+checksum = "555753b65bc33837bd011f981e2c6d52d8ddc330d92c2deb9aa3f0b378a58bcc"
 dependencies = [
  "libc",
  "log",
@@ -882,15 +863,15 @@ dependencies = [
 
 [[package]]
 name = "virtio-bindings"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f498a26d5a63be7bbb8bdcd3869c3f286c4c4a17108905276454da0caf8cb"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
 
 [[package]]
 name = "virtio-queue"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
+checksum = "f631bfd09362a9b17f0cfd5ca3b0a1b179d153fa276f9ce86919d560891e61d6"
 dependencies = [
  "libc",
  "log",
@@ -901,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.1",
@@ -921,51 +902,6 @@ checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.127"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.127"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.127"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.127"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
-dependencies = [
- "unicode-ident",
 ]
 
 [[package]]

--- a/staging/Cargo.toml
+++ b/staging/Cargo.toml
@@ -6,9 +6,9 @@ members = [
 ]
 
 [workspace.dependencies]
-vhost = { version = "0.15", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.21"
+vhost = { version = "0.17", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.23"
 virtio-bindings = "0.2.5"
-virtio-queue = "0.17"
-vm-memory = "0.17.1"
+virtio-queue = "0.18"
+vm-memory = "0.18.0"
 vmm-sys-util = "0.15"

--- a/staging/vhost-device-video/Cargo.toml
+++ b/staging/vhost-device-video/Cargo.toml
@@ -30,7 +30,7 @@ vhost = { workspace = true }
 vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }
-vm-memory = { workspace = true }
+vm-memory = { workspace = true, features = ["backend-mmap", "backend-atomic"] }
 vmm-sys-util = { workspace = true }
 v4l2r = { git =  "https://github.com/Gnurou/v4l2r", rev = "110fd77", optional = true }
 

--- a/staging/vhost-device-video/src/vhu_video_thread.rs
+++ b/staging/vhost-device-video/src/vhu_video_thread.rs
@@ -13,7 +13,7 @@ use log::{debug, warn};
 use vhost_user_backend::{VringEpollHandler, VringRwLock, VringT};
 use virtio_queue::{desc::split::Descriptor as SplitDescriptor, QueueOwnedT};
 use vm_memory::{
-    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
+    ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemoryAtomic, GuestMemoryBackend,
     GuestMemoryMmap,
 };
 use vmm_sys_util::epoll::EventSet;


### PR DESCRIPTION
Bumps the rust-vmm group with 5 updates in the /staging directory:

| Package | From | To |
| --- | --- | --- |
| [vhost](https://github.com/rust-vmm/vhost) | `0.15.0` | `0.17.0` | | [vhost-user-backend](https://github.com/rust-vmm/vhost) | `0.21.0` | `0.22.0` | | [virtio-bindings](https://github.com/rust-vmm/vm-virtio) | `0.2.6` | `0.2.7` | | [virtio-queue](https://github.com/rust-vmm/vm-virtio) | `0.17.0` | `0.18.0` | | [vm-memory](https://github.com/rust-vmm/vm-memory) | `0.17.1` | `0.18.0` |

Updates `vhost` from 0.15.0 to 0.17.0
- [Release notes](https://github.com/rust-vmm/vhost/releases)
- [Commits](https://github.com/rust-vmm/vhost/compare/vhost-v0.15.0...vhost-v0.17.0)

Updates `vhost-user-backend` from 0.21.0 to 0.22.0
- [Release notes](https://github.com/rust-vmm/vhost/releases)
- [Commits](https://github.com/rust-vmm/vhost/compare/vhost-user-backend-v0.21.0...vhost-user-backend-v0.22.0)

Updates `virtio-bindings` from 0.2.6 to 0.2.7
- [Release notes](https://github.com/rust-vmm/vm-virtio/releases)
- [Commits](https://github.com/rust-vmm/vm-virtio/compare/virtio-bindings-v0.2.6...virtio-bindings-v0.2.7)

Updates `virtio-queue` from 0.17.0 to 0.18.0
- [Release notes](https://github.com/rust-vmm/vm-virtio/releases)
- [Commits](https://github.com/rust-vmm/vm-virtio/compare/virtio-queue-v0.17.0...virtio-queue-v0.18.0)

Updates `vm-memory` from 0.17.1 to 0.18.0
- [Release notes](https://github.com/rust-vmm/vm-memory/releases)
- [Changelog](https://github.com/rust-vmm/vm-memory/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rust-vmm/vm-memory/compare/v0.17.1...v0.18.0)

---
updated-dependencies:
- dependency-name: vhost dependency-version: 0.17.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: vhost dependency-version: 0.17.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: vhost-user-backend dependency-version: 0.22.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: vhost-user-backend dependency-version: 0.22.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: virtio-bindings dependency-version: 0.2.7 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-vmm
- dependency-name: virtio-bindings dependency-version: 0.2.7 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-vmm
- dependency-name: virtio-queue dependency-version: 0.18.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: virtio-queue dependency-version: 0.18.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: vm-memory dependency-version: 0.18.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm
- dependency-name: vm-memory dependency-version: 0.18.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: rust-vmm ...

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [ ] Any newly added `unsafe` code is properly documented.
